### PR TITLE
Fix an error with the is_pil_image function

### DIFF
--- a/telebot/util.py
+++ b/telebot/util.py
@@ -11,7 +11,7 @@ import queue as Queue
 import logging
 
 try:
-    import PIL
+    from PIL import Image
     from io import BytesIO
     pil_imported = True
 except:
@@ -164,7 +164,7 @@ def is_bytes(var):
     return isinstance(var, bytes)
 
 def is_pil_image(var):
-    return pil_imported and isinstance(var, PIL.Image.Image)
+    return pil_imported and isinstance(var, Image.Image)
 
 def pil_image_to_file(image, extension='JPEG', quality='web_low'):
     if pil_imported:


### PR DESCRIPTION
When I've tried to send_photo as shown in detailed_example, I got an error: "AttributeError: module 'PIL' has no attribute 'Image'". 
This error was described well here: https://stackoverflow.com/a/11911536/9092263. So in accordance to prescriptions, I've made changes and It works fine for me.

Steps to reproduce:
1. initiate bot via TeleBot constructor
2. call function `bot.send_photo(call.message.chat.id, open("some_image.jpg", "rb"))`

P.S.
Error Environment: 
- python==3.8.5
- pyTelegramBotAPI==3.7.3
- PIL==7.2.0