### PR TITLE
Video Note support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To start the bot, simply open up a terminal and enter `python echo_bot.py` to ru
 All types are defined in types.py. They are all completely in line with the [Telegram API's definition of the types](https://core.telegram.org/bots/api#available-types), except for the Message's `from` field, which is renamed to `from_user` (because `from` is a Python reserved token). Thus, attributes such as `message_id` can be accessed directly with `message.message_id`. Note that `message.chat` can be either an instance of `User` or `GroupChat` (see [How can I distinguish a User and a GroupChat in message.chat?](#how-can-i-distinguish-a-user-and-a-groupchat-in-messagechat)).
 
 The Message object also has a `content_type`attribute, which defines the type of the Message. `content_type` can be one of the following strings:
-`text`, `audio`, `document`, `photo`, `sticker`, `video`, `voice`, `location`, `contact`, `new_chat_member`, `left_chat_member`, `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`, `supergroup_chat_created`, `channel_chat_created`, `migrate_to_chat_id`, `migrate_from_chat_id`, `pinned_message`.
+`text`, `audio`, `document`, `photo`, `sticker`, `video`, `video_note`, `voice`, `location`, `contact`, `new_chat_member`, `left_chat_member`, `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`, `supergroup_chat_created`, `channel_chat_created`, `migrate_to_chat_id`, `migrate_from_chat_id`, `pinned_message`.
 
 ### Methods
 
@@ -282,6 +282,11 @@ tb.send_sticker(chat_id, "FILEID")
 # sendVideo
 video = open('/tmp/video.mp4', 'rb')
 tb.send_video(chat_id, video)
+tb.send_video(chat_id, "FILEID")
+
+# sendVideoNote
+videonote = open('/tmp/videonote.mp4', 'rb')
+tb.send_video(chat_id, videonote)
 tb.send_video(chat_id, "FILEID")
 
 # sendLocation

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -576,7 +576,7 @@ class TeleBot:
         its typing status).
         :param chat_id:
         :param action:  One of the following strings: 'typing', 'upload_photo', 'record_video', 'upload_video',
-                        'record_audio', 'upload_audio', 'upload_document', 'find_location'.
+                        'record_audio', 'upload_audio', 'upload_document', 'find_location', 'record_video_note', 'upload_video_note'.
         :return: API reply. :type: boolean
         """
         return apihelper.send_chat_action(self.token, chat_id, action)

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -39,6 +39,7 @@ class TeleBot:
         sendDocument
         sendSticker
         sendVideo
+        sendVideoNote
         sendLocation
         sendChatAction
         getUserProfilePhotos
@@ -510,6 +511,22 @@ class TeleBot:
             apihelper.send_video(self.token, chat_id, data, duration, caption, reply_to_message_id, reply_markup,
                                  disable_notification, timeout))
 
+    def send_video_note(self, chat_id, data, duration=None, length=None, reply_to_message_id=None, reply_markup=None,
+                   disable_notification=None, timeout=None):
+        """
+        Use this method to send video files, Telegram clients support mp4 videos.
+        :param chat_id: Integer : Unique identifier for the message recipient — User or GroupChat id
+        :param data: InputFile or String : Video note to send. You can either pass a file_id as String to resend a video that is already on the Telegram server
+        :param duration: Integer : Duration of sent video in seconds
+        :param length: Integer : Video width and height, Can't be None and should be in range of (0, 640)
+        :param reply_to_message_id:
+        :param reply_markup:
+        :return:
+        """
+        return types.Message.de_json(
+            apihelper.send_video_note(self.token, chat_id, data, duration, length, reply_to_message_id, reply_markup,
+                                 disable_notification, timeout))
+
     def send_location(self, chat_id, latitude, longitude, reply_to_message_id=None, reply_markup=None,
                       disable_notification=None):
         """
@@ -952,6 +969,10 @@ class AsyncTeleBot(TeleBot):
     @util.async()
     def send_video(self, *args, **kwargs):
         return TeleBot.send_video(self, *args, **kwargs)
+
+    @util.async()
+    def send_video_note(self, *args, **kwargs):
+        return TeleBot.send_video_note(self, *args, **kwargs)
 
     @util.async()
     def send_location(self, *args, **kwargs):

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -335,13 +335,14 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_m
     files = None
     if not util.is_string(data):
         files = {'video_note': data}
-        files['video_note']['length'] = 639  # seems like it is MAX length size
     else:
         payload['video_note'] = data
     if duration:
         payload['duration'] = duration
     if length:
         payload['length'] = length
+    else:
+        payload['length'] = 639  # seems like it is MAX length size
     if reply_to_message_id:
         payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -328,6 +328,31 @@ def send_voice(token, chat_id, voice, caption=None, duration=None, reply_to_mess
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
+def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_message_id=None, reply_markup=None,
+                    disable_notification=None, timeout=None):
+    method_url = r'sendVideoNote'
+    payload = {'chat_id': chat_id}
+    files = None
+    if not util.is_string(data):
+        files = {'video_note': data}
+        files['video_note']['length'] = 639  # seems like it is MAX length size
+    else:
+        payload['video_note'] = data
+    if duration:
+        payload['duration'] = duration
+    if length:
+        payload['length'] = length
+    if reply_to_message_id:
+        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_markup:
+        payload['reply_markup'] = _convert_markup(reply_markup)
+    if disable_notification:
+        payload['disable_notification'] = disable_notification
+    if timeout:
+        payload['connect-timeout'] = timeout
+    return _make_request(token, method_url, params=payload, files=files, method='post')
+
+
 def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None, reply_to_message_id=None,
                reply_markup=None, disable_notification=None, timeout=None):
     method_url = r'sendAudio'
@@ -525,7 +550,6 @@ def answer_callback_query(token, callback_query_id, text=None, show_alert=None, 
     """
     Use this method to send answers to callback queries sent from inline keyboards. The answer will be displayed to the user as a notification at the top of the chat screen or as an alert. On success, True is returned.
     Alternatively, the user can be redirected to the specified Game URL. For this option to work, you must first create a game for your bot via BotFather and accept the terms. Otherwise, you may use links like telegram.me/your_bot?start=XXXX that open your bot with a parameter.
-    
     :param token: Bot's token (you don't need to fill this)
     :param callback_query_id: Unique identifier for the query to be answered
     :param text: (Optional) Text of the notification. If not specified, nothing will be shown to the user, 0-200 characters

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -283,6 +283,9 @@ class Message(JsonDeserializable):
         if 'new_chat_member' in obj:
             opts['new_chat_member'] = User.de_json(obj['new_chat_member'])
             content_type = 'new_chat_member'
+        if 'new_chat_members' in obj:
+            opts['new_chat_members'] = obj['new_chat_members']
+            content_type = 'new_chat_members'
         if 'left_chat_member' in obj:
             opts['left_chat_member'] = User.de_json(obj['left_chat_member'])
             content_type = 'left_chat_member'

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -263,6 +263,9 @@ class Message(JsonDeserializable):
         if 'video' in obj:
             opts['video'] = Video.de_json(obj['video'])
             content_type = 'video'
+        if 'video_note' in obj:
+            opts['video_note'] = VideoNote.de_json(obj['video_note'])
+            content_type = 'video_note'
         if 'voice' in obj:
             opts['voice'] = Audio.de_json(obj['voice'])
             content_type = 'voice'
@@ -342,6 +345,7 @@ class Message(JsonDeserializable):
         self.photo = None
         self.sticker = None
         self.video = None
+        self.video_note = None
         self.voice = None
         self.caption = None
         self.contact = None
@@ -504,6 +508,27 @@ class Video(JsonDeserializable):
         self.duration = duration
         self.thumb = thumb
         self.mime_type = mime_type
+        self.file_size = file_size
+
+
+class VideoNote(JsonDeserializable):
+    @classmethod
+    def de_json(cls, json_string):
+        obj = cls.check_json(json_string)
+        file_id = obj['file_id']
+        length = obj['length']
+        duration = obj['duration']
+        thumb = None
+        if 'thumb' in obj:
+            thumb = PhotoSize.de_json(obj['thumb'])
+        file_size = obj.get('file_size')
+        return cls(file_id, length, duration, thumb, file_size)
+
+    def __init__(self, file_id, length, duration, thumb=None, file_size=None):
+        self.file_id = file_id
+        self.length = length
+        self.duration = duration
+        self.thumb = thumb
         self.file_size = file_size
 
 


### PR DESCRIPTION
Send and receive round video messages.
Support for `send_video_note` method and `video_note` content type.


[Take a look](https://github.com/eternnoir/pyTelegramBotAPI/pull/338/files#diff-9b5a06a5a5b33ef7c3d1268ac38b778aR338) at `length` parameter, I have made some tests and found out that
only numbers in range `(0, 640)` are working, else you will got an error: `{"ok":false,"error_code":400,"description":"Bad Request: wrong video note length"}`, but there are no any restrictions about video note [length](https://core.telegram.org/bots/api#sendvideonote), by the way, i do not see any changes in `video_note` after `length` parameter use. 

Also changing a duration of `video_note` does not affect it in a right way, just check [@videonote](https://t.me/videonote) and [this gist](https://gist.github.com/Kylmakalle/0de6a10a2b12abc994bfd49ef38fff90)
Seems like only timecodes are affected and `duration` is tied to a `video_note` file. [Screenshot](https://cloud.githubusercontent.com/assets/24507532/26255031/1621fc30-3cc1-11e7-8bd0-bf2ffb3d1a86.png)


[New commit](https://github.com/eternnoir/pyTelegramBotAPI/pull/338/commits/3f5596ddce5a94aaf2cfda11139aab9931c74f01#diff-16fc4c0416dfd7dcc37887265594541dR579), action `upload_video_note` does not work properly for Desktop version, but `record_video_note` is OK on both PC and Mobile versions