### PR TITLE
middleware handlers exception handling

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -350,12 +350,12 @@ class TeleBot:
                     logger.error(str(e))
                     if not self.suppress_middleware_excepions:
                         raise
-                    update.middleware_error = e # for future handling if it needed
+                    else:
+                        if update.update_id > self.last_update_id: self.last_update_id = update.update_id
+                        continue
                     
             if update.update_id > self.last_update_id:
                 self.last_update_id = update.update_id
-            if hasattr(update, 'middleware_error'):
-                continue
             if update.message:
                 if new_messages is None: new_messages = []
                 new_messages.append(update.message)

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -456,7 +456,7 @@ class TeleBot:
                     try:
                         typed_middleware_handler(self, getattr(update, update_type))
                     except Exception as e:
-                        e.args = (f'Typed middleware handler "{typed_middleware_handler.__qualname__}" raised exception: {str(e)}',)
+                        e.args = e.args + (f'Typed middleware handler "{typed_middleware_handler.__qualname__}"',)
                         raise
 
         if len(self.default_middleware_handlers) > 0:
@@ -464,7 +464,7 @@ class TeleBot:
                 try:
                     default_middleware_handler(self, update)
                 except Exception as e:
-                    e.args = (f'Default middleware handler "{typed_middleware_handler.__qualname__}" raised exception: {str(e)}',)
+                    e.args = e.args + (f'Default middleware handler "{default_middleware_handler.__qualname__}"',)
                     raise
 
     def __notify_update(self, new_messages):

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -95,7 +95,8 @@ class TeleBot:
 
     def __init__(
             self, token, parse_mode=None, threaded=True, skip_pending=False, num_threads=2,
-            next_step_backend=None, reply_backend=None, exception_handler=None, last_update_id=0
+            next_step_backend=None, reply_backend=None, exception_handler=None, last_update_id=0,
+            suppress_middleware_excepions=False
     ):
         """
         :param token: bot API token
@@ -107,6 +108,7 @@ class TeleBot:
         self.parse_mode = parse_mode
         self.update_listener = []
         self.skip_pending = skip_pending
+        self.suppress_middleware_excepions = suppress_middleware_excepions
 
         self.__stop_polling = threading.Event()
         self.last_update_id = last_update_id
@@ -346,6 +348,8 @@ class TeleBot:
                     self.process_middlewares(update)
                 except Exception as e:
                     logger.error(str(e))
+                    if not self.suppress_middleware_excepions:
+                        raise
                     update.middleware_error = e # for future handling if it needed
                     
             if update.update_id > self.last_update_id:


### PR DESCRIPTION
For now any exceptions in a middleware handlers are fatal.

This fix will keep TeleBot alive if anything goes wrong. 
Update which caused exception will be skipped.