### PR TITLE
Fixed wrong method call

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -661,7 +661,7 @@ class TeleBot:
         return types.Message.de_json(result)
 
     def answer_shipping_query(self, shipping_query_id, ok, shipping_options=None, error_message=None):
-        return apihelper.answer_shippingQuery(self.token, shipping_query_id, ok, shipping_options, error_message)
+        return apihelper.answer_shipping_query(self.token, shipping_query_id, ok, shipping_options, error_message)
 
     def answer_pre_checkout_query(self, pre_checkout_query_id, ok, error_message=None):
         return apihelper.answer_pre_checkout_query(self.token, pre_checkout_query_id, ok, error_message)


### PR DESCRIPTION
Should be called `apihelper.answer_shipping_query` instead of `apihelper.answer_shippingQuery`
Fixes `AttributeError: module 'telebot.apihelper' has no attribute 'answer_shippingQuery'`