### PR TITLE
Update version list in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
     - "pypy"
     - "pypy3"
 install: "pip install -r requirements.txt"


### PR DESCRIPTION
Travis: removed 2.6 and 3.3 (not supported). Added 3.7. Also added 3.8 (for experiment)