### PR TITLE
Added retries to _make_request and download_file. Alternate solution to #481

### DIFF
--- a/telebot/util.py
+++ b/telebot/util.py
@@ -83,6 +83,8 @@ class WorkerThread(threading.Thread):
 
         def stop(self):
             self._running = False
+            #The event will surely stop
+            self.continue_event.set()
 
 
 class ThreadPool:
@@ -234,12 +236,12 @@ def OrEvent(*events):
 def extract_arguments(text):
     """
     Returns the argument after the command.
-    
+
     Examples:
     extract_arguments("/get name"): 'name'
     extract_arguments("/get"): ''
     extract_arguments("/get@botName name"): 'name'
-    
+
     :param text: String to extract the arguments from a command
     :return: the arguments if `text` is a command (according to is_command), else None.
     """
@@ -248,7 +250,11 @@ def extract_arguments(text):
     return result.group(2) if is_command(text) else None
 
 
-def per_thread(key, construct_value):
+def per_thread(key, construct_value, reset):
+    if reset == True:
+        value = construct_value()
+        setattr(thread_local, key, value)
+
     try:
         return getattr(thread_local, key)
     except AttributeError:


### PR DESCRIPTION
Possible fix to #474, #453, #399. `Connection Reset by Peer`, `ReadTimeOut`:
- I noticed that connection reset by peer maybe could be solved by resetting the `requests.session()`. `ReadTimeOut` too maybe can be solved by resetting it. So, when a request is made and a exception is captured,  the session is resetted and a retry is done.  Retries limit was set to 5.

Made an alternate solution to #481: 
- Made `polling_thread` an instance variable: since if `Telebot` is threaded, maybe is for the best to limit `polling_thread` instances to just one. 
- The function `stop_instance` disables the Telebot instance (since it closes the `worker_pool` its threads can't be restarted), but it grants that the polling_thread is closed too, if some unhandled exception happened on `_threaded_polling` and the `self.polling_thread` wasn't closed. 
- In `WorkerThread`'s `stop()` function, added a `self.continue_event.set()`, just to make sure that the thread will get out of the `while self._running:` loop (could the thread be stuck on the `self.continue_event.wait()`?).  