### PR TITLE
Updating send_media_group method

### DIFF
--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -141,7 +141,6 @@ def file_to_send(files, text):
         photoExtensions = ['gif', 'jpeg', 'jpg', 'png'] # photo extensions
         videoExtensions = ['mp4'] # video extensions
         for i in files:
-            print(i)
             url = None
             if len(files_to_send) > 0:
                 text = ''

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -302,7 +302,7 @@ def send_photo(token, chat_id, photo, caption=None, reply_to_message_id=None, re
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
-def send_media_group(token, chat_id, media, disable_notification=None, reply_to_message_id=None):
+def send_media_group(token, chat_id, media, disable_notification=None, reply_to_message_id=None, caption=''):
     method_url = r'sendMediaGroup'
     try:
         media_list = files_to_send(media, caption)


### PR DESCRIPTION
Added automated formatting files for send_media_group. User just provide files's names in `media` list (or way to the each file) and they will be automatically uploaded to telegra.ph/upload and will be sent to Telegram using such Bot API feature as uploading data from URL (https://core.telegram.org/bots/api#sending-files) so size limits are the same: 5 MB max size for photos and 20 MB max for other types of content.
Supported file extensions are: 
GIF, JPEG, JPG, PNG and MP4. 
Also added caption support for send_media_group. Now user can provide some text as `caption` param in send_media_group and it will be set as first file descrption. Limits are standart (0-200 characters).