### PR TITLE
Added AsyncTeleBot

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ def listener(*messages):
     """
     for m in messages:
         chatid = m.chat.id
-        if m.content_type == 'text'
+        if m.content_type == 'text':
             text = m.text
             tb.send_message(chatid, text)
 
@@ -146,7 +146,7 @@ def echo_messages(*messages):
 	"""
     for m in messages:
         chatid = m.chat.id
-        if m.content_type == 'text'
+        if m.content_type == 'text':
             text = m.text
             bot.send_message(chatid, text)
 ```
@@ -182,24 +182,24 @@ bot = telebot.TeleBot(TOKEN)
 # Handle /start and /help
 @bot.message_handler(commands=['start', 'help'])
 def command_help(message):
-    bot.send_message(message.chat.id, "Hello, did someone call for help?")
+    bot.reply_to(message, "Hello, did someone call for help?")
     
 # Handles all messages which text matches the regex regexp.
 # See https://en.wikipedia.org/wiki/Regular_expression
 # This regex matches all sent url's.
 @bot.message_handler(regexp='((https?):((//)|(\\\\))+([\w\d:#@%/;$()~_?\+-=\\\.&](#!)?)*)')
 def command_url(message):
-    bot.send_message(message.chat.id, "I shouldn't open that url, should I?")
+    bot.reply_to(message, "I shouldn't open that url, should I?")
 
 # Handle all sent documents of type 'text/plain'.
 @bot.message_handler(func=lambda message: message.document.mime_type == 'text/plain', content_types=['document'])
 def command_handle_document(message):
-    bot.send_message(message.chat.id, "Document received, sir!")
+    bot.reply_to(message, "Document received, sir!")
 
 # Default command handler. A lambda expression which always returns True is used for this purpose.
 @bot.message_handler(func=lambda message: True, content_types=['audio', 'video', 'document', 'text', 'location', 'contact', 'sticker'])
 def default_command(message):
-    bot.send_message(message.chat.id, "This is the default command handler.")
+    bot.reply_to(message, "This is the default command handler.")
 ```
 * And finally, call bot.polling()
 ```python

--- a/examples/echo_bot.py
+++ b/examples/echo_bot.py
@@ -7,6 +7,7 @@ API_TOKEN = '<api_token>'
 
 bot = telebot.TeleBot(API_TOKEN)
 
+
 # Handle '/start' and '/help'
 @bot.message_handler(commands=['help, start'])
 def send_welcome(message):
@@ -14,6 +15,7 @@ def send_welcome(message):
 Hi there, I am EchoBot.
 I am here to echo your kind words back to you. Just say anything nice and I'll say the exact same thing to you!\
 """)
+
 
 # Handle all other messages with content_type 'text' (content_types defaults to ['text'])
 @bot.message_handler(func=lambda message: True)

--- a/examples/echo_bot.py
+++ b/examples/echo_bot.py
@@ -1,0 +1,26 @@
+# This is a simple echo bot using the decorator mechanism.
+# It echoes any incoming text messages.
+
+import telebot
+
+API_TOKEN = '<api_token>'
+
+bot = telebot.TeleBot(API_TOKEN)
+
+# Handle '/start' and '/help'
+@bot.message_handler(commands=['help, start'])
+def send_welcome(message):
+    bot.reply_to(message, """\
+Hi there, I am EchoBot.
+I am here to echo your kind words back to you. Just say anything nice and I'll say the exact same thing to you!\
+""")
+
+# Handle all other messages with content_type 'text' (content_types defaults to ['text'])
+@bot.message_handler(func=lambda message: True)
+def echo_message(message):
+    bot.reply_to(message, message.text)
+
+bot.polling()
+
+while True:
+    pass

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -220,6 +220,9 @@ class TeleBot:
         """
         return apihelper.send_chat_action(self.token, chat_id, action)
 
+    def reply_to(self, message, text, **kwargs):
+        return self.send_message(message.chat.id, text, reply_to_message_id=message.message_id, **kwargs)
+
     def message_handler(self, commands=None, regexp=None, func=None, content_types=['text']):
         """
         Message handler decorator.

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -56,12 +56,16 @@ def send_message(token, chat_id, text, disable_web_page_preview=None, reply_to_m
     return _make_request(token, method_url, params=payload)
 
 
-def get_updates(token, offset=None):
+def get_updates(token, offset=None, limit=None, timeout=None):
     method_url = r'getUpdates'
-    if offset is not None:
-        return _make_request(token, method_url, params={'offset': offset})
-    else:
-        return _make_request(token, method_url)
+    payload = {}
+    if offset:
+        payload['offset'] = offset
+    if limit:
+        payload['limit'] = limit
+    if timeout:
+        payload['timeout'] = timeout
+    return _make_request(token, method_url, params=payload)
 
 
 def get_user_profile_photos(token, user_id, offset=None, limit=None):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -290,6 +290,7 @@ class Contact(JsonDeserializable):
         phone_number = obj['phone_number']
         first_name = obj['first_name']
         last_name = None
+        user_id = None
         if 'last_name' in obj:
             last_name = obj['last_name']
         if 'user_id' in obj:


### PR DESCRIPTION
Added TeleBot#reply_to(message, text)
Extended message_handler decorator to accept argument 'commands' (E.g. commands=['start', 'help'] will qualify this message_handler for /start and /help
TeleBot now makes use of the timeout argument of getUpdates (so-called long polling), which is more effective compared to using time.sleep.
Updated README.md.

AsyncTeleBot is a subclass of TeleBot and therefore inherits all of TeleBot's properties. It simply modifies some functions to be asynchronous.
AsyncTeleBot example:
```python
bot = telebot.AsyncTeleBot(TOKEN)

task1 = bot.get_me() # Fires an async API call.
assert isinstance(task1, telebot.AsyncTask)

task2 = bot.send_message(chat_id, "Hi how are you!") # Also async
assert isinstance(task2, telebot.AsyncTask)

me = task1.wait() # Gets the result of the first operation.
print(me.first_name)
```

And finally, added an "examples" dir. I thought it might be useful now the API is getting more complicated.