### PR TITLE
Get attribute worker_pool of self or value False

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -740,7 +740,7 @@ class TeleBot:
 
     def stop_bot(self):
         self.stop_polling()
-        if self.worker_pool:
+        if getattr(self, 'worker_pool', False):
             self.worker_pool.close()
 
     def set_update_listener(self, listener):


### PR DESCRIPTION
When #1224 happens the attribute `worker_pool` never is defined, then not can be read in https://github.com/eternnoir/pyTelegramBotAPI/blob/db2accc2f84feb594a2f743e8a13cfe6fc16da41/telebot/__init__.py#L743.