### PR TITLE
Bot Api 3.6

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -486,24 +486,25 @@ class TeleBot:
         return apihelper.delete_message(self.token, chat_id, message_id)
 
     def send_photo(self, chat_id, photo, caption=None, reply_to_message_id=None, reply_markup=None,
-                   disable_notification=None):
+                   parse_mode=None, disable_notification=None):
         """
         Use this method to send photos.
         :param disable_notification:
         :param chat_id:
         :param photo:
         :param caption:
+        :param parse_mode
         :param reply_to_message_id:
         :param reply_markup:
         :return: API reply.
         """
         return types.Message.de_json(
             apihelper.send_photo(self.token, chat_id, photo, caption, reply_to_message_id, reply_markup,
-                                 disable_notification))
+                                 parse_mode, disable_notification))
 
     def send_audio(self, chat_id, audio, caption=None, duration=None, performer=None, title=None,
                    reply_to_message_id=None,
-                   reply_markup=None, disable_notification=None, timeout=None):
+                   reply_markup=None, parse_mode=None, disable_notification=None, timeout=None):
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .mp3 format.
         :param chat_id:Unique identifier for the message recipient
@@ -511,16 +512,17 @@ class TeleBot:
         :param duration:Duration of the audio in seconds
         :param performer:Performer
         :param title:Track name
+        :param parse_mode
         :param reply_to_message_id:If the message is a reply, ID of the original message
         :param reply_markup:
         :return: Message
         """
         return types.Message.de_json(
             apihelper.send_audio(self.token, chat_id, audio, caption, duration, performer, title, reply_to_message_id,
-                                 reply_markup, disable_notification, timeout))
+                                 reply_markup, parse_mode, disable_notification, timeout))
 
     def send_voice(self, chat_id, voice, caption=None, duration=None, reply_to_message_id=None, reply_markup=None,
-                   disable_notification=None, timeout=None):
+                   parse_mode=None, disable_notification=None, timeout=None):
         """
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
         :param chat_id:Unique identifier for the message recipient.
@@ -528,25 +530,27 @@ class TeleBot:
         :param duration:Duration of sent audio in seconds
         :param reply_to_message_id:
         :param reply_markup:
+        :param parse_mode
         :return: Message
         """
         return types.Message.de_json(
             apihelper.send_voice(self.token, chat_id, voice, caption, duration, reply_to_message_id, reply_markup,
-                                 disable_notification, timeout))
+                                 parse_mode, disable_notification, timeout))
 
     def send_document(self, chat_id, data, reply_to_message_id=None, caption=None, reply_markup=None,
-                      disable_notification=None, timeout=None):
+                      parse_mode=None, disable_notification=None, timeout=None):
         """
         Use this method to send general files.
         :param chat_id:
         :param data:
         :param reply_to_message_id:
         :param reply_markup:
+        :param parse_mode
         :return: API reply.
         """
         return types.Message.de_json(
             apihelper.send_data(self.token, chat_id, data, 'document', reply_to_message_id, reply_markup,
-                                disable_notification, timeout, caption=caption))
+                                parse_mode, disable_notification, timeout, caption=caption))
 
     def send_sticker(self, chat_id, data, reply_to_message_id=None, reply_markup=None, disable_notification=None,
                      timeout=None):
@@ -563,20 +567,22 @@ class TeleBot:
                                 disable_notification, timeout))
 
     def send_video(self, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
-                   disable_notification=None, timeout=None):
+                   parse_mode=None, supports_streaming=None, disable_notification=None, timeout=None):
         """
         Use this method to send video files, Telegram clients support mp4 videos.
         :param chat_id: Integer : Unique identifier for the message recipient — User or GroupChat id
         :param data: InputFile or String : Video to send. You can either pass a file_id as String to resend a video that is already on the Telegram server
         :param duration: Integer : Duration of sent video in seconds
         :param caption: String : Video caption (may also be used when resending videos by file_id).
+        :param parse_mode:
+        :param supports_streaming:
         :param reply_to_message_id:
         :param reply_markup:
         :return:
         """
         return types.Message.de_json(
             apihelper.send_video(self.token, chat_id, data, duration, caption, reply_to_message_id, reply_markup,
-                                 disable_notification, timeout))
+                                 parse_mode, supports_streaming, disable_notification, timeout))
 
     def send_video_note(self, chat_id, data, duration=None, length=None, reply_to_message_id=None, reply_markup=None,
                         disable_notification=None, timeout=None):

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -503,8 +503,8 @@ class TeleBot:
                                  parse_mode, disable_notification))
 
     def send_audio(self, chat_id, audio, caption=None, duration=None, performer=None, title=None,
-                   reply_to_message_id=None,
-                   reply_markup=None, parse_mode=None, disable_notification=None, timeout=None):
+                   reply_to_message_id=None, reply_markup=None, parse_mode=None, disable_notification=None,
+                   timeout=None):
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .mp3 format.
         :param chat_id:Unique identifier for the message recipient
@@ -545,7 +545,8 @@ class TeleBot:
         :param data:
         :param reply_to_message_id:
         :param reply_markup:
-        :param parse_mode
+        :param parse_mode:
+        :param disable_notification:
         :return: API reply.
         """
         return types.Message.de_json(

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -909,9 +909,10 @@ class TeleBot:
     def answer_pre_checkout_query(self, pre_checkout_query_id, ok, error_message=None):
         return apihelper.answer_pre_checkout_query(self.token, pre_checkout_query_id, ok, error_message)
 
-    def edit_message_caption(self, caption, chat_id=None, message_id=None, inline_message_id=None, reply_markup=None):
+    def edit_message_caption(self, caption, chat_id=None, message_id=None, inline_message_id=None,
+                             parse_mode=None, reply_markup=None):
         result = apihelper.edit_message_caption(self.token, caption, chat_id, message_id, inline_message_id,
-                                                reply_markup)
+                                                parse_mode, reply_markup)
         if type(result) == bool:
             return result
         return types.Message.de_json(result)

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -616,7 +616,8 @@ def edit_message_text(token, text, chat_id=None, message_id=None, inline_message
     return _make_request(token, method_url, params=payload)
 
 
-def edit_message_caption(token, caption, chat_id=None, message_id=None, inline_message_id=None, reply_markup=None):
+def edit_message_caption(token, caption, chat_id=None, message_id=None, inline_message_id=None,
+                         parse_mode=None, reply_markup=None):
     method_url = r'editMessageCaption'
     payload = {'caption': caption}
     if chat_id:
@@ -625,6 +626,8 @@ def edit_message_caption(token, caption, chat_id=None, message_id=None, inline_m
         payload['message_id'] = message_id
     if inline_message_id:
         payload['inline_message_id'] = inline_message_id
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     return _make_request(token, method_url, params=payload)

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -460,8 +460,8 @@ def send_audio(token, chat_id, audio, caption=None, duration=None, performer=Non
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
-def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_markup=None, disable_notification=None,
-              timeout=None, parse_mode=None, caption=None):
+def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_markup=None, parse_mode=None,
+              disable_notification=None, timeout=None, caption=None):
     method_url = get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -236,7 +236,7 @@ def forward_message(token, chat_id, from_chat_id, message_id, disable_notificati
 
 
 def send_photo(token, chat_id, photo, caption=None, reply_to_message_id=None, reply_markup=None,
-               disable_notification=None):
+               parse_mode=None, disable_notification=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None
@@ -250,6 +250,8 @@ def send_photo(token, chat_id, photo, caption=None, reply_to_message_id=None, re
         payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
     if disable_notification:
         payload['disable_notification'] = disable_notification
     return _make_request(token, method_url, params=payload, files=files, method='post')
@@ -349,7 +351,7 @@ def send_chat_action(token, chat_id, action):
 
 
 def send_video(token, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
-               disable_notification=None, timeout=None):
+               parse_mode=None, supports_streaming=None, disable_notification=None, timeout=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -365,6 +367,10 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_to_messa
         payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
+    if supports_streaming:
+        payload['supports_streaming'] = supports_streaming
     if disable_notification:
         payload['disable_notification'] = disable_notification
     if timeout:
@@ -373,7 +379,7 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_to_messa
 
 
 def send_voice(token, chat_id, voice, caption=None, duration=None, reply_to_message_id=None, reply_markup=None,
-               disable_notification=None, timeout=None):
+               parse_mode=None, disable_notification=None, timeout=None):
     method_url = r'sendVoice'
     payload = {'chat_id': chat_id}
     files = None
@@ -389,6 +395,8 @@ def send_voice(token, chat_id, voice, caption=None, duration=None, reply_to_mess
         payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
     if disable_notification:
         payload['disable_notification'] = disable_notification
     if timeout:
@@ -423,7 +431,7 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_m
 
 
 def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None, reply_to_message_id=None,
-               reply_markup=None, disable_notification=None, timeout=None):
+               reply_markup=None, parse_mode=None, disable_notification=None, timeout=None):
     method_url = r'sendAudio'
     payload = {'chat_id': chat_id}
     files = None
@@ -443,6 +451,8 @@ def send_audio(token, chat_id, audio, caption=None, duration=None, performer=Non
         payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
     if disable_notification:
         payload['disable_notification'] = disable_notification
     if timeout:
@@ -451,7 +461,7 @@ def send_audio(token, chat_id, audio, caption=None, duration=None, performer=Non
 
 
 def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_markup=None, disable_notification=None,
-              timeout=None, caption=None):
+              timeout=None, parse_mode=None, caption=None):
     method_url = get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None
@@ -463,6 +473,8 @@ def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_m
         payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
+    if parse_mode and data_type == 'document':
+        payload['parse_mode'] = parse_mode
     if disable_notification:
         payload['disable_notification'] = disable_notification
     if timeout:

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -366,6 +366,9 @@ class Message(JsonDeserializable):
         if 'successful_payment' in obj:
             opts['successful_payment'] = SuccessfulPayment.de_json(obj['successful_payment'])
             content_type = 'successful_payment'
+        if 'connected_website' in obj:
+            opts['connected_website'] = obj['connected_website']
+            content_type = 'connected_website'
         return cls(message_id, from_user, date, chat, content_type, opts)
 
     @classmethod
@@ -430,6 +433,7 @@ class Message(JsonDeserializable):
         self.pinned_message = None
         self.invoice = None
         self.successful_payment = None
+        self.connected_website = None
         for key in options:
             setattr(self, key, options[key])
 
@@ -1975,10 +1979,11 @@ class MaskPosition(JsonDeserializable, JsonSerializable):
 # InputMedia
 
 class InputMediaPhoto(JsonSerializable):
-    def __init__(self, media, caption=None):
+    def __init__(self, media, caption=None, parse_mode=None):
         self.type = "photo"
         self.media = media
         self.caption = caption
+        self.parse_mode = parse_mode
 
     def to_json(self):
         return json.dumps(self.to_dic())
@@ -1988,17 +1993,22 @@ class InputMediaPhoto(JsonSerializable):
                if not util.is_string(self.media) else self.media}
         if self.caption:
             ret['caption'] = self.caption
+        if self.parse_mode:
+            ret['parse_mode'] = self.parse_mode
         return ret
 
 
 class InputMediaVideo(JsonSerializable):
-    def __init__(self, media, caption=None, width=None, height=None, duration=None):
+    def __init__(self, media, caption=None, parse_mode=None, width=None, height=None, duration=None,
+                 supports_streaming=None):
         self.type = "video"
         self.media = media
         self.caption = caption
+        self.parse_mode = parse_mode
         self.width = width
         self.height = height
         self.duration = duration
+        self.supports_streaming = supports_streaming
 
     def to_json(self):
         return json.dumps(self.to_dic())
@@ -2008,10 +2018,14 @@ class InputMediaVideo(JsonSerializable):
                if not util.is_string(self.media) else self.media}
         if self.caption:
             ret['caption'] = self.caption
+        if self.parse_mode:
+            ret['parse_mode'] = self.parse_mode
         if self.width:
             ret['width'] = self.width
         if self.height:
             ret['height'] = self.height
         if self.duration:
             ret['duration'] = self.duration
+        if self.supports_streaming:
+            ret['supports_streaming'] = self.supports_streaming
         return ret

--- a/tests/test_telebot.py
+++ b/tests/test_telebot.py
@@ -420,3 +420,51 @@ class TestTeleBot:
         assert len(result) == 2
         assert result[0].media_group_id is not None
         assert result[0].media_group_id == result[1].media_group_id
+
+    def test_send_media_group_local_files(self):
+        photo = open('../examples/detailed_example/kitten.jpg', 'rb')
+        video = open('./test_data/test_video.mp4', 'rb')
+        tb = telebot.TeleBot(TOKEN)
+        medias = [types.InputMediaPhoto(photo, "View"),
+                  types.InputMediaVideo(video)]
+        result = tb.send_media_group(CHAT_ID, medias)
+        assert len(result) == 2
+        assert result[0].media_group_id is not None
+        assert result[1].media_group_id is not None
+
+    def test_send_photo_formating_caption(self):
+        file_data = open('../examples/detailed_example/kitten.jpg', 'rb')
+        tb = telebot.TeleBot(TOKEN)
+        ret_msg = tb.send_photo(CHAT_ID, file_data, caption='_italic_', parse_mode='Markdown')
+        assert ret_msg.caption_entities[0].type == 'italic'
+
+    def test_send_video_formatting_caption(self):
+        file_data = open('./test_data/test_video.mp4', 'rb')
+        tb = telebot.TeleBot(TOKEN)
+        ret_msg = tb.send_video(CHAT_ID, file_data, caption='_italic_', parse_mode='Markdown')
+        assert ret_msg.caption_entities[0].type == 'italic'
+
+    def test_send_audio_formatting_caption(self):
+        file_data = open('./test_data/record.mp3', 'rb')
+        tb = telebot.TeleBot(TOKEN)
+        ret_msg = tb.send_audio(CHAT_ID, file_data, caption='<b>bold</b>', parse_mode='HTML')
+        assert ret_msg.caption_entities[0].type == 'bold'
+
+    def test_send_voice_formatting_caprion(self):
+        file_data = open('./test_data/record.ogg', 'rb')
+        tb = telebot.TeleBot(TOKEN)
+        ret_msg = tb.send_voice(CHAT_ID, file_data, caption='<b>bold</b>', parse_mode='HTML')
+        assert ret_msg.caption_entities[0].type == 'bold'
+        assert ret_msg.voice.mime_type == 'audio/ogg'
+
+    def test_send_media_group_formatting_caption(self):
+        tb = telebot.TeleBot(TOKEN)
+        img1 = 'https://i.imgur.com/CjXjcnU.png'
+        img2 = 'https://i.imgur.com/CjXjcnU.png'
+        medias = [types.InputMediaPhoto(img1, "*View*", parse_mode='Markdown'),
+                  types.InputMediaPhoto(img2, "_Dog_", parse_mode='Markdown')]
+        result = tb.send_media_group(CHAT_ID, medias)
+        assert len(result) == 2
+        assert result[0].media_group_id is not None
+        assert result[0].caption_entities[0].type == 'bold'
+        assert result[1].caption_entities[0].type == 'italic'

--- a/tests/test_telebot.py
+++ b/tests/test_telebot.py
@@ -468,3 +468,9 @@ class TestTeleBot:
         assert result[0].media_group_id is not None
         assert result[0].caption_entities[0].type == 'bold'
         assert result[1].caption_entities[0].type == 'italic'
+
+    def test_send_document_formating_caption(self):
+        file_data = open('../examples/detailed_example/kitten.jpg', 'rb')
+        tb = telebot.TeleBot(TOKEN)
+        ret_msg = tb.send_document(CHAT_ID, file_data, caption='_italic_', parse_mode='Markdown')
+        assert ret_msg.caption_entities[0].type == 'italic'


### PR DESCRIPTION
- Supported text formatting in media captions. Specify the desired parse_mode (Markdown or HTML) when you provide a caption. Example:
```python
bot.send_photo(chat_id, photo, caption='<b>bold text</b>, parse_mode='HTML')
```

- In supergroups, if the bot receives a message that is a reply, it will also receive the message to which that message is replying – even if the original message is inaccessible due to the bot's privacy settings. (In other words, replying to any message in a supergroup with a message that mentions the bot or features a command for it acts as forwarding the original message to the bot).

- Added the new field _connected_website_ to Message. The bot will receive a message with this field in a private chat when a user logs in on the bot's connected website using the [Login Widget](https://core.telegram.org/widgets/login) and allows sending messages from your bot.
To handle a message, you need to set `content_types=['connected_website']`. For example:
```python
@bot.message_handler(content_types=['connected_website'])
def response_from_website(message):
    print(message.connected_website)
```

- Added the new parameter _supports_streaming_ to the sendVideo method and a field with the same name to the inputMediaVideo object.
```python
bot.send_video(chat_id, video, supports_streaming=True)
```