### PR TITLE
Use session to ensure persistent connection to api.telegram.org

### DIFF
--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -6,6 +6,7 @@ from telebot import types
 from telebot import util
 
 logger = telebot.logger
+req_session = requests.session()
 
 API_URL = "https://api.telegram.org/bot{0}/{1}"
 FILE_URL = "https://api.telegram.org/file/bot{0}/{1}"
@@ -31,7 +32,7 @@ def _make_request(token, method_name, method='get', params=None, files=None, bas
     if params:
         if 'timeout' in params: read_timeout = params['timeout'] + 10
         if 'connect-timeout' in params: connect_timeout = params['connect-timeout'] + 10
-    result = requests.request(method, request_url, params=params, files=files, timeout=(connect_timeout, read_timeout))
+    result = req_session.request(method, request_url, params=params, files=files, timeout=(connect_timeout, read_timeout))
     logger.debug("The server returned: '{0}'".format(result.text.encode('utf8')))
     return _check_result(method_name, result)['result']
 
@@ -80,7 +81,7 @@ def get_file(token, file_id):
 
 def download_file(token, file_path):
     url = FILE_URL.format(token, file_path)
-    result = requests.get(url)
+    result = req_session.get(url)
     if result.status_code != 200:
         msg = 'The server returned HTTP {0} {1}. Response body:\n[{2}]' \
             .format(result.status_code, result.reason, result.text)


### PR DESCRIPTION
Requests's sessions [provide](http://docs.python-requests.org/en/master/user/advanced/#keep-alive) connection reuse, read more about [HTTP Keep-Alive](https://en.wikipedia.org/wiki/HTTP_persistent_connection) in Wikipedia.