### PR TITLE
Possibility to use alternative serializer

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -76,7 +76,10 @@ class Saver:
         os.makedirs(dirs, exist_ok=True)
 
         with open(filename + ".tmp", file_mode) as file:
-            pickle.dump(handlers, file)
+            if (apihelper.CUSTOM_SERIALIZER is None):
+                pickle.dump(handlers, file)
+            else:
+                apihelper.CUSTOM_SERIALIZER.dump(handlers, file)
 
         if os.path.isfile(filename):
             os.remove(filename)
@@ -87,7 +90,10 @@ class Saver:
     def return_load_handlers(filename, del_file_after_loading=True):
         if os.path.isfile(filename) and os.path.getsize(filename) > 0:
             with open(filename, "rb") as file:
-                handlers = pickle.load(file)
+                if (apihelper.CUSTOM_SERIALIZER is None):
+                    handlers = pickle.load(file)
+                else:
+                    handlers = apihelper.CUSTOM_SERIALIZER.load(file)
 
             if del_file_after_loading:
                 os.remove(filename)

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -18,6 +18,7 @@ from telebot import types
 from telebot import util
 
 logger = telebot.logger
+
 proxy = None
 
 API_URL = None
@@ -25,6 +26,8 @@ FILE_URL = None
 
 CONNECT_TIMEOUT = 3.5
 READ_TIMEOUT = 9999
+
+CUSTOM_SERIALIZER = None
 
 ENABLE_MIDDLEWARE = False
 


### PR DESCRIPTION
With apihelper.CUSTOM_SERIALIZER you can replace pickle with other "dumper" like dill.