### PR TITLE
Added option to delete messages.

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -416,7 +416,7 @@ class TeleBot:
         :param message_id: which message to delete
         :return: API reply.
         """
-        return types.Message.de_json(apihelper.delete_message(self.token, chat_id, message_id))
+        return apihelper.delete_message(self.token, chat_id, message_id)
 
     def send_photo(self, chat_id, photo, caption=None, reply_to_message_id=None, reply_markup=None,
                    disable_notification=None):

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -33,6 +33,7 @@ class TeleBot:
         getMe
         sendMessage
         forwardMessage
+        deleteMessage
         sendPhoto
         sendAudio
         sendDocument
@@ -407,6 +408,15 @@ class TeleBot:
         """
         return types.Message.de_json(
             apihelper.forward_message(self.token, chat_id, from_chat_id, message_id, disable_notification))
+
+    def delete_message(self, chat_id, message_id):
+        """
+        Use this method to delete message. Returns True on success. 
+        :param chat_id: in which chat to delete
+        :param message_id: which message to delete
+        :return: API reply.
+        """
+        return types.Message.de_json(apihelper.delete_message(self.token, chat_id, message_id))
 
     def send_photo(self, chat_id, photo, caption=None, reply_to_message_id=None, reply_markup=None,
                    disable_notification=None):

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -446,6 +446,12 @@ def edit_message_reply_markup(token, chat_id=None, message_id=None, inline_messa
     return _make_request(token, method_url, params=payload)
 
 
+def delete_message(token, chat_id=None, message_id=None):
+    method_url = r'deleteMessage'
+    payload = {'chat_id': chat_id, 'message_id': message_id}
+    return _make_request(token, method_url, params=payload)
+
+
 # Game
 
 def send_game(token, chat_id, game_short_name, disable_notification=None, reply_to_message_id=None, reply_markup=None):


### PR DESCRIPTION
Added option to delete messages.

Some bots do not support `deleteMessage` method now, waiting for an official api update
release.

So, here is a small [script](https://gist.github.com/Kylmakalle/1132315523fee96c386b3330cdcdde13) to check possibility of your bot to delete messages **NOW**, while this method in non-release stage

**UPD: 08.05** Now 6/10 my bots can delete messages, telegram updates our bots gradually
**UPD: 12.05** 8/10 can delete messages, old bots updated.
**UPD: 14.05** 9/10 can delete messages, new bot updated