### PR TITLE
Fixed content_types for 'new_chat_member' and 'left_chat_member'

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -707,6 +707,10 @@ class TeleBot:
     @staticmethod
     def _test_filter(filter, filter_value, message):
         if filter == 'content_types':
+            if 'new_chat_member' in filter_value:
+                return message.new_chat_member is not None
+            if 'left_chat_member' in filter_value:
+                return message.left_chat_member is not None
             return message.content_type in filter_value
         if filter == 'regexp':
             return message.content_type == 'text' and re.search(filter_value, message.text)

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -707,9 +707,9 @@ class TeleBot:
     @staticmethod
     def _test_filter(filter, filter_value, message):
         if filter == 'content_types':
-            if 'new_chat_member' in filter_value:
+            if 'new_chat_member' in filter_value or 'new_chat_participant' in filter_value:
                 return message.new_chat_member is not None
-            if 'left_chat_member' in filter_value:
+            if 'left_chat_member' in filter_value or 'left_chat_participant' in filter_value:
                 return message.left_chat_member is not None
             return message.content_type in filter_value
         if filter == 'regexp':

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -212,6 +212,14 @@ class Message(JsonDeserializable):
             opts['new_chat_member'] = User.de_json(obj['new_chat_member'])
         if 'left_chat_member' in obj:
             opts['left_chat_member'] = User.de_json(obj['left_chat_member'])
+        
+        # Retrocompatibility fields
+        if 'new_chat_participant' in obj:
+            opts['new_chat_participant'] = User.de_json(obj['new_chat_participant'])
+        if 'left_chat_participant' in obj:
+            opts['left_chat_participant'] = User.de_json(obj['left_chat_participant'])
+        # /end
+            
         if 'new_chat_title' in obj:
             opts['new_chat_title'] = obj['new_chat_title']
         if 'new_chat_photo' in obj:


### PR DESCRIPTION
Telegram no longer provides **content_type** field when user is added or removed from a group.
I added it *manually* checking if the field **new_chat_member** of the message.

**new_chat_participant** and **left_chat_participant** will work too.