### PR TITLE
Added missing author_signature field to Message object

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -383,6 +383,7 @@ class Message(JsonDeserializable):
         self.forward_date = None
         self.reply_to_message = None
         self.edit_date = None
+        self.author_signature = None
         self.text = None
         self.entities = None
         self.audio = None


### PR DESCRIPTION
`author_signature` field was checked, but never added to `Message` object.