### PR TITLE
Add step handler backend mechanism; implement memory and redis backends

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1290,6 +1290,12 @@ class TeleBot:
                     self._exec_task(message_handler['function'], message)
                     break
 
+    def add_step_handler(self, callback):
+        return self.step_handler_backend.add_handler(callback)
+
+    def add_step_handlers(self, *callbacks):
+        self.step_handler_backend.add_handlers(*callbacks)
+
 
 class AsyncTeleBot(TeleBot):
     def __init__(self, *args, **kwargs):

--- a/telebot/step_handler_backends.py
+++ b/telebot/step_handler_backends.py
@@ -1,4 +1,16 @@
 class StepHandlerBaseBackend(object):
+    _callbacks = {}
+
+    @classmethod
+    def add_handler(cls, callback):
+        cls._callbacks[callback.__name__] = callback
+        return callback
+
+    @classmethod
+    def add_handlers(cls, *callbacks):
+        for callback in callbacks:
+            cls.add_handler(callback)
+
     def register_handler(self, chat_id, callback):
         raise NotImplementedError()
 
@@ -26,18 +38,6 @@ class StepHandlerMemoryBackend(StepHandlerBaseBackend):
 
 
 class StepHandlerRedisBackend(StepHandlerBaseBackend):
-    _callbacks = {}
-
-    @classmethod
-    def add_handler(cls, callback):
-        cls._callbacks[callback.__name__] = callback
-        return callback
-
-    @classmethod
-    def add_handlers(cls, *callbacks):
-        for callback in callbacks:
-            cls.add_handler(callback)
-
     def __init__(self, host='localhost', port=6379, db=0, prefix='telebot'):
         from redis import Redis
         self.prefix = str(prefix)

--- a/telebot/step_handler_backends.py
+++ b/telebot/step_handler_backends.py
@@ -1,0 +1,57 @@
+class StepHandlerBaseBackend(object):
+    def register_handler(self, chat_id, callback):
+        raise NotImplementedError()
+
+    def clear_handler(self, chat_id):
+        raise NotImplementedError()
+
+    def get_handlers(self, chat_id):
+        raise NotImplementedError()
+
+
+class StepHandlerMemoryBackend(StepHandlerBaseBackend):
+    _callbacks = {}
+
+    def register_handler(self, chat_id, callback):
+        if chat_id in self._callbacks:
+            self._callbacks[chat_id].append(callback)
+        else:
+            self._callbacks[chat_id] = [callback]
+
+    def clear_handler(self, chat_id):
+        self._callbacks[chat_id] = []
+
+    def get_handlers(self, chat_id):
+        return self._callbacks.get(chat_id, [])
+
+
+class StepHandlerRedisBackend(StepHandlerBaseBackend):
+    _callbacks = {}
+
+    @classmethod
+    def add_handler(cls, callback):
+        cls._callbacks[callback.__name__] = callback
+        return callback
+
+    @classmethod
+    def add_handlers(cls, *callbacks):
+        for callback in callbacks:
+            cls.add_handler(callback)
+
+    def __init__(self, host='localhost', port=6379, db=0, prefix='telebot'):
+        from redis import Redis
+        self.prefix = str(prefix)
+        self.redis = Redis(host, port, db)
+
+    def _get_key(self, chat_id):
+        return ':'.join((self.prefix, str(chat_id)))
+
+    def register_handler(self, chat_id, callback):
+        self.redis.sadd(self._get_key(chat_id), callback.__name__)
+
+    def clear_handler(self, chat_id):
+        self.redis.delete(self._get_key(chat_id))
+
+    def get_handlers(self, chat_id):
+        lst = self.redis.smembers(self._get_key(chat_id)) or []
+        return [self._callbacks[name.decode()] for name in lst]


### PR DESCRIPTION
I've encountered a problem: step handlers do not persist between processes (when using webhooks and running multiple uwsgi/gunicorn/etc workers) or restarts (ie. when bot polling crashes because of exceptions or temporary bot API unavailability), so I've implemented external storage (particularly redis, other backends could be implemented as well) for these handlers. 

I cannot figure out one thing: what's the purpose of `pre_message_subscribers_next_step` dict? Nothing but empty dicts get written there.

Also what do you think about my design decisions, maybe something might be improved?