### PR TITLE
Choosable blocking

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -459,11 +459,10 @@ class TeleBot:
         logger.info('Stopped polling.')
 
     def _exec_task(self, task, *args, **kwargs):
-        if self.threaded and not kwargs.get('blocking'):
-            kwargs.pop('blocking', None)
+        _blocking = kwargs.pop('blocking', None)
+        if self.threaded and not _blocking:
             self.worker_pool.put(task, *args, **kwargs)
         else:
-            kwargs.pop('blocking', None)
             return task(*args, **kwargs)
 
     def stop_polling(self):

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -462,7 +462,7 @@ class TeleBot:
         if self.threaded:
             self.worker_pool.put(task, *args, **kwargs)
         else:
-            task(*args, **kwargs)
+            return task(*args, **kwargs)
 
     def stop_polling(self):
         self.__stop_polling.set()
@@ -1487,8 +1487,9 @@ class TeleBot:
         for message in new_messages:
             for message_handler in handlers:
                 if self._test_message_handler(message_handler, message):
-                    self._exec_task(message_handler['function'], message)
-                    break
+                    result = self._exec_task(message_handler['function'], message)
+                    if result == util.TELEBOT_EAT_ALL:
+                        break
 
 
 class AsyncTeleBot(TeleBot):

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1311,6 +1311,7 @@ class TeleBot:
         return {
             'function': handler,
             'blocking':filters.pop("blocking", None),
+            'final':filters.pop("final", util.TELEBOT_DEFAULT_BREAK),
             'filters' : filters
         }
 
@@ -1489,9 +1490,10 @@ class TeleBot:
         for message in new_messages:
             for message_handler in handlers:
                 blocking = message_handler.get('blocking')
+                final = message_handler.get('final')
                 if self._test_message_handler(message_handler, message):
                     result = self._exec_task(message_handler['function'], message, blocking=blocking)
-                    if result == util.TELEBOT_EAT_ALL:
+                    if final or result == util.TELEBOT_EAT_ALL:
                         break
 
 

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -21,8 +21,9 @@ logger = logging.getLogger('TeleBot')
 
 thread_local = threading.local()
 
-TELEBOT_EAT_NONE=None
-TELEBOT_EAT_ALL=-256
+TELEBOT_EAT_NONE = None
+TELEBOT_EAT_ALL = -256
+TELEBOT_DEFAULT_BREAK = True
 
 class WorkerThread(threading.Thread):
         count = 0

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -21,6 +21,8 @@ logger = logging.getLogger('TeleBot')
 
 thread_local = threading.local()
 
+TELEBOT_EAT_NONE=None
+TELEBOT_EAT_ALL=-256
 
 class WorkerThread(threading.Thread):
         count = 0


### PR DESCRIPTION
Allows to pass event to the next handler. User controlled.

If you know that your listener can or will break the loop (i.e return util.TELEBOT_EAT_ALL) than your listener should have `blocking=True`, for example:
```
@bot.message_handler(func=lambda m: True, blocking=True, final=True)
@bot.channel_post_handler(func=lambda m: True, blocking=True, final=True)
def do_something(msg):
    print("Shall not pass.")
    return util.TELEBOT_EAT_ALL #will break the loop even in threaded mode
```
`final=True` will break loop in any case despite default settings and `blocking` param.
Please remember that blocking listeners order is mandatory.

Supports async mode.

Added `final` key to honor default telebot's behaviour on breaking the loop.

`final` defaults to util.TELEBOT_DEFAULT_BREAK.
Set util.TELEBOT_DEFAULT_BREAK=False to not break the loop by default.
