### PR TITLE
Add @bot.poll_handler to be notified of new poll states

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -167,6 +167,7 @@ class TeleBot:
         self.callback_query_handlers = []
         self.shipping_query_handlers = []
         self.pre_checkout_query_handlers = []
+        self.poll_handlers = []
 
         self.threaded = threaded
         if self.threaded:
@@ -289,6 +290,7 @@ class TeleBot:
         new_callback_querys = []
         new_shipping_querys = []
         new_pre_checkout_querys = []
+        new_polls = []
 
         for update in updates:
             if update.update_id > self.last_update_id:
@@ -311,6 +313,8 @@ class TeleBot:
                 new_shipping_querys.append(update.shipping_query)
             if update.pre_checkout_query:
                 new_pre_checkout_querys.append(update.pre_checkout_query)
+            if update.poll:
+                new_polls.append(update.poll)
 
         logger.debug('Received {0} new updates'.format(len(updates)))
         if len(new_messages) > 0:
@@ -331,6 +335,8 @@ class TeleBot:
             self.process_new_shipping_query(new_shipping_querys)
         if len(new_pre_checkout_querys) > 0:
             self.process_new_pre_checkout_query(new_pre_checkout_querys)
+        if len(new_polls) > 0:
+            self.process_new_poll(new_polls)
 
     def process_new_messages(self, new_messages):
         self._notify_next_handlers(new_messages)
@@ -361,6 +367,9 @@ class TeleBot:
 
     def process_new_pre_checkout_query(self, pre_checkout_querys):
         self._notify_command_handlers(self.pre_checkout_query_handlers, pre_checkout_querys)
+
+    def process_new_poll(self, polls):
+        self._notify_command_handlers(self.poll_handlers, polls)
 
     def __notify_update(self, new_messages):
         for listener in self.update_listener:
@@ -1754,6 +1763,28 @@ class TeleBot:
         :return:
         """
         self.pre_checkout_query_handlers.append(handler_dict)
+
+    def poll_handler(self, func, **kwargs):
+        """
+        Poll request handler
+        :param func:
+        :param kwargs:
+        :return:
+        """
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
+            self.add_poll_handler(handler_dict)
+            return handler
+
+        return decorator
+
+    def add_poll_handler(self, handler_dict):
+        """
+        Adds a poll request handler
+        :param handler_dict:
+        :return:
+        """
+        self.poll_handlers.append(handler_dict)
 
     def _test_message_handler(self, message_handler, message):
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -327,10 +327,10 @@ class TeleBot:
             self.process_new_chosen_inline_query(new_chosen_inline_results)
         if len(new_callback_querys) > 0:
             self.process_new_callback_query(new_callback_querys)
-        if len(new_pre_checkout_querys) > 0:
-            self.process_new_pre_checkout_query(new_pre_checkout_querys)
         if len(new_shipping_querys) > 0:
             self.process_new_shipping_query(new_shipping_querys)
+        if len(new_pre_checkout_querys) > 0:
+            self.process_new_pre_checkout_query(new_pre_checkout_querys)
 
     def process_new_messages(self, new_messages):
         self._notify_next_handlers(new_messages)

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -103,6 +103,7 @@ class Update(JsonDeserializable):
         callback_query = None
         shipping_query = None
         pre_checkout_query = None
+        poll = None
         if 'message' in obj:
             message = Message.de_json(obj['message'])
         if 'edited_message' in obj:
@@ -121,11 +122,13 @@ class Update(JsonDeserializable):
             shipping_query = ShippingQuery.de_json(obj['shipping_query'])
         if 'pre_checkout_query' in obj:
             pre_checkout_query = PreCheckoutQuery.de_json(obj['pre_checkout_query'])
+        if 'poll' in obj:
+            poll = Poll.de_json(obj['poll'])
         return cls(update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
-                   chosen_inline_result, callback_query, shipping_query, pre_checkout_query)
+                   chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll)
 
     def __init__(self, update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
-                 chosen_inline_result, callback_query, shipping_query, pre_checkout_query):
+                 chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll):
         self.update_id = update_id
         self.message = message
         self.edited_message = edited_message
@@ -136,6 +139,7 @@ class Update(JsonDeserializable):
         self.callback_query = callback_query
         self.shipping_query = shipping_query
         self.pre_checkout_query = pre_checkout_query
+        self.poll = poll
 
 
 class WebhookInfo(JsonDeserializable):
@@ -2240,12 +2244,22 @@ class Poll(JsonDeserializable):
         options = []
         for opt in obj['options']:
             options.append(PollOption.de_json(opt))
-        poll.options = options
+        total_voter_count = obj['total_voter_count']
         is_closed = obj['is_closed']
-        poll.id = poll_id
-        poll.is_closed = is_closed
         is_anonymous = obj['is_anonymous']
+        poll_type = obj['type']
+        allows_multiple_answers = obj['allows_multiple_answers']
+        correct_option_id = None
+        if 'correct_option_id' in obj:
+            correct_option_id = obj['correct_option_id']
+        poll.id = poll_id
+        poll.options = options
+        poll.total_voter_count = total_voter_count
+        poll.is_closed = is_closed
         poll.is_anonymous = is_anonymous
+        poll.type = poll_type
+        poll.allows_multiple_answers = allows_multiple_answers
+        poll.correct_option_id = correct_option_id
         return poll
 
     def __init__(self, question):


### PR DESCRIPTION
Pretty straight-forward edits, implemented similarly to other handlers. Updated `types.Poll` so it stores all fields passed by Telegram.

Can be used similar to other handlers:
```
@bot.poll_handler(func=lambda call: True)
def handle_vote(poll):
	print poll
```

Didn't update README and didn't write any tests/examples.