### PR TITLE
Added missing import for extract_arguments()

### DIFF
--- a/telebot/util.py
+++ b/telebot/util.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import threading
+import re
 import sys
 import six
 from six import string_types


### PR DESCRIPTION
`telebot/util.py` was missing the import of the `re` module required for `extract_arguments()` function.