### PR TITLE
Minor keyboard code redisign

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -18,7 +18,7 @@ console_output_handler = logging.StreamHandler(sys.stderr)
 console_output_handler.setFormatter(formatter)
 logger.addHandler(console_output_handler)
 
-logger.setLevel(logging.ERROR)
+logger.setLevel(logging.WARNING)
 
 from telebot import apihelper, types, util
 from telebot.handler_backends import MemoryHandlerBackend, FileHandlerBackend

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import logging
+
 try:
     import ujson as json
 except ImportError:
@@ -9,6 +11,7 @@ import six
 
 from telebot import util
 
+logger = logging.getLogger('TeleBot')
 
 class JsonSerializable(object):
     """
@@ -807,7 +810,8 @@ class ReplyKeyboardRemove(JsonSerializable):
 class ReplyKeyboardMarkup(JsonSerializable):
     def __init__(self, resize_keyboard=None, one_time_keyboard=None, selective=None, row_width=3):
         if row_width>12:
-            raise ValueError('Telegram does not support reply keyboard row width over 12')
+            logger.warning('Telegram does not support reply keyboard row width over 12')
+            row_width=12
 
         self.resize_keyboard = resize_keyboard
         self.one_time_keyboard = one_time_keyboard
@@ -822,15 +826,16 @@ class ReplyKeyboardMarkup(JsonSerializable):
         when row_width is set to 1.
         When row_width is set to 2, the following is the result of this function: {keyboard: [["A", "B"], ["C"]]}
         See https://core.telegram.org/bots/api#replykeyboardmarkup
-        :raises ValueError: If row_width > 12
         :param args: KeyboardButton to append to the keyboard
         :param row_width: width of row
         :return: self, to allow function chaining.
         """
         row_width = row_width or self.row_width
         
+        
         if row_width>12:
-            raise ValueError('Telegram does not support reply keyboard row width over 12')
+            logger.warning('Telegram does not support reply keyboard row width over 12')
+            row_width=12
         
         for row in util.chunks(args, row_width):
             button_array = []
@@ -907,12 +912,12 @@ class InlineKeyboardMarkup(Dictionaryable, JsonSerializable):
         This object represents an inline keyboard that appears
             right next to the message it belongs to.
         
-        :raises ValueError: If row_width > 8
         :return:
         """
         if row_width>8:
-            raise ValueError('Telegram does not support inline keyboard row width over 8')
-
+            logger.warning('Telegram does not support inline keyboard row width over 8')
+            row_width=8
+        
         self.row_width = row_width
         self.keyboard = []
 
@@ -927,7 +932,6 @@ class InlineKeyboardMarkup(Dictionaryable, JsonSerializable):
             {keyboard: [["A", "B"], ["C"]]}
         See https://core.telegram.org/bots/api#inlinekeyboardmarkup
         
-        :raises ValueError: If row_width > 8
         :param args: Array of InlineKeyboardButton to append to the keyboard
         :param row_width: width of row
         :return: self, to allow function chaining.
@@ -935,7 +939,8 @@ class InlineKeyboardMarkup(Dictionaryable, JsonSerializable):
         row_width = row_width or self.row_width
         
         if row_width>8:
-            raise ValueError('Telegram does not support inline keyboard row width over 8')
+            logger.warning('Telegram does not support inline keyboard row width over 8')
+            row_width=8
         
         for row in util.chunks(args, row_width):
             button_array = [button.to_dict() for button in row]
@@ -2299,6 +2304,9 @@ class InputMedia(Dictionaryable, JsonSerializable):
 
 class InputMediaPhoto(InputMedia):
     def __init__(self, media, caption=None, parse_mode=None):
+        if util.is_pil_image(media):
+            media = util.pil_image_to_file(media)
+    
         super(InputMediaPhoto, self).__init__(type="photo", media=media, caption=caption, parse_mode=parse_mode)
 
     def to_dict(self):

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -166,6 +166,12 @@ def async_dec():
 def is_string(var):
     return isinstance(var, string_types)
 
+def is_dict(var):
+    return isinstance(var, dict)
+
+def is_bytes(var):
+    return isinstance(var, bytes)
+
 def is_pil_image(var):
     return pil_imported and isinstance(var, PIL.Image.Image)
 
@@ -278,6 +284,11 @@ def per_thread(key, construct_value, reset=False):
 
     return getattr(thread_local, key)
 
+def chunks(lst, n):
+    """Yield successive n-sized chunks from lst."""
+    # https://stackoverflow.com/a/312464/9935473
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
 
 def generate_random_token():
     return ''.join(random.sample(string.ascii_letters, 16))


### PR DESCRIPTION
- add() method now has a row_width parameter, self.row_width is used if row_width is not specified
- add() and row() methods now support auto row splitting
- add() method now also returns self to allow function chaining
- add() method now throw a ValueError exception if row_width >8 (for inline keyboard) or >12 (for reply keyboard), before this telegram just ignored buttons that didn't fit

Also, type-checking moved to utils to keep code consistent