### PR TITLE
change the documentation of TeleBot.polling in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ tb = telebot.TeleBot(TOKEN)	#create a new Telegram Bot object
 # - none_stop: True/False (default False) - Don't stop polling when receiving an error from the Telegram servers
 # - interval: True/False (default False) - The interval between polling requests
 #           Note: Editing this parameter harms the bot's response time
-# - block: True/False (default True) - Blocks upon calling this function
-tb.polling(none_stop=False, interval=0, block=True)
+# - timeout: integer (default 20) - Timeout in seconds for long polling.
+tb.polling(none_stop=False, interval=0, timeout=20)
 
 # getMe
 user = tb.get_me()

--- a/README.rst
+++ b/README.rst
@@ -421,8 +421,8 @@ TeleBot
     # - none_stop: True/False (default False) - Don't stop polling when receiving an error from the Telegram servers
     # - interval: True/False (default False) - The interval between polling requests
     #           Note: Editing this parameter harms the bot's response time
-    # - block: True/False (default True) - Blocks upon calling this function
-    tb.polling(none_stop=False, interval=0, block=True)
+    # - timeout: integer (default 20) - Timeout in seconds for long polling.
+    tb.polling(none_stop=False, interval=0, timeout=20)
 
     # getMe
     user = tb.get_me()


### PR DESCRIPTION
The interface of `TeleBot.polling()` in module telebot has changed. The old `block` parameter is removed and a `timeout` is added, but the readme documents don't reflect these changes.