### PR TITLE
Added optional connection (aka sending) timeouts to methods that may …

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -334,7 +334,7 @@ class TeleBot:
                                  disable_notification))
 
     def send_audio(self, chat_id, audio, duration=None, performer=None, title=None, reply_to_message_id=None,
-                   reply_markup=None, disable_notification=None):
+                   reply_markup=None, disable_notification=None, timeout=None):
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .mp3 format.
         :param chat_id:Unique identifier for the message recipient
@@ -348,10 +348,10 @@ class TeleBot:
         """
         return types.Message.de_json(
             apihelper.send_audio(self.token, chat_id, audio, duration, performer, title, reply_to_message_id,
-                                 reply_markup, disable_notification))
+                                 reply_markup, disable_notification, timeout))
 
     def send_voice(self, chat_id, voice, duration=None, reply_to_message_id=None, reply_markup=None,
-                   disable_notification=None):
+                   disable_notification=None, timeout=None):
         """
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
         :param chat_id:Unique identifier for the message recipient.
@@ -363,9 +363,9 @@ class TeleBot:
         """
         return types.Message.de_json(
             apihelper.send_voice(self.token, chat_id, voice, duration, reply_to_message_id, reply_markup,
-                                 disable_notification))
+                                 disable_notification, timeout))
 
-    def send_document(self, chat_id, data, reply_to_message_id=None, reply_markup=None, disable_notification=None):
+    def send_document(self, chat_id, data, reply_to_message_id=None, reply_markup=None, disable_notification=None, timeout=None):
         """
         Use this method to send general files.
         :param chat_id:
@@ -376,9 +376,9 @@ class TeleBot:
         """
         return types.Message.de_json(
             apihelper.send_data(self.token, chat_id, data, 'document', reply_to_message_id, reply_markup,
-                                disable_notification))
+                                disable_notification, timeout))
 
-    def send_sticker(self, chat_id, data, reply_to_message_id=None, reply_markup=None, disable_notification=None):
+    def send_sticker(self, chat_id, data, reply_to_message_id=None, reply_markup=None, disable_notification=None, timeout=None):
         """
         Use this method to send .webp stickers.
         :param chat_id:
@@ -389,10 +389,10 @@ class TeleBot:
         """
         return types.Message.de_json(
             apihelper.send_data(self.token, chat_id, data, 'sticker', reply_to_message_id, reply_markup,
-                                disable_notification))
+                                disable_notification, timeout))
 
     def send_video(self, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
-                   disable_notification=None):
+                   disable_notification=None, timeout=None):
         """
         Use this method to send video files, Telegram clients support mp4 videos.
         :param chat_id: Integer : Unique identifier for the message recipient — User or GroupChat id
@@ -405,7 +405,7 @@ class TeleBot:
         """
         return types.Message.de_json(
             apihelper.send_video(self.token, chat_id, data, duration, caption, reply_to_message_id, reply_markup,
-                                 disable_notification))
+                                 disable_notification, timeout))
 
     def send_location(self, chat_id, latitude, longitude, reply_to_message_id=None, reply_markup=None,
                       disable_notification=None):

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -27,9 +27,11 @@ def _make_request(token, method_name, method='get', params=None, files=None, bas
     request_url = base_url.format(token, method_name)
     logger.debug("Request: method={0} url={1} params={2} files={3}".format(method, request_url, params, files))
     read_timeout = READ_TIMEOUT
+    connect_timeout = CONNECT_TIMEOUT
     if params:
         if 'timeout' in params: read_timeout = params['timeout'] + 10
-    result = requests.request(method, request_url, params=params, files=files, timeout=(CONNECT_TIMEOUT, read_timeout))
+        if 'connect-timeout' in params: connect_timeout = params['connect-timeout'] + 10
+    result = requests.request(method, request_url, params=params, files=files, timeout=(connect_timeout, read_timeout))
     logger.debug("The server returned: '{0}'".format(result.text.encode('utf8')))
     return _check_result(method_name, result)['result']
 
@@ -225,7 +227,7 @@ def send_chat_action(token, chat_id, action):
 
 
 def send_video(token, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
-               disable_notification=None):
+               disable_notification=None, timeout=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -243,11 +245,13 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_to_messa
         payload['reply_markup'] = _convert_markup(reply_markup)
     if disable_notification:
         payload['disable_notification'] = disable_notification
+    if timeout:
+        payload['connect-timeout'] = timeout
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_voice(token, chat_id, voice, duration=None, reply_to_message_id=None, reply_markup=None,
-               disable_notification=None):
+               disable_notification=None, timeout=None):
     method_url = r'sendVoice'
     payload = {'chat_id': chat_id}
     files = None
@@ -263,11 +267,13 @@ def send_voice(token, chat_id, voice, duration=None, reply_to_message_id=None, r
         payload['reply_markup'] = _convert_markup(reply_markup)
     if disable_notification:
         payload['disable_notification'] = disable_notification
+    if timeout:
+        payload['connect-timeout'] = timeout
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_audio(token, chat_id, audio, duration=None, performer=None, title=None, reply_to_message_id=None,
-               reply_markup=None, disable_notification=None):
+               reply_markup=None, disable_notification=None, timeout=None):
     method_url = r'sendAudio'
     payload = {'chat_id': chat_id}
     files = None
@@ -287,10 +293,12 @@ def send_audio(token, chat_id, audio, duration=None, performer=None, title=None,
         payload['reply_markup'] = _convert_markup(reply_markup)
     if disable_notification:
         payload['disable_notification'] = disable_notification
+    if timeout:
+        payload['connect-timeout'] = timeout
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
-def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_markup=None, disable_notification=None):
+def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_markup=None, disable_notification=None, timeout=None):
     method_url = get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None
@@ -304,6 +312,8 @@ def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_m
         payload['reply_markup'] = _convert_markup(reply_markup)
     if disable_notification:
         payload['disable_notification'] = disable_notification
+    if timeout:
+        payload['connect-timeout'] = timeout
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 


### PR DESCRIPTION
…upload big chunks of data: send_audio, send_voice, send_document, send_sticker and send_video.

Hi! I just ran into an issue while trying to send audio (4MB+) files through send_document method because the 3.5 seconds connection timeout set by default in apihelper.py weren't enough. 
So I added to the methods  send_audio, send_voice, send_document, send_sticker and send_video an optional argument "timeout" so the user can override this value if he or she considers so.

Cheers!