### PR TITLE
Per-thread requests sessions

### DIFF
--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -50,7 +50,7 @@ def _make_request(token, method_name, method='get', params=None, files=None, bas
     if params:
         if 'timeout' in params: read_timeout = params['timeout'] + 10
         if 'connect-timeout' in params: connect_timeout = params['connect-timeout'] + 10
-    result = _get_req_session().req_session.request(method, request_url, params=params, files=files,
+    result = _get_req_session().request(method, request_url, params=params, files=files,
             timeout=(connect_timeout, read_timeout), proxies=proxy)
     logger.debug("The server returned: '{0}'".format(result.text.encode('utf8')))
     return _check_result(method_name, result)['result']

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -17,6 +17,9 @@ except ImportError:
 from telebot import logger
 
 
+thread_local = threading.local()
+
+
 class WorkerThread(threading.Thread):
         count = 0
 
@@ -242,3 +245,12 @@ def extract_arguments(text):
     regexp = re.compile("\/\w*(@\w*)*\s*([\s\S]*)",re.IGNORECASE)
     result = regexp.match(text)
     return result.group(2) if is_command(text) else None
+
+
+def per_thread(key, construct_value):
+    try:
+        return getattr(thread_local, key)
+    except AttributeError:
+        value = construct_value()
+        setattr(thread_local, key, value)
+        return value


### PR DESCRIPTION
It's not safe to use global requests.Session instance in threaded application, so I made sessions thread-local. For more info see: https://github.com/requests/requests/issues/2766