### PR TITLE
Some improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python
 from setuptools import setup
 from io import open
+import re
 
 def read(filename):
     with open(filename, encoding='utf-8') as file:
         return file.read()
 
+with open('telebot/version.py', 'r', encoding='utf-8') as f:  # Credits: LonamiWebs
+    version = re.search(r"^__version__\s*=\s*'(.*)'.*$",
+                        f.read(), flags=re.MULTILINE).group(1)
+
 setup(name='pyTelegramBotAPI',
-      version='3.7.2',
+      version=version,
       description='Python Telegram bot api. ',
       long_description=read('README.md'),
       long_description_content_type="text/markdown",

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -743,8 +743,8 @@ class TeleBot:
             apihelper.send_voice(self.token, chat_id, voice, caption, duration, reply_to_message_id, reply_markup,
                                  parse_mode, disable_notification, timeout))
 
-    def send_document(self, chat_id, data, reply_to_message_id=None, caption=None, reply_markup=None,
-                      parse_mode=None, disable_notification=None, timeout=None):
+    def send_document(self, chat_id, data,reply_to_message_id=None, caption=None, reply_markup=None,
+                      parse_mode=None, disable_notification=None, timeout=None, thumb=None):
         """
         Use this method to send general files.
         :param chat_id:
@@ -755,13 +755,14 @@ class TeleBot:
         :param parse_mode:
         :param disable_notification:
         :param timeout:
+        :param thumb: InputFile or String : Thumbnail of the file sent
         :return: API reply.
         """
         parse_mode = self.parse_mode if not parse_mode else parse_mode
 
-        return types.Message.de_json(
+        return types.Message.de_json( 
             apihelper.send_data(self.token, chat_id, data, 'document', reply_to_message_id, reply_markup,
-                                parse_mode, disable_notification, timeout, caption=caption))
+                                parse_mode, disable_notification, timeout, caption, thumb))
 
     def send_sticker(
             self, chat_id, data, reply_to_message_id=None, reply_markup=None,
@@ -795,7 +796,9 @@ class TeleBot:
         :param reply_markup:
         :param disable_notification:
         :param timeout:
-	    :param thumb:
+	    :param thumb: InputFile or String : Thumbnail of the file sent
+        :param width:
+        :param height:
         :return:
         """
         parse_mode = self.parse_mode if not parse_mode else parse_mode
@@ -804,8 +807,10 @@ class TeleBot:
             apihelper.send_video(self.token, chat_id, data, duration, caption, reply_to_message_id, reply_markup,
                                  parse_mode, supports_streaming, disable_notification, timeout, thumb, width, height))
 
-    def send_animation(self, chat_id, animation, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
-                   parse_mode=None, disable_notification=None, timeout=None):
+    def send_animation(self, chat_id, animation, duration=None,
+                       caption=None, reply_to_message_id=None,
+                       reply_markup=None, parse_mode=None,
+                       disable_notification=None, timeout=None, thumb=None):
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         :param chat_id: Integer : Unique identifier for the message recipient — User or GroupChat id
@@ -817,18 +822,20 @@ class TeleBot:
         :param reply_markup:
         :param disable_notification:
         :param timeout:
+        :param thumb: InputFile or String : Thumbnail of the file sent
         :return:
         """
         parse_mode = self.parse_mode if not parse_mode else parse_mode
 
         return types.Message.de_json(
             apihelper.send_animation(self.token, chat_id, animation, duration, caption, reply_to_message_id, reply_markup,
-                                 parse_mode, disable_notification, timeout))
+                                 parse_mode, disable_notification, timeout, thumb))
 
-    def send_video_note(self, chat_id, data, duration=None, length=None, reply_to_message_id=None, reply_markup=None,
-                        disable_notification=None, timeout=None):
+    def send_video_note(self, chat_id, data, duration=None, length=None,
+                        reply_to_message_id=None, reply_markup=None,
+                        disable_notification=None, timeout=None, thumb=None):
         """
-        Use this method to send video files, Telegram clients support mp4 videos.
+        As of v.4.0, Telegram clients support rounded square mp4 videos of up to 1 minute long. Use this method to send video messages.
         :param chat_id: Integer : Unique identifier for the message recipient — User or GroupChat id
         :param data: InputFile or String : Video note to send. You can either pass a file_id as String to resend a video that is already on the Telegram server
         :param duration: Integer : Duration of sent video in seconds
@@ -837,11 +844,12 @@ class TeleBot:
         :param reply_markup:
         :param disable_notification:
         :param timeout:
+        :param thumb: InputFile or String : Thumbnail of the file sent
         :return:
         """
         return types.Message.de_json(
             apihelper.send_video_note(self.token, chat_id, data, duration, length, reply_to_message_id, reply_markup,
-                                      disable_notification, timeout))
+                                      disable_notification, timeout, thumb))
 
     def send_media_group(
             self, chat_id, media,

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -509,7 +509,7 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_to_messa
 
 
 def send_animation(token, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
-               parse_mode=None, disable_notification=None, timeout=None):
+               parse_mode=None, disable_notification=None, timeout=None, thumb=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}
     files = None
@@ -531,6 +531,8 @@ def send_animation(token, chat_id, data, duration=None, caption=None, reply_to_m
         payload['disable_notification'] = disable_notification
     if timeout:
         payload['connect-timeout'] = timeout
+    if thumb:
+        payload['thumb'] = thumb
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -561,7 +563,7 @@ def send_voice(token, chat_id, voice, caption=None, duration=None, reply_to_mess
 
 
 def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_message_id=None, reply_markup=None,
-                    disable_notification=None, timeout=None):
+                    disable_notification=None, timeout=None, thumb=None):
     method_url = r'sendVideoNote'
     payload = {'chat_id': chat_id}
     files = None
@@ -571,7 +573,7 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_m
         payload['video_note'] = data
     if duration:
         payload['duration'] = duration
-    if length:
+    if length and (str(length).isdigit() and int(length) <= 639):
         payload['length'] = length
     else:
         payload['length'] = 639  # seems like it is MAX length size
@@ -583,6 +585,8 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_m
         payload['disable_notification'] = disable_notification
     if timeout:
         payload['connect-timeout'] = timeout
+    if thumb:
+        payload['thumb'] = thumb
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -622,7 +626,7 @@ def send_audio(token, chat_id, audio, caption=None, duration=None, performer=Non
 
 
 def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_markup=None, parse_mode=None,
-              disable_notification=None, timeout=None, caption=None):
+              disable_notification=None, timeout=None, caption=None, thumb=None):
     method_url = get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None
@@ -642,6 +646,8 @@ def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_m
         payload['connect-timeout'] = timeout
     if caption:
         payload['caption'] = caption
+    if thumb:
+        payload['thumb'] = thumb
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 

--- a/telebot/version.py
+++ b/telebot/version.py
@@ -1,0 +1,3 @@
+# Versions should comply with PEP440.
+# This line is parsed in setup.py:
+__version__ = '3.7.3'

--- a/telebot/version.py
+++ b/telebot/version.py
@@ -1,3 +1,3 @@
 # Versions should comply with PEP440.
 # This line is parsed in setup.py:
-__version__ = '3.7.3'
+__version__ = '3.7.2'


### PR DESCRIPTION
- Added missing thumb parameters to `send_document`, `send_animation` and `send_video_note`
- Implemented getting the runtime version of pyTelegramBotAPI
- Fixed docstring for `send_video_note` function

closes #948 
closes #951 