### PR TITLE
skip_updates

### DIFF
--- a/examples/skip_updates_example.py
+++ b/examples/skip_updates_example.py
@@ -1,0 +1,15 @@
+import telebot
+
+bot = telebot.TeleBot("TOKEN")
+
+@bot.message_handler(commands=['start', 'help'])
+def send_welcome(message):
+	bot.reply_to(message, "Howdy, how are you doing?")
+
+@bot.message_handler(func=lambda message: True)
+def echo_all(message):
+	bot.reply_to(message, message.text)
+
+bot.polling(skip_updates=True) # Will skip old messages when skip_updates is set
+
+# Also, you can use skip_updates in infinity_polling()

--- a/examples/skip_updates_example.py
+++ b/examples/skip_updates_example.py
@@ -1,6 +1,6 @@
 import telebot
 
-bot = telebot.TeleBot("TOKEN",skip_pending=True)# Skip pending skips old updates
+bot = telebot.TeleBot("TOKEN")
 
 @bot.message_handler(commands=['start', 'help'])
 def send_welcome(message):
@@ -10,4 +10,4 @@ def send_welcome(message):
 def echo_all(message):
 	bot.reply_to(message, message.text)
 
-bot.polling()
+bot.polling(skip_pending=True)# Skip pending skips old updates

--- a/examples/skip_updates_example.py
+++ b/examples/skip_updates_example.py
@@ -1,6 +1,6 @@
 import telebot
 
-bot = telebot.TeleBot("TOKEN")
+bot = telebot.TeleBot("TOKEN",skip_pending=True)# Skip pending skips old updates
 
 @bot.message_handler(commands=['start', 'help'])
 def send_welcome(message):
@@ -10,6 +10,4 @@ def send_welcome(message):
 def echo_all(message):
 	bot.reply_to(message, message.text)
 
-bot.polling(skip_updates=True) # Will skip old messages when skip_updates is set
-
-# Also, you can use skip_updates in infinity_polling()
+bot.polling()

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -556,7 +556,7 @@ class TeleBot:
         for listener in self.update_listener:
             self._exec_task(listener, new_messages)
 
-    def infinity_polling(self, timeout=20, long_polling_timeout=20, logger_level=logging.ERROR,
+    def infinity_polling(self, timeout=20, skip_updates=False, long_polling_timeout=20, logger_level=logging.ERROR,
             allowed_updates=None, *args, **kwargs):
         """
         Wrap polling with infinite loop and exception handling to avoid bot stops polling.
@@ -565,6 +565,7 @@ class TeleBot:
         :param long_polling_timeout: Timeout in seconds for long polling (see API docs)
         :param logger_level: Custom logging level for infinity_polling logging.
             Use logger levels from logging as a value. None/NOTSET = no error logging
+        :param skip_updates: Skip previous updates
         :param allowed_updates: A list of the update types you want your bot to receive.
             For example, specify [“message”, “edited_channel_post”, “callback_query”] to only receive updates of these types. 
             See util.update_types for a complete list of available update types. 
@@ -574,6 +575,8 @@ class TeleBot:
             Please note that this parameter doesn't affect updates created before the call to the get_updates, 
             so unwanted updates may be received for a short period of time.
         """
+        if skip_updates:
+            apihelper.get_updates(self.token, -1)
         while not self.__stop_polling.is_set():
             try:
                 self.polling(none_stop=True, timeout=timeout, long_polling_timeout=long_polling_timeout,
@@ -590,7 +593,7 @@ class TeleBot:
         if logger_level and logger_level >= logging.INFO:
             logger.error("Break infinity polling")
 
-    def polling(self, none_stop: bool=False, interval: int=0, timeout: int=20, 
+    def polling(self, none_stop: bool=False, skip_updates=False, interval: int=0, timeout: int=20, 
             long_polling_timeout: int=20, allowed_updates: Optional[List[str]]=None):
         """
         This function creates a new Thread that calls an internal __retrieve_updates function.
@@ -601,6 +604,7 @@ class TeleBot:
         Always get updates.
         :param interval: Delay between two update retrivals
         :param none_stop: Do not stop polling when an ApiException occurs.
+        :param skip_updates: Skip previous updates
         :param timeout: Request connection timeout
         :param long_polling_timeout: Timeout in seconds for long polling (see API docs)
         :param allowed_updates: A list of the update types you want your bot to receive.
@@ -613,6 +617,8 @@ class TeleBot:
             so unwanted updates may be received for a short period of time.
         :return:
         """
+        if skip_updates:
+            apihelper.get_updates(self.token, -1)
         if self.threaded:
             self.__threaded_polling(none_stop, interval, timeout, long_polling_timeout, allowed_updates)
         else:

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -2110,6 +2110,7 @@ class TeleBot:
             message_id: Optional[int]=None, 
             inline_message_id: Optional[str]=None,
             parse_mode: Optional[str]=None, 
+            caption_entities: Optional[List[types.MessageEntity]]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None) -> Union[types.Message, bool]:
         """
         Use this method to edit captions of messages
@@ -2124,7 +2125,7 @@ class TeleBot:
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
 
         result = apihelper.edit_message_caption(self.token, caption, chat_id, message_id, inline_message_id,
-                                                parse_mode, reply_markup)
+                                                parse_mode, caption_entities, reply_markup)
         if type(result) == bool:
             return result
         return types.Message.de_json(result)


### PR DESCRIPTION
Added skip_updates
It skip old updates except last one.
Added only to polling and infinity polling. Added example too.
As telegram api says in getUpdates method:
The negative offset can be specified to retrieve updates starting from -offset update from the end of the updates queue. All previous updates will forgotten.
I passed negative 1 as offset
Results are shown in images
Before skip updates
<img width="1155" alt="Screen Shot 2021-08-15 at 11 45 19" src="https://user-images.githubusercontent.com/63740404/129471050-edcbe2d9-db2e-4366-b260-2e0447da8f3d.png">
After 
<img width="1110" alt="Screen Shot 2021-08-15 at 11 45 53" src="https://user-images.githubusercontent.com/63740404/129471070-371fd9dc-61b9-439e-b046-0c9940687a67.png">
As I understood, by passing negative offset will clear all updates except the latest one.
