### PR TITLE
Filter clearance

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -2521,6 +2521,14 @@ class TeleBot:
         if content_types is None:
             content_types = ["text"]
 
+        if isinstance(commands, str):
+            logger.warning("message_handler: 'commands' filter should be List of strings (commands), not string.")
+            commands = [commands]
+
+        if isinstance(content_types, str):
+            logger.warning("message_handler: 'content_types' filter should be List of strings (content types), not string.")
+            content_types = [content_types]
+
         def decorator(handler):
             handler_dict = self._build_handler_dict(handler,
                                                     chat_types=chat_types,
@@ -2553,6 +2561,14 @@ class TeleBot:
         :param chat_types: True for private chat
         :return: decorated function
         """
+        if isinstance(commands, str):
+            logger.warning("register_message_handler: 'commands' filter should be List of strings (commands), not string.")
+            commands = [commands]
+
+        if isinstance(content_types, str):
+            logger.warning("register_message_handler: 'content_types' filter should be List of strings (content types), not string.")
+            content_types = [content_types]
+
         handler_dict = self._build_handler_dict(callback,
                                                 chat_types=chat_types,
                                                 content_types=content_types,
@@ -2576,6 +2592,14 @@ class TeleBot:
 
         if content_types is None:
             content_types = ["text"]
+
+        if isinstance(commands, str):
+            logger.warning("edited_message_handler: 'commands' filter should be List of strings (commands), not string.")
+            commands = [commands]
+
+        if isinstance(content_types, str):
+            logger.warning("edited_message_handler: 'content_types' filter should be List of strings (content types), not string.")
+            content_types = [content_types]
 
         def decorator(handler):
             handler_dict = self._build_handler_dict(handler,
@@ -2609,6 +2633,14 @@ class TeleBot:
         :param chat_types: True for private chat
         :return: decorated function
         """
+        if isinstance(commands, str):
+            logger.warning("register_edited_message_handler: 'commands' filter should be List of strings (commands), not string.")
+            commands = [commands]
+
+        if isinstance(content_types, str):
+            logger.warning("register_edited_message_handler: 'content_types' filter should be List of strings (content types), not string.")
+            content_types = [content_types]
+
         handler_dict = self._build_handler_dict(callback,
                                                 chat_types=chat_types,
                                                 content_types=content_types,
@@ -2628,9 +2660,16 @@ class TeleBot:
         :param kwargs:
         :return:
         """
-
         if content_types is None:
             content_types = ["text"]
+
+        if isinstance(commands, str):
+            logger.warning("channel_post_handler: 'commands' filter should be List of strings (commands), not string.")
+            commands = [commands]
+
+        if isinstance(content_types, str):
+            logger.warning("channel_post_handler: 'content_types' filter should be List of strings (content types), not string.")
+            content_types = [content_types]
 
         def decorator(handler):
             handler_dict = self._build_handler_dict(handler,
@@ -2662,6 +2701,14 @@ class TeleBot:
         :param func:
         :return: decorated function
         """
+        if isinstance(commands, str):
+            logger.warning("register_channel_post_handler: 'commands' filter should be List of strings (commands), not string.")
+            commands = [commands]
+
+        if isinstance(content_types, str):
+            logger.warning("register_channel_post_handler: 'content_types' filter should be List of strings (content types), not string.")
+            content_types = [content_types]
+
         handler_dict = self._build_handler_dict(callback,
                                                 content_types=content_types,
                                                 commands=commands,
@@ -2680,9 +2727,16 @@ class TeleBot:
         :param kwargs:
         :return:
         """
-
         if content_types is None:
             content_types = ["text"]
+
+        if isinstance(commands, str):
+            logger.warning("edited_channel_post_handler: 'commands' filter should be List of strings (commands), not string.")
+            commands = [commands]
+
+        if isinstance(content_types, str):
+            logger.warning("edited_channel_post_handler: 'content_types' filter should be List of strings (content types), not string.")
+            content_types = [content_types]
 
         def decorator(handler):
             handler_dict = self._build_handler_dict(handler,
@@ -2714,6 +2768,14 @@ class TeleBot:
         :param func:
         :return: decorated function
         """
+        if isinstance(commands, str):
+            logger.warning("register_edited_channel_post_handler: 'commands' filter should be List of strings (commands), not string.")
+            commands = [commands]
+
+        if isinstance(content_types, str):
+            logger.warning("register_edited_channel_post_handler: 'content_types' filter should be List of strings (content types), not string.")
+            content_types = [content_types]
+
         handler_dict = self._build_handler_dict(callback,
                                                 content_types=content_types,
                                                 commands=commands,

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -2425,7 +2425,9 @@ class TeleBot:
         """
         return {
             'function': handler,
-            'filters': filters
+            'filters': {ftype: fvalue for ftype, fvalue in filters.items() if fvalue is not None}
+            # Remove None values, they are skipped in _test_filter anyway
+            #'filters': filters
         }
 
     def middleware_handler(self, update_types=None):
@@ -2521,10 +2523,10 @@ class TeleBot:
 
         def decorator(handler):
             handler_dict = self._build_handler_dict(handler,
+                                                    chat_types=chat_types,
                                                     content_types=content_types,
                                                     commands=commands,
                                                     regexp=regexp,
-                                                    chat_types=chat_types,
                                                     func=func,
                                                     **kwargs)
             self.add_message_handler(handler_dict)
@@ -2552,13 +2554,14 @@ class TeleBot:
         :return: decorated function
         """
         handler_dict = self._build_handler_dict(callback,
+                                                chat_types=chat_types,
                                                 content_types=content_types,
                                                 commands=commands,
                                                 regexp=regexp,
                                                 func=func,
-                                                chat_types=chat_types,
                                                 **kwargs)
         self.add_message_handler(handler_dict)
+
     def edited_message_handler(self, commands=None, regexp=None, func=None, content_types=None, chat_types=None, **kwargs):
         """
         Edit message handler decorator
@@ -2576,11 +2579,11 @@ class TeleBot:
 
         def decorator(handler):
             handler_dict = self._build_handler_dict(handler,
+                                                    chat_types=chat_types,
+                                                    content_types=content_types,
                                                     commands=commands,
                                                     regexp=regexp,
                                                     func=func,
-                                                    content_types=content_types,
-                                                    chat_types=chat_types,
                                                     **kwargs)
             self.add_edited_message_handler(handler_dict)
             return handler
@@ -2607,13 +2610,14 @@ class TeleBot:
         :return: decorated function
         """
         handler_dict = self._build_handler_dict(callback,
+                                                chat_types=chat_types,
                                                 content_types=content_types,
                                                 commands=commands,
                                                 regexp=regexp,
                                                 func=func,
-                                                chat_types=chat_types,
                                                 **kwargs)
         self.add_edited_message_handler(handler_dict)
+
     def channel_post_handler(self, commands=None, regexp=None, func=None, content_types=None, **kwargs):
         """
         Channel post handler decorator
@@ -2630,10 +2634,10 @@ class TeleBot:
 
         def decorator(handler):
             handler_dict = self._build_handler_dict(handler,
+                                                    content_types=content_types,
                                                     commands=commands,
                                                     regexp=regexp,
                                                     func=func,
-                                                    content_types=content_types,
                                                     **kwargs)
             self.add_channel_post_handler(handler_dict)
             return handler
@@ -2665,6 +2669,7 @@ class TeleBot:
                                                 func=func,
                                                 **kwargs)
         self.add_channel_post_handler(handler_dict)
+
     def edited_channel_post_handler(self, commands=None, regexp=None, func=None, content_types=None, **kwargs):
         """
         Edit channel post handler decorator
@@ -2681,10 +2686,10 @@ class TeleBot:
 
         def decorator(handler):
             handler_dict = self._build_handler_dict(handler,
+                                                    content_types=content_types,
                                                     commands=commands,
                                                     regexp=regexp,
                                                     func=func,
-                                                    content_types=content_types,
                                                     **kwargs)
             self.add_edited_channel_post_handler(handler_dict)
             return handler
@@ -2782,7 +2787,6 @@ class TeleBot:
         """
         handler_dict = self._build_handler_dict(callback, func=func, **kwargs)
         self.add_chosen_inline_handler(handler_dict)
-
 
     def callback_query_handler(self, func, **kwargs):
         """
@@ -2913,9 +2917,7 @@ class TeleBot:
         :param func:
         :return: decorated function
         """
-        handler_dict = self._build_handler_dict(callback,
-                                                    func=func,
-                                                    **kwargs)
+        handler_dict = self._build_handler_dict(callback, func=func, **kwargs)
         self.add_poll_handler(handler_dict)
 
     def poll_answer_handler(self, func=None, **kwargs):
@@ -2948,9 +2950,7 @@ class TeleBot:
         :param func:
         :return: decorated function
         """
-        handler_dict = self._build_handler_dict(callback,
-                                                    func=func,
-                                                    **kwargs)
+        handler_dict = self._build_handler_dict(callback, func=func, **kwargs)
         self.add_poll_answer_handler(handler_dict)
 
     def my_chat_member_handler(self, func=None, **kwargs):
@@ -2983,9 +2983,7 @@ class TeleBot:
         :param func:
         :return: decorated function
         """
-        handler_dict = self._build_handler_dict(callback,
-                                                    func=func,
-                                                    **kwargs)
+        handler_dict = self._build_handler_dict(callback, func=func, **kwargs)
         self.add_my_chat_member_handler(handler_dict)
 
     def chat_member_handler(self, func=None, **kwargs):

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -33,7 +33,7 @@ READ_TIMEOUT = 30
 
 LONG_POLLING_TIMEOUT = 10 # Should be positive, short polling should be used for testing purposes only (https://core.telegram.org/bots/api#getupdates)
 
-SESSION_TIME_TO_LIVE = None  # In seconds. None - live forever, 0 - one-time
+SESSION_TIME_TO_LIVE = 600  # In seconds. None - live forever, 0 - one-time
 
 RETRY_ON_ERROR = False
 RETRY_TIMEOUT = 2


### PR DESCRIPTION
1. Filter optimization: should not store empty filters
2. Filter order: chat_type, content, others
3. Default requests session lifetime set to 600 instead of "forever".
4. Typo fix