### PR TITLE
Alter listener decorators to be able to trigger at any event with `text` or `caption`

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1476,8 +1476,8 @@ class TeleBot:
     def _test_filter(filter, filter_value, message):
         test_cases = {
             'content_types': lambda msg: msg.content_type in filter_value,
-            'regexp': lambda msg: msg.content_type == 'text' and re.search(filter_value, msg.text, re.IGNORECASE),
-            'commands': lambda msg: msg.content_type == 'text' and util.extract_command(msg.text) in filter_value,
+            'regexp':   lambda msg: (msg.text is not None and re.search(filter_value, msg.text, re.IGNORECASE)) or (msg.caption is not None and re.search(filter_value, msg.caption, re.IGNORECASE)),
+            'commands': lambda msg: (msg.text is not None and util.extract_command(msg.text)) or (msg.caption is not None and util.extract_command(msg.caption)) in filter_value,
             'func': lambda msg: filter_value(msg)
         }
 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1477,7 +1477,7 @@ class TeleBot:
         test_cases = {
             'content_types': lambda msg: msg.content_type in filter_value,
             'regexp':   lambda msg: (msg.text is not None and re.search(filter_value, msg.text, re.IGNORECASE)) or (msg.caption is not None and re.search(filter_value, msg.caption, re.IGNORECASE)),
-            'commands': lambda msg: (msg.text is not None and util.extract_command(msg.text)) or (msg.caption is not None and util.extract_command(msg.caption)) in filter_value,
+            'commands': lambda msg: util.extract_command(msg.text or msg.caption or '') in filter_value,
             'func': lambda msg: filter_value(msg)
         }
 


### PR DESCRIPTION
regexp and command handler now work with any message that have text or caption instead of text messages only
