### PR TITLE
🐛 Bugfix: Add return statement to to_dict() method inside InputInvoiceMessageContent type

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1569,7 +1569,7 @@ class InputInvoiceMessageContent(Dictionaryable):
             json_dict['send_email_to_provider'] = self.send_email_to_provider 
         if self.is_flexible is not None:
             json_dict['is_flexible'] = self.is_flexible 
-        
+        return json_dict
 
 class ChosenInlineResult(JsonDeserializable):
     @classmethod

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1571,6 +1571,7 @@ class InputInvoiceMessageContent(Dictionaryable):
             json_dict['is_flexible'] = self.is_flexible 
         return json_dict
 
+
 class ChosenInlineResult(JsonDeserializable):
     @classmethod
     def de_json(cls, json_string):


### PR DESCRIPTION
This is a fix for 
```
A request to the Telegram API was unsuccessful. Error code: 400. Description: Bad Request: can't parse inline query result: Field "input_message_content" must be of type Object
```
error. It happens when you try to send `InputInvoiceMessageContent` as a part of `InlineQueryResultArticle` query with 
```
bot.answer_inline_query()
```