### PR TITLE
sendAnimation

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -107,6 +107,7 @@ class TeleBot:
         sendDocument
         sendSticker
         sendVideo
+        sendAnimation
         sendVideoNote
         sendLocation
         sendChatAction
@@ -718,6 +719,23 @@ class TeleBot:
         return types.Message.de_json(
             apihelper.send_video(self.token, chat_id, data, duration, caption, reply_to_message_id, reply_markup,
                                  parse_mode, supports_streaming, disable_notification, timeout))
+
+    def send_animation(self, chat_id, animation, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
+                   parse_mode=None, disable_notification=None, timeout=None):
+        """
+        Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
+        :param chat_id: Integer : Unique identifier for the message recipient — User or GroupChat id
+        :param data: InputFile or String : Animation to send. You can either pass a file_id as String to resend an animation that is already on the Telegram server
+        :param duration: Integer : Duration of sent video in seconds
+        :param caption: String : Animation caption (may also be used when resending animation by file_id).
+        :param parse_mode:
+        :param reply_to_message_id:
+        :param reply_markup:
+        :return:
+        """
+        return types.Message.de_json(
+            apihelper.send_animation(self.token, chat_id, animation, duration, caption, reply_to_message_id, reply_markup,
+                                 parse_mode, disable_notification, timeout))
 
     def send_video_note(self, chat_id, data, duration=None, length=None, reply_to_message_id=None, reply_markup=None,
                         disable_notification=None, timeout=None):

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -384,6 +384,32 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_to_messa
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
+def send_animation(token, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
+               parse_mode=None, disable_notification=None, timeout=None):
+    method_url = r'sendAnimation'
+    payload = {'chat_id': chat_id}
+    files = None
+    if not util.is_string(data):
+        files = {'animation': data}
+    else:
+        payload['animation'] = data
+    if duration:
+        payload['duration'] = duration
+    if caption:
+        payload['caption'] = caption
+    if reply_to_message_id:
+        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_markup:
+        payload['reply_markup'] = _convert_markup(reply_markup)
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
+    if disable_notification:
+        payload['disable_notification'] = disable_notification
+    if timeout:
+        payload['connect-timeout'] = timeout
+    return _make_request(token, method_url, params=payload, files=files, method='post')
+
+
 def send_voice(token, chat_id, voice, caption=None, duration=None, reply_to_message_id=None, reply_markup=None,
                parse_mode=None, disable_notification=None, timeout=None):
     method_url = r'sendVoice'


### PR DESCRIPTION
Added the method sendAnimation, which can be used instead of sendDocument to send animations, specifying their duration.
https://github.com/eternnoir/pyTelegramBotAPI/issues/542