### PR TITLE
Create a template for QWERTY custom keyboard an example for ReplyKeyboardMarkup

### DIFF
--- a/examples/reply_keyboard_markup_example.py
+++ b/examples/reply_keyboard_markup_example.py
@@ -1,0 +1,63 @@
+# This example shows you how to create a custom QWERTY keyboard using reply keyboard markup
+import telebot
+from telebot.types import ReplyKeyboardMarkup, KeyboardButton
+
+TOKEN = "<your_token>"
+bot = telebot.TeleBot(TOKEN)
+
+keys = ["1","2","3","4","5","6","7","8","9","0","q","w","e","r","t","y","u","i","o","p","a","s","d","f","g","h","j","k","l","z","x","c","v","b","n","m"]
+symbols = ["1","2","3","4","5","6","7","8","9","0","!","@","#","$","%","^","&","*","(",")","\'","\"","/","\\",",",".",";",":"]
+
+def keyboard(key_type="Normal"):
+    markup = ReplyKeyboardMarkup(row_width=10)
+    if key_type == "Normal":
+        row = [KeyboardButton(x) for x in keys[:10]]
+        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9])
+        row = [KeyboardButton(x) for x in keys[10:20]]
+        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9])
+        row = [KeyboardButton(x) for x in keys[20:29]]
+        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8])
+        row = [KeyboardButton(x) for x in keys[29:]]
+        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6])
+        markup.add(KeyboardButton("Caps Lock"),KeyboardButton("Symbols"),KeyboardButton("🔙Delete"),KeyboardButton("✅Done"))
+    elif key_type == "Symbols":
+        row = [KeyboardButton(x) for x in symbols[:10]]
+        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9])
+        row = [KeyboardButton(x) for x in symbols[10:20]]
+        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9])
+        row = [KeyboardButton(x) for x in symbols[20:]]
+        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7])
+        markup.add(KeyboardButton("Caps Lock"),KeyboardButton("Normal"),KeyboardButton("🔙Delete"),KeyboardButton("✅Done"))
+    else:
+        row = [KeyboardButton(x.upper()) for x in keys[:10]]
+        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9])
+        row = [KeyboardButton(x.upper()) for x in keys[10:20]]
+        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9])
+        row = [KeyboardButton(x.upper()) for x in keys[20:29]]
+        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8])
+        row = [KeyboardButton(x.upper()) for x in keys[29:]]
+        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6])
+        markup.add(KeyboardButton("Normal"),KeyboardButton("Symbols"),KeyboardButton("🔙Delete"),KeyboardButton("✅Done"))
+    return markup
+
+@bot.message_handler(commands=["start"])
+def start_message(message):
+    bot.send_message(message.chat.id,"You can use the keyboard",reply_markup=keyboard())
+
+@bot.message_handler(func=lambda message:True)
+def all_messages(message):
+    if message.text == "✅Done":
+        markup = telebot.types.ReplyKeyboardRemove()
+        bot.send_message(message.from_user.id,"Done with Keyboard",reply_markup=markup)
+    elif message.text == "Symbols":
+        bot.send_message(message.from_user.id,"Special characters",reply_markup=keyboard("Symbols"))
+    elif message.text == "Normal":
+        bot.send_message(message.from_user.id,"Normal Keyboard",reply_markup=keyboard("Normal"))
+    elif message.text == "Caps Lock":
+        bot.send_message(message.from_user.id,"Caps Lock",reply_markup=keyboard("Caps"))
+    elif message.text == "🔙Delete":
+        bot.delete_message(message.from_user.id,message.message_id)
+    else:
+        bot.send_message(message.chat.id,message.text)
+
+bot.polling()

--- a/examples/reply_keyboard_markup_example.py
+++ b/examples/reply_keyboard_markup_example.py
@@ -12,31 +12,31 @@ def keyboard(key_type="Normal"):
     markup = ReplyKeyboardMarkup(row_width=10)
     if key_type == "Normal":
         row = [KeyboardButton(x) for x in keys[:10]]
-        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9])
+        markup.add(*row)
         row = [KeyboardButton(x) for x in keys[10:20]]
-        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9])
+        markup.add(*row)
         row = [KeyboardButton(x) for x in keys[20:29]]
-        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8])
+        markup.add(*row)
         row = [KeyboardButton(x) for x in keys[29:]]
-        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6])
+        markup.add(*row)
         markup.add(KeyboardButton("Caps Lock"),KeyboardButton("Symbols"),KeyboardButton("🔙Delete"),KeyboardButton("✅Done"))
     elif key_type == "Symbols":
         row = [KeyboardButton(x) for x in symbols[:10]]
-        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9])
+        markup.add(*row)
         row = [KeyboardButton(x) for x in symbols[10:20]]
-        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9])
+        markup.add(*row)
         row = [KeyboardButton(x) for x in symbols[20:]]
-        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7])
+        markup.add(*row)
         markup.add(KeyboardButton("Caps Lock"),KeyboardButton("Normal"),KeyboardButton("🔙Delete"),KeyboardButton("✅Done"))
     else:
         row = [KeyboardButton(x.upper()) for x in keys[:10]]
-        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9])
+        markup.add(*row)
         row = [KeyboardButton(x.upper()) for x in keys[10:20]]
-        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9])
+        markup.add(*row)
         row = [KeyboardButton(x.upper()) for x in keys[20:29]]
-        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8])
+        markup.add(*row)
         row = [KeyboardButton(x.upper()) for x in keys[29:]]
-        markup.add(row[0],row[1],row[2],row[3],row[4],row[5],row[6])
+        markup.add(*row)
         markup.add(KeyboardButton("Normal"),KeyboardButton("Symbols"),KeyboardButton("🔙Delete"),KeyboardButton("✅Done"))
     return markup
 


### PR DESCRIPTION
Created a template for QWERTY custom keyboard that can be used by users for their own use cases.
This is an example created using ReplyKeyboardMarkup. 