### PR TITLE
Exceptions classes redesign followup

### DIFF
--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -127,14 +127,15 @@ def _check_result(method_name, result):
     try:
         result_json = result.json()
     except:
-        raise ApiInvalidJSONException(method_name, result)
+        if result.status_code != 200:
+            raise ApiHTTPException(method_name, result)
+        else:
+            raise ApiInvalidJSONException(method_name, result)
+        
     else:    
         if not result_json['ok']:
             raise ApiTelegramException(method_name, result, result_json)
             
-        elif result.status_code != 200:
-            raise ApiHTTPException(method_name, result)
-    
         return result_json
 
 


### PR DESCRIPTION
Changes:
- Now API request can return only one exception per time
- ApiTelegramException now has error_code field, which contains telegram api error code
- API methods now return None if there was error while execution
- Bug fixed