### PR TITLE
#405 - Message has callback function but it exec command handlers too.

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1259,10 +1259,13 @@ class TeleBot:
 
     def _notify_command_handlers(self, handlers, new_messages):
         for message in new_messages:
-            for message_handler in handlers:
-                if self._test_message_handler(message_handler, message):
-                    self._exec_task(message_handler['function'], message)
-                    break
+            # if message has next step handler, dont exec command handlers
+            if (isinstance(message, types.CallbackQuery)) or \
+                   (isinstance(message, types.Message) and (message.chat.id not in self.message_subscribers_next_step)):
+                for message_handler in handlers:
+                    if self._test_message_handler(message_handler, message):
+                        self._exec_task(message_handler['function'], message)
+                        break
 
 
 class AsyncTeleBot(TeleBot):


### PR DESCRIPTION
Hello. There is an error in register_next_step_handler: when new message comes, callback function is called. Its okey. But it processes like regular message, too. 
Look: I have handler for text and then check if message.text == "/start" and etc. An if it doesn't match any command it send unknown command message. So when user sends message after register_next_step_handler, it send message from callback function and from handler! So I fixed this bug.

Issues:
https://github.com/eternnoir/pyTelegramBotAPI/issues/405
https://github.com/eternnoir/pyTelegramBotAPI/issues/315