### PR TITLE
json.dumps(allowed_updates) before sending request

### DIFF
--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
 
+try:
+    import ujson as json
+except ImportError:
+    import json
+
 import requests
 
 try:
@@ -137,7 +142,7 @@ def set_webhook(token, url=None, certificate=None, max_connections=None, allowed
     if max_connections:
         payload['max_connections'] = max_connections
     if allowed_updates:
-        payload['allowed_updates'] = allowed_updates
+        payload['allowed_updates'] = json.dumps(allowed_updates)
     return _make_request(token, method_url, params=payload, files=files)
 
 
@@ -162,7 +167,7 @@ def get_updates(token, offset=None, limit=None, timeout=None, allowed_updates=No
     if timeout:
         payload['timeout'] = timeout
     if allowed_updates:
-        payload['allowed_updates'] = allowed_updates
+        payload['allowed_updates'] = json.dumps(allowed_updates)
     return _make_request(token, method_url, params=payload)
 
 


### PR DESCRIPTION
Without this code Telegram Bot API will never get a correct json with set up `allowed_updates` field.

Before this code it's easy to check that passing allowed_updates does not work:
1. send `setWebhook` command with passed `allowed_updates = ['message']` (for example)
2. send `getWebhookInfo` command and you will get `allowed_updates: None` in response.
3. That's why bot continues to get updates non-message type.