### PR TITLE
 Travis CI: Drop Python versions that are EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
-    - "3.3"
-    - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
     - "pypy"
     - "pypy3"
 install: "pip install -r requirements.txt"


### PR DESCRIPTION
https://devguide.python.org/devcycle#end-of-life-branches
https://devguide.python.org/#branchstatus