### PR TITLE
fix: 'NoneType' object has no attribute 'to_dic'

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -867,10 +867,7 @@ class InlineKeyboardMarkup(Dictionaryable, JsonSerializable):
         """
         btn_array = []
         for button in args:
-            if button is None:
-                continue
-            else:
-                btn_array.append(button.to_dic())
+            btn_array.append(button.to_dic())
         self.keyboard.append(btn_array)
         return self
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -867,7 +867,10 @@ class InlineKeyboardMarkup(Dictionaryable, JsonSerializable):
         """
         btn_array = []
         for button in args:
-            btn_array.append(button.to_dic())
+            if button is None:
+                continue
+            else:
+                btn_array.append(button.to_dic())
         self.keyboard.append(btn_array)
         return self
 


### PR DESCRIPTION
if pass None as a value in the .row method (InlineKeyboard), we will be having an error: 'NoneType' object has no attribute 'to_dic'