### PR TITLE
Bot API 5.5

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1668,8 +1668,7 @@ class TeleBot:
         return apihelper.set_chat_administrator_custom_title(self.token, chat_id, user_id, custom_title)
 
     
-    def ban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str],
-        until_date:Optional[Union[int, datetime]]=None) -> bool:
+    def ban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str]) -> bool:
         """
         Use this method to ban a channel chat in a supergroup or a channel.
         The owner of the chat will not be able to send messages and join live 
@@ -1685,7 +1684,7 @@ class TeleBot:
         or less than 30 seconds from the current time they are considered to be banned forever.
         :return: True on success.
         """
-        return apihelper.ban_chat_sender_chat(self.token, chat_id, sender_chat_id, until_date)
+        return apihelper.ban_chat_sender_chat(self.token, chat_id, sender_chat_id)
 
     def unban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str]) -> bool:
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1680,8 +1680,6 @@ class TeleBot:
         :params:
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :param sender_chat_id: Unique identifier of the target sender chat
-        :param until_date: Date when the sender chat will be unbanned, unix time. If the chat is banned for more than 366 days
-        or less than 30 seconds from the current time they are considered to be banned forever.
         :return: True on success.
         """
         return apihelper.ban_chat_sender_chat(self.token, chat_id, sender_chat_id)

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -75,59 +75,74 @@ class TeleBot:
         logOut
         close
         sendMessage
-        Formatting options
         forwardMessage
         copyMessage
+        deleteMessage
         sendPhoto
         sendAudio
         sendDocument
+        sendSticker
         sendVideo
+        sendVenue
         sendAnimation
-        sendVoice
         sendVideoNote
-        sendMediaGroup
         sendLocation
+        sendChatAction
+        sendDice
+        sendContact
+        sendInvoice
+        sendMediaGroup
+        getUserProfilePhotos
+        getUpdates
+        getFile
+        sendPoll
+        stopPoll
+        sendGame
+        setGameScore
+        getGameHighScores
+        editMessageText
+        editMessageCaption
+        editMessageMedia
+        editMessageReplyMarkup
         editMessageLiveLocation
         stopMessageLiveLocation
-        sendVenue
-        sendContact
-        sendPoll
-        sendDice
-        sendChatAction
-        getUserProfilePhotos
-        getFile
         banChatMember
         unbanChatMember
         restrictChatMember
         promoteChatMember
         setChatAdministratorCustomTitle
-        banChatSenderChat
-        unbanChatSenderChat
         setChatPermissions
-        exportChatInviteLink
         createChatInviteLink
         editChatInviteLink
         revokeChatInviteLink
-        approveChatJoinRequest
-        declineChatJoinRequest
+        exportChatInviteLink
+        setChatStickerSet
+        deleteChatStickerSet
+        createNewStickerSet
+        addStickerToSet
+        deleteStickerFromSet
+        setStickerPositionInSet
+        uploadStickerFile
+        setStickerSetThumb
+        getStickerSet
         setChatPhoto
         deleteChatPhoto
         setChatTitle
         setChatDescription
         pinChatMessage
         unpinChatMessage
-        unpinAllChatMessages
         leaveChat
         getChat
         getChatAdministrators
         getChatMemberCount
         getChatMember
-        setChatStickerSet
-        deleteChatStickerSet
         answerCallbackQuery
+        getMyCommands
         setMyCommands
         deleteMyCommands
-        getMyCommands
+        answerInlineQuery
+        answerShippingQuery
+        answerPreCheckoutQuery
         """
 
     def __init__(

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1667,6 +1667,41 @@ class TeleBot:
         """
         return apihelper.set_chat_administrator_custom_title(self.token, chat_id, user_id, custom_title)
 
+    
+    def ban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str],
+        until_date:Optional[Union[int, datetime]]=None) -> bool:
+        """
+        Use this method to ban a channel chat in a supergroup or a channel.
+        The owner of the chat will not be able to send messages and join live 
+        streams on behalf of the chat, unless it is unbanned first. 
+        The bot must be an administrator in the supergroup or channel 
+        for this to work and must have the appropriate administrator rights. 
+        Returns True on success.
+
+        :params:
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :param sender_chat_id: Unique identifier of the target sender chat
+        :param until_date: Date when the sender chat will be unbanned, unix time. If the chat is banned for more than 366 days
+        or less than 30 seconds from the current time they are considered to be banned forever.
+        :return: True on success.
+        """
+        return apihelper.ban_chat_sender_chat(self.token, chat_id, sender_chat_id, until_date)
+
+    def unban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str]) -> bool:
+        """
+        Use this method to unban a previously banned channel chat in a supergroup or channel. 
+        The bot must be an administrator for this to work and must have the appropriate 
+        administrator rights.
+        Returns True on success.
+
+        :params:
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :param sender_chat_id: Unique identifier of the target sender chat
+        :return: True on success.
+        """
+        return apihelper.unban_chat_sender_chat(self.token, chat_id, sender_chat_id)
+
+
     def set_chat_permissions(
             self, chat_id: Union[int, str], permissions: types.ChatPermissions) -> bool:
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -75,74 +75,59 @@ class TeleBot:
         logOut
         close
         sendMessage
+        Formatting options
         forwardMessage
         copyMessage
-        deleteMessage
         sendPhoto
         sendAudio
         sendDocument
-        sendSticker
         sendVideo
-        sendVenue
         sendAnimation
+        sendVoice
         sendVideoNote
-        sendLocation
-        sendChatAction
-        sendDice
-        sendContact
-        sendInvoice
         sendMediaGroup
-        getUserProfilePhotos
-        getUpdates
-        getFile
-        sendPoll
-        stopPoll
-        sendGame
-        setGameScore
-        getGameHighScores
-        editMessageText
-        editMessageCaption
-        editMessageMedia
-        editMessageReplyMarkup
+        sendLocation
         editMessageLiveLocation
         stopMessageLiveLocation
+        sendVenue
+        sendContact
+        sendPoll
+        sendDice
+        sendChatAction
+        getUserProfilePhotos
+        getFile
         banChatMember
         unbanChatMember
         restrictChatMember
         promoteChatMember
         setChatAdministratorCustomTitle
+        banChatSenderChat
+        unbanChatSenderChat
         setChatPermissions
+        exportChatInviteLink
         createChatInviteLink
         editChatInviteLink
         revokeChatInviteLink
-        exportChatInviteLink
-        setChatStickerSet
-        deleteChatStickerSet
-        createNewStickerSet
-        addStickerToSet
-        deleteStickerFromSet
-        setStickerPositionInSet
-        uploadStickerFile
-        setStickerSetThumb
-        getStickerSet
+        approveChatJoinRequest
+        declineChatJoinRequest
         setChatPhoto
         deleteChatPhoto
         setChatTitle
         setChatDescription
         pinChatMessage
         unpinChatMessage
+        unpinAllChatMessages
         leaveChat
         getChat
         getChatAdministrators
         getChatMemberCount
         getChatMember
+        setChatStickerSet
+        deleteChatStickerSet
         answerCallbackQuery
-        getMyCommands
         setMyCommands
         deleteMyCommands
-        answerInlineQuery
-        answerShippingQuery
-        answerPreCheckoutQuery
+        getMyCommands
         """
 
     def __init__(

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -969,11 +969,9 @@ def set_chat_administrator_custom_title(token, chat_id, user_id, custom_title):
     return _make_request(token, method_url, params=payload, method='post')
 
 
-def ban_chat_sender_chat(token, chat_id, sender_chat_id, until_date=None):
+def ban_chat_sender_chat(token, chat_id, sender_chat_id):
     method_url = 'banChatSenderChat'
     payload = {'chat_id': chat_id, 'sender_chat_id': sender_chat_id}
-    if until_date:
-        payload['until_date'] = until_date
     return _make_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -969,6 +969,20 @@ def set_chat_administrator_custom_title(token, chat_id, user_id, custom_title):
     return _make_request(token, method_url, params=payload, method='post')
 
 
+def ban_chat_sender_chat(token, chat_id, sender_chat_id, until_date=None):
+    method_url = 'banChatSenderChat'
+    payload = {'chat_id': chat_id, 'sender_chat_id': sender_chat_id}
+    if until_date:
+        payload['until_date'] = until_date
+    return _make_request(token, method_url, params=payload, method='post')
+
+
+def unban_chat_sender_chat(token, chat_id, sender_chat_id):
+    method_url = 'unbanChatSenderChat'
+    payload = {'chat_id': chat_id, 'sender_chat_id': sender_chat_id}
+    return _make_request(token, method_url, params=payload, method='post')
+
+
 def set_chat_permissions(token, chat_id, permissions):
     method_url = 'setChatPermissions'
     payload = {

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -94,7 +94,66 @@ class CancelUpdate:
         pass
 
 class AsyncTeleBot:
-    
+    """ This is AsyncTeleBot Class
+    Methods:
+        getMe
+        logOut
+        close
+        sendMessage
+        Formatting options
+        forwardMessage
+        copyMessage
+        sendPhoto
+        sendAudio
+        sendDocument
+        sendVideo
+        sendAnimation
+        sendVoice
+        sendVideoNote
+        sendMediaGroup
+        sendLocation
+        editMessageLiveLocation
+        stopMessageLiveLocation
+        sendVenue
+        sendContact
+        sendPoll
+        sendDice
+        sendChatAction
+        getUserProfilePhotos
+        getFile
+        banChatMember
+        unbanChatMember
+        restrictChatMember
+        promoteChatMember
+        setChatAdministratorCustomTitle
+        banChatSenderChat
+        unbanChatSenderChat
+        setChatPermissions
+        exportChatInviteLink
+        createChatInviteLink
+        editChatInviteLink
+        revokeChatInviteLink
+        approveChatJoinRequest
+        declineChatJoinRequest
+        setChatPhoto
+        deleteChatPhoto
+        setChatTitle
+        setChatDescription
+        pinChatMessage
+        unpinChatMessage
+        unpinAllChatMessages
+        leaveChat
+        getChat
+        getChatAdministrators
+        getChatMemberCount
+        getChatMember
+        setChatStickerSet
+        deleteChatStickerSet
+        answerCallbackQuery
+        setMyCommands
+        deleteMyCommands
+        getMyCommands
+        """
 
     def __init__(self, token: str, parse_mode: Optional[str]=None, offset=None,
                 exception_handler=None) -> None: # TODO: ADD TYPEHINTS

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -2135,6 +2135,40 @@ class AsyncTeleBot:
         """
         return await asyncio_helper.set_chat_administrator_custom_title(self.token, chat_id, user_id, custom_title)
 
+
+    async def ban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str],
+        until_date:Optional[Union[int, datetime]]=None) -> bool:
+        """
+        Use this method to ban a channel chat in a supergroup or a channel.
+        The owner of the chat will not be able to send messages and join live 
+        streams on behalf of the chat, unless it is unbanned first. 
+        The bot must be an administrator in the supergroup or channel 
+        for this to work and must have the appropriate administrator rights. 
+        Returns True on success.
+
+        :params:
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :param sender_chat_id: Unique identifier of the target sender chat
+        :param until_date: Date when the sender chat will be unbanned, unix time. If the chat is banned for more than 366 days
+        or less than 30 seconds from the current time they are considered to be banned forever.
+        :return: True on success.
+        """
+        return await asyncio_helper.ban_chat_sender_chat(self.token, chat_id, sender_chat_id, until_date)
+
+    async def unban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str]) -> bool:
+        """
+        Use this method to unban a previously banned channel chat in a supergroup or channel. 
+        The bot must be an administrator for this to work and must have the appropriate 
+        administrator rights.
+        Returns True on success.
+
+        :params:
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :param sender_chat_id: Unique identifier of the target sender chat
+        :return: True on success.
+        """
+        return await asyncio_helper.unban_chat_sender_chat(self.token, chat_id, sender_chat_id)
+
     async def set_chat_permissions(
             self, chat_id: Union[int, str], permissions: types.ChatPermissions) -> bool:
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -2136,8 +2136,7 @@ class AsyncTeleBot:
         return await asyncio_helper.set_chat_administrator_custom_title(self.token, chat_id, user_id, custom_title)
 
 
-    async def ban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str],
-        until_date:Optional[Union[int, datetime]]=None) -> bool:
+    async def ban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str]) -> bool:
         """
         Use this method to ban a channel chat in a supergroup or a channel.
         The owner of the chat will not be able to send messages and join live 
@@ -2153,7 +2152,7 @@ class AsyncTeleBot:
         or less than 30 seconds from the current time they are considered to be banned forever.
         :return: True on success.
         """
-        return await asyncio_helper.ban_chat_sender_chat(self.token, chat_id, sender_chat_id, until_date)
+        return await asyncio_helper.ban_chat_sender_chat(self.token, chat_id, sender_chat_id)
 
     async def unban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str]) -> bool:
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -2222,8 +2222,6 @@ class AsyncTeleBot:
         :params:
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :param sender_chat_id: Unique identifier of the target sender chat
-        :param until_date: Date when the sender chat will be unbanned, unix time. If the chat is banned for more than 366 days
-        or less than 30 seconds from the current time they are considered to be banned forever.
         :return: True on success.
         """
         return await asyncio_helper.ban_chat_sender_chat(self.token, chat_id, sender_chat_id)

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -100,59 +100,74 @@ class AsyncTeleBot:
         logOut
         close
         sendMessage
-        Formatting options
         forwardMessage
         copyMessage
+        deleteMessage
         sendPhoto
         sendAudio
         sendDocument
+        sendSticker
         sendVideo
+        sendVenue
         sendAnimation
-        sendVoice
         sendVideoNote
-        sendMediaGroup
         sendLocation
+        sendChatAction
+        sendDice
+        sendContact
+        sendInvoice
+        sendMediaGroup
+        getUserProfilePhotos
+        getUpdates
+        getFile
+        sendPoll
+        stopPoll
+        sendGame
+        setGameScore
+        getGameHighScores
+        editMessageText
+        editMessageCaption
+        editMessageMedia
+        editMessageReplyMarkup
         editMessageLiveLocation
         stopMessageLiveLocation
-        sendVenue
-        sendContact
-        sendPoll
-        sendDice
-        sendChatAction
-        getUserProfilePhotos
-        getFile
         banChatMember
         unbanChatMember
         restrictChatMember
         promoteChatMember
         setChatAdministratorCustomTitle
-        banChatSenderChat
-        unbanChatSenderChat
         setChatPermissions
-        exportChatInviteLink
         createChatInviteLink
         editChatInviteLink
         revokeChatInviteLink
-        approveChatJoinRequest
-        declineChatJoinRequest
+        exportChatInviteLink
+        setChatStickerSet
+        deleteChatStickerSet
+        createNewStickerSet
+        addStickerToSet
+        deleteStickerFromSet
+        setStickerPositionInSet
+        uploadStickerFile
+        setStickerSetThumb
+        getStickerSet
         setChatPhoto
         deleteChatPhoto
         setChatTitle
         setChatDescription
         pinChatMessage
         unpinChatMessage
-        unpinAllChatMessages
         leaveChat
         getChat
         getChatAdministrators
         getChatMemberCount
         getChatMember
-        setChatStickerSet
-        deleteChatStickerSet
         answerCallbackQuery
+        getMyCommands
         setMyCommands
         deleteMyCommands
-        getMyCommands
+        answerInlineQuery
+        answerShippingQuery
+        answerPreCheckoutQuery
         """
 
     def __init__(self, token: str, parse_mode: Optional[str]=None, offset=None,

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -912,11 +912,9 @@ async def set_chat_administrator_custom_title(token, chat_id, user_id, custom_ti
     return await _process_request(token, method_url, params=payload, method='post')
 
 
-async def ban_chat_sender_chat(token, chat_id, sender_chat_id, until_date=None):
+async def ban_chat_sender_chat(token, chat_id, sender_chat_id):
     method_url = 'banChatSenderChat'
     payload = {'chat_id': chat_id, 'sender_chat_id': sender_chat_id}
-    if until_date:
-        payload['until_date'] = until_date
     return await _process_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -912,6 +912,19 @@ async def set_chat_administrator_custom_title(token, chat_id, user_id, custom_ti
     return await _process_request(token, method_url, params=payload, method='post')
 
 
+async def ban_chat_sender_chat(token, chat_id, sender_chat_id, until_date=None):
+    method_url = 'banChatSenderChat'
+    payload = {'chat_id': chat_id, 'sender_chat_id': sender_chat_id}
+    if until_date:
+        payload['until_date'] = until_date
+    return await _process_request(token, method_url, params=payload, method='post')
+
+
+async def unban_chat_sender_chat(token, chat_id, sender_chat_id):
+    method_url = 'unbanChatSenderChat'
+    payload = {'chat_id': chat_id, 'sender_chat_id': sender_chat_id}
+    return await _process_request(token, method_url, params=payload, method='post')
+
 async def set_chat_permissions(token, chat_id, permissions):
     method_url = 'setChatPermissions'
     payload = {

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -274,10 +274,11 @@ class Chat(JsonDeserializable):
         return cls(**obj)
 
     def __init__(self, id, type, title=None, username=None, first_name=None,
-                 last_name=None, photo=None, bio=None, description=None, invite_link=None,
-                 pinned_message=None, permissions=None, slow_mode_delay=None,
-                 message_auto_delete_time=None, sticker_set_name=None, can_set_sticker_set=None,
-                 linked_chat_id=None, location=None, **kwargs):
+                 last_name=None, photo=None, bio=None, has_private_forwards=None,
+                 description=None, invite_link=None, pinned_message=None, 
+                 permissions=None, slow_mode_delay=None,
+                 message_auto_delete_time=None, has_protected_content=None, sticker_set_name=None,
+                 can_set_sticker_set=None, linked_chat_id=None, location=None, **kwargs):
         self.id: int = id
         self.type: str = type
         self.title: str = title
@@ -286,12 +287,14 @@ class Chat(JsonDeserializable):
         self.last_name: str = last_name
         self.photo: ChatPhoto = photo
         self.bio: str = bio
+        self.has_private_forwards: bool = has_private_forwards
         self.description: str = description
         self.invite_link: str = invite_link
         self.pinned_message: Message = pinned_message
         self.permissions: ChatPermissions = permissions
         self.slow_mode_delay: int = slow_mode_delay
         self.message_auto_delete_time: int = message_auto_delete_time
+        self.has_protected_content: bool = has_protected_content
         self.sticker_set_name: str = sticker_set_name
         self.can_set_sticker_set: bool = can_set_sticker_set
         self.linked_chat_id: int = linked_chat_id
@@ -334,12 +337,16 @@ class Message(JsonDeserializable):
             opts['forward_sender_name'] = obj.get('forward_sender_name')
         if 'forward_date' in obj:
             opts['forward_date'] = obj.get('forward_date')
+        if 'is_automatic_forward' in obj:
+            opts['is_automatic_forward'] = obj.get('is_automatic_forward')
         if 'reply_to_message' in obj:
             opts['reply_to_message'] = Message.de_json(obj['reply_to_message'])
         if 'via_bot' in obj:
             opts['via_bot'] = User.de_json(obj['via_bot'])
         if 'edit_date' in obj:
             opts['edit_date'] = obj.get('edit_date')
+        if 'has_protected_content' in obj:
+            opts['has_protected_content'] = obj.get('has_protected_content')
         if 'media_group_id' in obj:
             opts['media_group_id'] = obj.get('media_group_id')
         if 'author_signature' in obj:
@@ -503,9 +510,11 @@ class Message(JsonDeserializable):
         self.forward_signature: Optional[str] = None
         self.forward_sender_name: Optional[str] = None
         self.forward_date: Optional[int] = None
+        self.is_automatic_forward: Optional[bool] = None
         self.reply_to_message: Optional[Message] = None
         self.via_bot: Optional[User] = None
         self.edit_date: Optional[int] = None
+        self.has_protected_content: Optional[bool] = None
         self.media_group_id: Optional[str] = None
         self.author_signature: Optional[str] = None
         self.text: Optional[str] = None

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -50,7 +50,7 @@ def test_json_message_with_dice():
 
 
 def test_json_message_group():
-    json_string = r'{"message_id":10,"from":{"id":12345,"first_name":"g","last_name":"G","username":"GG","is_bot":true},"chat":{"id":-866,"type":"private","title":"\u4ea4"},"date":1435303157,"text":"HIHI"}'
+    json_string = r'{"message_id":10,"from":{"id":12345,"first_name":"g","last_name":"G","username":"GG","is_bot":true},"chat":{"id":-866,"type":"private","title":"\u4ea4"},"date":1435303157,"text":"HIHI","has_protected_content":true}'
     msg = types.Message.de_json(json_string)
     assert msg.text == 'HIHI'
     assert len(msg.chat.title) != 0


### PR DESCRIPTION
December 7, 2021
Bot API 5.5

Bots are now allowed to contact users who sent a join request to a chat where the bot is an administrator with the can_invite_users administrator right – even if the user never interacted with the bot before.
Added support for mentioning users by their ID in inline keyboards. This will only work in Telegram versions released after December 7, 2021. Older clients will display unsupported message.
Added the methods banChatSenderChat and unbanChatSenderChat for banning and unbanning channel chats in supergroups and channels.
Added the field has_private_forwards to the class Chat for private chats, which can be used to check the possibility of mentioning the user by their ID.
Added the field has_protected_content to the classes Chat and Message.
Added the field is_automatic_forward to the class Message.
Note: After this update it will become impossible to forward messages from some chats. Use the fields has_protected_content in the classes Message and Chat to check this.

Note: After this update users are able to send messages on behalf of channels they own. Bots are expected to use the field sender_chat in the class Message to correctly support such messages.

Note: As previously announced, user identifiers can now have up to 52 significant bits and require a 64-bit integer or double-precision float type to be stored safely.