### PR TITLE
Stop looping of the next handler

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6,6 +6,7 @@ import time
 import re
 import sys
 import six
+import collections
 
 import logging
 
@@ -693,6 +694,7 @@ class TeleBot:
             chat_id = message.chat.id
             if chat_id in self.message_subscribers_next_step:
                 handlers = self.message_subscribers_next_step[chat_id]
+                handlers = list(collections.Counter(handlers))
                 for handler in handlers:
                     self._exec_task(handler, message)
                 self.message_subscribers_next_step.pop(chat_id, None)


### PR DESCRIPTION
Let's imagine the situation when some command initializes step by step script. For example: after type /start bot asked your name. Also there are cases when bot could be in down for a short time with active users. These users repeat to type command a several times. And when bot has been restarted users got a problem with repeating handlers of the next step. For example: user types /start command 5 time and he will get a question about his name 5 times. BTW: this tiny commit solve this problem.