### PR TITLE
_notify_next_handlers drops messages if empty handler list

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1155,10 +1155,11 @@ class TeleBot:
             chat_id = message.chat.id
             if chat_id in self.next_step_handlers.keys():
                 handlers = self.next_step_handlers[chat_id]
-                for handler in handlers:
-                    self._exec_task(handler["callback"], message, *handler["args"], **handler["kwargs"])
+                if (handlers):
+                    for handler in handlers:
+                        self._exec_task(handler["callback"], message, *handler["args"], **handler["kwargs"])
+                    new_messages.pop(i)  # removing message that detects with next_step_handler
                 self.next_step_handlers.pop(chat_id, None)
-                new_messages.pop(i)  # removing message that detects with next_step_handler
             i += 1
 
     @staticmethod

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1153,14 +1153,17 @@ class TeleBot:
         while i < len(new_messages):
             message = new_messages[i]
             chat_id = message.chat.id
+            was_poped = False
             if chat_id in self.next_step_handlers.keys():
                 handlers = self.next_step_handlers[chat_id]
                 if (handlers):
                     for handler in handlers:
                         self._exec_task(handler["callback"], message, *handler["args"], **handler["kwargs"])
                     new_messages.pop(i)  # removing message that detects with next_step_handler
+                    was_poped = True
                 self.next_step_handlers.pop(chat_id, None)
-            i += 1
+            if (not was_poped):
+                i += 1
 
     @staticmethod
     def _build_handler_dict(handler, **filters):


### PR DESCRIPTION
After calling
`clear_step_handler(...)`
the code:
`self.next_step_handlers[chat_id] = []`
left the key in next_step_handlers. When a next message arrives, the old handler executes nothing (no handlers), but still remove message from message queue:
`new_messages.pop(i)`

Updated to pop message only when there are real handlers in the list.