### PR TITLE
Added split_string to apihelper.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Python implementation for the Telegram Bot API.
 
 See [https://core.telegram.org/bots/api](https://core.telegram.org/bots/api)
 
+[![Build Status](https://travis-ci.org/eternnoir/pyTelegramBotAPI.svg?branch=master)](https://travis-ci.org/eternnoir/pyTelegramBotAPI)
+
 ## How to install
 
 Python 2 or Python 3 is required.

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -188,6 +188,10 @@ class TeleBot:
     def send_message(self, chat_id, text, disable_web_page_preview=None, reply_to_message_id=None, reply_markup=None):
         """
         Use this method to send text messages.
+
+        Warning: Do not send more than about 5000 characters each message, otherwise you'll risk an HTTP 414 error.
+        If you must send more than 5000 characters, use the split_string function in apihelper.py.
+
         :param chat_id:
         :param text:
         :param disable_web_page_preview:

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -56,7 +56,7 @@ def send_message(token, chat_id, text, disable_web_page_preview=None, reply_to_m
         payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
-    return _make_request(token, method_url, params=payload)
+    return _make_request(token, method_url, params=payload, method='post')
 
 
 def get_updates(token, offset=None, limit=None, timeout=None):
@@ -178,6 +178,18 @@ def extract_command(text):
     :return: the command if `text` is a command (according to is_command), else None.
     """
     return text.split()[0].split('@')[0][1:] if is_command(text) else None
+
+
+def split_string(text, chars_per_string):
+    """
+    Splits one string into multiple strings, with a maximum amount of `chars_per_string` characters per string.
+    This is very useful for splitting one giant message into multiples.
+
+    :param text: The text to split
+    :param chars_per_string: The number of characters per line the text is split into.
+    :return: The splitted text as a list of strings.
+    """
+    return [text[i:i + chars_per_string] for i in range(0, len(text), chars_per_string)]
 
 class ApiException(Exception):
     """


### PR DESCRIPTION
Added a warning to send_message to not exceed 5000 characters per message.
Changed send_message to use HTTP POST instead of GET, to stretch the maximum character limit a little more.