### PR TITLE
Bug fix with middleware

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -380,7 +380,7 @@ class TeleBot:
 
     def process_middlewares(self, update):
         for update_type, middlewares in self.typed_middleware_handlers.items():
-            if hasattr(update, update_type):
+            if hasattr(update, update_type) and update.__dict__[update_type]:
                 for typed_middleware_handler in middlewares:
                     typed_middleware_handler(self, getattr(update, update_type))
 


### PR DESCRIPTION
Fixes the bug which was causing other update_types involved in middleware.

**For instance, when update_types argument was set only for 'messages' this bug was causing other updates notifying this handler.**

So update_types argument hasn't been necessary for the decorator.