### PR TITLE
Fix traceback exeptions

### DIFF
--- a/telebot/util.py
+++ b/telebot/util.py
@@ -72,7 +72,8 @@ class WorkerThread(threading.Thread):
             except Queue.Empty:
                 pass
             except Exception as e:
-                logger.debug(type(e).__name__ + " occurred, args=" + str(e.args) + "\n" + traceback.format_exc())
+                logger.error(f"{type(e).__name__} occurred, args={e.args}\n"
+                             f"{traceback.format_exc()}")
                 self.exception_info = e
                 self.exception_event.set()
                 if self.exception_callback:


### PR DESCRIPTION
logger.debug is only for debugging telebot, but we need to fix bugs in our bots, so this will help