### PR TITLE
make telebot compatible with python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: python
 python:
     - "2.6"
     - "2.7"
+    - "3.4"
 install: "pip install -r requirements.txt"
 script: cd tests && py.test

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Python Telegram Bot API.
 
 ## How to install
 
-* Need python2
+* Need python2 or python3
 * Install from source
 
 ```

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 import json
 import time
 import threading
 
-import apihelper
-import types
+from telebot import apihelper, types
 
 """
 Module : telebot
@@ -73,15 +73,15 @@ class TeleBot:
         self.polling_thread.start()
 
     def __polling(self):
-        print 'telegram bot start polling'
+        print('telegram bot start polling')
         while not self.__stop_polling:
             try:
                 self.get_update()
             except Exception as e:
-                print e
+                print(e)
             time.sleep(self.interval)
 
-        print 'telegram bot stop polling'
+        print('telegram bot stop polling')
 
     def stop_polling(self):
         self.__stop_polling = True

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -133,11 +133,13 @@ def check_result(func_name, result):
         raise ApiError(func_name + r' error.', result)
     return result_json
 
+
 def convert_markup(markup):
     if isinstance(markup, types.ReplyKeyboardMarkup):
         return markup.to_json()
     else:
         return markup
+
 
 class ApiError(Exception):
     def __init__(self, message, result):


### PR DESCRIPTION
small fixes to make telebot compatible with python3. I would prefer using logging, but there's not much use in the module now so maybe later.

also two very small two space PEP8 fixes.