### PR TITLE
Fixed typo in types.py

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -670,7 +670,7 @@ class InlineKeyboardButton(JsonSerializable):
         if self.callback_data:
             json_dic['callback_data'] = self.callback_data
         if self.switch_inline_query:
-            json_dic['switch_inline_quer'] = self.switch_inline_quer
+            json_dic['switch_inline_quer'] = self.switch_inline_query
         return json_dic
 
 


### PR DESCRIPTION
"switch_inline_quer" -> "switch_inline_query"