### PR TITLE
Support add list of InlineKeyboardMarkup

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -943,8 +943,17 @@ class InlineKeyboardMarkup(Dictionaryable, JsonSerializable):
             row_width=8
         
         for row in util.chunks(args, row_width):
-            button_array = [button.to_dict() for button in row]
-            self.keyboard.append(button_array)
+            for button in row:
+                if isinstance(button, list):
+                    button_array = []
+                    for _button in button:
+                        button_array.extend([_button.to_dict()])
+                    self.keyboard.append(button_array)
+                else:
+                    button_array = [button.to_dict()]
+                    self.keyboard.append(button_array)
+        
+        return self
         
         return self
         


### PR DESCRIPTION
Useful for saving buttons to a list (for example, in a loop) and later saving to the keyboard.

```
keyboard = InlineKeyboardMarkup()
keyboard.row_width = 2

button_names = ['button_1', 'button_2', 'button_3']
buttons = []

for button_name in button_names:
    buttons.append(InlineKeyboardButton(button_name, calback_data=f'go_to/{button_name}'))

keyboard.add(buttons)
```