### PR TITLE
Added description of the ApiTelegramException as attribute of the class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ var/
 
 .idea/
 venv/
+.venv/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1661,4 +1661,5 @@ class ApiTelegramException(ApiException):
             result)
         self.result_json = result_json
         self.error_code = result_json['error_code']
+        self.description = result_json['description']
         


### PR DESCRIPTION
The class ApiTelegramException now has the attribute "description", returned in the response_json. In this way, the error's description is more accessible.