### PR TITLE
Fix not needed invocations on typed middleware handlers

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -380,7 +380,7 @@ class TeleBot:
 
     def process_middlewares(self, update):
         for update_type, middlewares in self.typed_middleware_handlers.items():
-            if hasattr(update, update_type):
+            if getattr(update, update_type) is not None:
                 for typed_middleware_handler in middlewares:
                     typed_middleware_handler(self, getattr(update, update_type))
 


### PR DESCRIPTION
This pull request fixes not needed all the time invocations on typed middleware handlers even if `update` did not have that `update_type` message.

It closes #800