### PR TITLE
fix issue #403: UnicodeEncodeError when sending a non-ASCII file in Python 2

### DIFF
--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -953,7 +953,7 @@ def _convert_input_media(array):
 def _no_encode(func):
     def wrapper(key, val):
         if key == 'filename':
-            return '{0}={1}'.format(key, val)
+            return u'{0}={1}'.format(key, val)
         else:
             return func(key, val)
 


### PR DESCRIPTION
Hi there,

This PR fix UnicodeEncodeError when sending a non-ASCII file in python 2.7.
Please refer to my previous issue #403

Thanks!