### PR TITLE
hide token from debug logs

### DIFF
--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -73,7 +73,7 @@ def _make_request(token, method_name, method='get', params=None, files=None):
     else:
         request_url = "https://api.telegram.org/bot{0}/{1}".format(token, method_name)
 
-    logger.debug("Request: method={0} url={1} params={2} files={3}".format(method, request_url, params, files))
+    logger.debug("Request: method={0} url={1} params={2} files={3}".format(method, request_url, params, files).replace(token, "{TOKEN}"))
     read_timeout = READ_TIMEOUT
     connect_timeout = CONNECT_TIMEOUT
     if files and format_header_param:

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -73,7 +73,7 @@ def _make_request(token, method_name, method='get', params=None, files=None):
     else:
         request_url = "https://api.telegram.org/bot{0}/{1}".format(token, method_name)
 
-    logger.debug("Request: method={0} url={1} params={2} files={3}".format(method, request_url, params, files).replace(token, "{TOKEN}"))
+    logger.debug("Request: method={0} url={1} params={2} files={3}".format(method, request_url, params, files).replace(token, token.split(':')[0] + ":{TOKEN}"))
     read_timeout = READ_TIMEOUT
     connect_timeout = CONNECT_TIMEOUT
     if files and format_header_param:


### PR DESCRIPTION
Prevent leaks of the bot token by hiding it from the log, learned it the hard way during https://github.com/eternnoir/pyTelegramBotAPI/issues/1058. 

