### PR TITLE
Fixed #578

### DIFF
--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -99,7 +99,7 @@ def get_file(token, file_id):
 
 
 def get_file_url(token, file_id):
-    return FILE_URL.format(token, get_file(token, file_id).file_path)
+    return FILE_URL.format(token, get_file(token, file_id)['file_path'])
 
 
 def download_file(token, file_path):


### PR DESCRIPTION
Fixed AttributeError that was caused by referencing `file_path` in object-attribute style on dict:
`get_file(token, file_id).file_path`

telebot/apihelper.py:101
```
def get_file_url(token, file_id):
    return FILE_URL.format(token, get_file(token, file_id)['file_path'])
```

**Why to reference as a dict item but not to de_json right here**
`get_file` function of apihelper.py returns a dict that is not converted to an object yet (as all functions in apihelper.py do).
De-json'ing of `apihhelper.get_file()` takes place in `TeleBot.get_file()`.

telebot/__init__.py:483
```
    def get_file(self, file_id):
        return types.File.de_json(apihelper.get_file(self.token, file_id))
```