### PR TITLE
Extending ReplyKeyboardMarkup and implementing the offset getUpdates parameter

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -42,6 +42,9 @@ class TeleBot:
         self.__stop_polling = False
         self.interval = 3
 
+    def get_last_update_id(self):
+        return self.update_id_list[-1] if len(self.update_id_list) > 0 else None
+
     def get_update(self):
         result = apihelper.get_updates(self.token)
         if result['ok'] is not True:

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -37,10 +37,13 @@ def send_message(token, chat_id, text, disable_web_page_preview=None, reply_to_m
     return check_result(method_url, req)
 
 
-def get_updates(token):
+def get_updates(token, offset=None):
     api_url = telebot.API_URL
     method_url = r'getUpdates'
-    request_url = api_url + 'bot' + token + '/' + method_url
+    if offset is not None:
+        request_url = api_url + 'bot' + token + '/' + method_url + '?offset=' + str(offset)
+    else:
+        request_url = api_url + 'bot' + token + '/' + method_url
     req = requests.get(request_url)
     return check_result(method_url, req)
 
@@ -101,7 +104,6 @@ def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_m
     if reply_markup:
         payload['reply_markup'] = reply_markup
     req = requests.post(request_url, params=payload, files=files)
-    req.status_code
     return check_result(method_url, req)
 
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -262,8 +262,60 @@ class UserProfilePhotos:
 
 
 class ReplyKeyboardMarkup:
-    def __init__(self, keyboard, resize_keyboard=None, one_time_keyboard=None, selective=None):
-        self.keyboard = keyboard
+    def __init__(self, keyboard=[], resize_keyboard=None, one_time_keyboard=None, selective=None, row_width=3):
         self.resize_keyboard = resize_keyboard
         self.one_time_keyboard = one_time_keyboard
         self.selective = selective
+        self.row_width = row_width
+
+        self.keyboard = []
+
+    def add(self, *args):
+        """
+        This function adds strings to the keyboard, while not exceeding row_width.
+        E.g. ReplyKeyboardMarkup#add("A", "B", "C") yields the json result {keyboard: [["A"], ["B"], ["C"]]}
+        when row_width is set to 1.
+        When row_width is set to 2, the following is the result of this function: {keyboard: [["A", "B"], ["C"]]}
+        See https://core.telegram.org/bots/api#replykeyboardmarkup
+        :param args: strings to append to the keyboard
+        """
+        i = 1
+        row = []
+        for string in args:
+            row.append(string)
+            if i % self.row_width == 0:
+                self.keyboard.append(row)
+                row = []
+            i += 1
+        if len(row) > 0:
+            self.keyboard.append(row)
+
+    def row(self, *args):
+        """
+        Adds a list of strings to the keyboard. This function does not consider row_width.
+        ReplyKeyboardMarkup#row("A")#row("B", "C")#to_json() outputs '{keyboard: [["A"], ["B", "C"]]}'
+        See https://core.telegram.org/bots/api#replykeyboardmarkup
+        :param args: strings
+        :return: self, to allow function chaining.
+        """
+        self.keyboard.append(args)
+        return self
+
+    def to_json(self):
+        """
+        Converts this object to its json representation following the Telegram API guidelines described here:
+        https://core.telegram.org/bots/api#replykeyboardmarkup
+        :return:
+        """
+        json_dict = {}
+        json_dict['keyboard'] = self.keyboard
+        if self.one_time_keyboard != False:
+            json_dict['one_time_keyboard'] = True
+
+        if self.resize_keyboard != False:
+            json_dict['resize_keyboard'] = True
+
+        if self.selective != False:
+            json_dict['selective'] = True
+
+        return json.dumps(json_dict)


### PR DESCRIPTION
I made two small commits, one concerning the ReplyKeyboardMarkup class and another to implement the offset parameter in the getUpdates API call (see https://core.telegram.org/bots/api#getupdates)

The ReplyKeyboardMarkup additions made my life a whole lot easier, I just thought I'd share.

The other commit was necessary to fix an internal bug my bot was experiencing, where I would only get up-to-date Updates when I passed the offset parameter along with the getUpdates call. This commit might improve the efficiency of the TeleBot#get_update function as well.