### PR TITLE
changed pickle serializer to dill

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,10 @@
+certifi==2019.11.28
+chardet==3.0.4
+dill==0.3.1.1
+idna==2.7
 py==1.4.29
 pytest==3.0.2
 requests==2.20.0
 six==1.9.0
+urllib3==1.24.3
 wheel==0.24.0

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import logging
 import os
-import pickle
+import dill as pickle
 import re
 import sys
 import threading


### PR DESCRIPTION
**pickle** can't serialize nested functions and have many other problems. In **dill** many of them are fixed. For instance, if somebody wants to save a decorated function as a `next_step_handler`, it won't be saved because of pickle problems.