### PR TITLE
docs: fix simple typo, perfomance -> performance

### DIFF
--- a/examples/webhook_examples/README.md
+++ b/examples/webhook_examples/README.md
@@ -37,7 +37,7 @@ There are 5 examples in this directory using different libraries:
   * **Pros:**
     * It's a web application framework
     * Python 3 compatible
-    * Asynchronous, excellent perfomance
+    * Asynchronous, excellent performance
     * Utilizes new async/await syntax
   * **Cons:**
     * Requires Python 3.4.2+, don't work with Python 2


### PR DESCRIPTION
There is a small typo in examples/webhook_examples/README.md.

Should read `performance` rather than `perfomance`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md