### PR TITLE
Added support for local files in the sendMediaGroup method

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1981,7 +1981,8 @@ class InputMediaPhoto(JsonSerializable):
         return json.dumps(self.to_dic())
 
     def to_dic(self):
-        ret = {'type': self.type, 'media': self.media}
+        ret = {'type': self.type, 'media': 'attach://' + util.generate_random_token()
+               if not util.is_string(self.media) else self.media}
         if self.caption:
             ret['caption'] = self.caption
         return ret
@@ -2000,7 +2001,8 @@ class InputMediaVideo(JsonSerializable):
         return json.dumps(self.to_dic())
 
     def to_dic(self):
-        ret = {'type': self.type, 'media': self.media}
+        ret = {'type': self.type, 'media': 'attach://' + util.generate_random_token()
+               if not util.is_string(self.media) else self.media}
         if self.caption:
             ret['caption'] = self.caption
         if self.width:

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-
+import random
+import string
 import threading
 import traceback
 import re
@@ -254,3 +255,7 @@ def per_thread(key, construct_value):
         value = construct_value()
         setattr(thread_local, key, value)
         return value
+
+
+def generate_random_token():
+    return ''.join(random.sample(string.ascii_letters, 16))


### PR DESCRIPTION
Added support for local files in the `send_media_group` method
For example:
```python
import telebot
from telebot.types import InputMediaPhoto, InputMediaVideo


bot = telebot.TeleBot(token)

@bot.message_handler(commands=['get'])
def get_media(message):
	with open('path/to/file1.jpg', 'rb') as f1, open('/path/to/file2.jpg', 'rb') as f2, \
		    open('/path/to/video.mp4', 'rb') as video:
		    files = bot.send_media_group(message.from_user.id,
		                                 [InputMediaPhoto(f1),
		                                  InputMediaPhoto(f2),
		                                  InputMediaPhoto(<url>),
		                                  InputMediaPhoto(<file_id>),
		                                  InputMediaVideo(video)])
```