### PR TITLE
Fix the bug that the return of request.get_data() is not string.

### DIFF
--- a/examples/webhook_examples/webhook_flask_echo_bot.py
+++ b/examples/webhook_examples/webhook_flask_echo_bot.py
@@ -48,7 +48,7 @@ def index():
 @app.route(WEBHOOK_URL_PATH, methods=['POST'])
 def webhook():
     if flask.request.headers.get('content-type') == 'application/json':
-        json_string = flask.request.get_data()
+        json_string = flask.request.get_data().decode('utf-8')
         update = telebot.types.Update.de_json(json_string)
         bot.process_new_messages([update.message])
         return ''


### PR DESCRIPTION
I just find that in the flask webhook example, request.get_data() return a value whose type is 'byte' instead of 'string'. And it will cause an error shown below
```
ValueError: json_type should be a json dict or string.
```
This commit is a patch that decode the byte value into string using decode('utf-8').