### PR TITLE
Added "user" to MessageEntity object

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -304,13 +304,15 @@ class MessageEntity(JsonDeserializable):
         offset = obj['offset']
         length = obj['length']
         url = obj.get('url')
-        return cls(type, offset, length, url)
+        user = obj.get('user')
+        return cls(type, offset, length, url, user)
 
-    def __init__(self, type, offset, length, url=None):
+    def __init__(self, type, offset, length, url=None, user=None):
         self.type = type
         self.offset = offset
         self.length = length
         self.url = url
+        self.user = user
 
 
 class PhotoSize(JsonDeserializable):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -304,7 +304,7 @@ class MessageEntity(JsonDeserializable):
         offset = obj['offset']
         length = obj['length']
         url = obj.get('url')
-        user = obj.get('user')
+        user = User.de_json(obj.get('user'))
         return cls(type, offset, length, url, user)
 
     def __init__(self, type, offset, length, url=None, user=None):


### PR DESCRIPTION
As of Bot API update 2.1, `MessageEntity` object now has optional `user` field.  
It is only present when there's a [text mention](https://telegram.org/blog/edit#new-mentions) in message.