### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/examples/inline_example.py
+++ b/examples/inline_example.py
@@ -51,7 +51,7 @@ def query_video(inline_query):
         print(e)
 
 
-@bot.inline_handler(lambda query: len(query.query) is 0)
+@bot.inline_handler(lambda query: len(query.query) == 0)
 def default_query(inline_query):
     try:
         r = types.InlineQueryResultArticle('1', 'default', types.InputTextMessageContent('default'))


### PR DESCRIPTION
Use ==/!= to compare str, bytes, and int literals because identity is not the same thing as equality in Python. These instances will raise SyntaxWarnings on Python >= 3.8 so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8