### PR TITLE
add default None for get_my_commands, examples for bot.set_my_commands

### DIFF
--- a/examples/asynchronous_telebot/set_command_example.py
+++ b/examples/asynchronous_telebot/set_command_example.py
@@ -6,7 +6,6 @@
 # Important, command for chat_id and for group have a higher priority than for all
 
 import asyncio
-import os
 import telebot
 from telebot.async_telebot import AsyncTeleBot
 

--- a/examples/asynchronous_telebot/set_command_example.py
+++ b/examples/asynchronous_telebot/set_command_example.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+
+# This is a set_my_commands example.
+# Press on [/] button in telegram client.
+# Important, to update the command menu, be sure to exit the chat with the bot and log in again
+# Important, command for chat_id and for group have a higher priority than for all
+
+import asyncio
+import os
+import telebot
+from telebot.async_telebot import AsyncTeleBot
+
+
+API_TOKEN = '<api_token>'
+bot = AsyncTeleBot(API_TOKEN)
+
+
+async def main():
+    # use in for delete with the necessary scope and language_code if necessary
+    await bot.delete_my_commands(scope=None, language_code=None)
+
+    await bot.set_my_commands(
+        commands=[
+            telebot.types.BotCommand("command1", "command1 description"),
+            telebot.types.BotCommand("command2", "command2 description")
+        ],
+        # scope=telebot.types.BotCommandScopeChat(12345678)  # use for personal command menu for users
+        # scope=telebot.types.BotCommandScopeAllPrivateChats()  # use for all private chats
+    )
+    
+    cmd = await bot.get_my_commands(scope=None, language_code=None)
+    print([c.to_json() for c in cmd])
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/examples/asynchronous_telebot/timer_bot_async.py
+++ b/examples/asynchronous_telebot/timer_bot_async.py
@@ -5,7 +5,7 @@
 # https://schedule.readthedocs.io
 
 import asyncio
-import os, aioschedule
+import aioschedule
 from telebot.async_telebot import AsyncTeleBot
 
 API_TOKEN = '<api_token>'

--- a/examples/set_command_example.py
+++ b/examples/set_command_example.py
@@ -5,7 +5,6 @@
 # Important, to update the command menu, be sure to exit the chat with the bot and enter to chat again
 # Important, command for chat_id and for group have a higher priority than for all
 
-import os
 import telebot
 
 

--- a/examples/set_command_example.py
+++ b/examples/set_command_example.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+
+# This is a set_my_commands example.
+# Press on [/] button in telegram client.
+# Important, to update the command menu, be sure to exit the chat with the bot and enter to chat again
+# Important, command for chat_id and for group have a higher priority than for all
+
+import os
+import telebot
+
+
+API_TOKEN = '<api_token>'
+bot = telebot.TeleBot(API_TOKEN)
+
+# use in for delete with the necessary scope and language_code if necessary
+bot.delete_my_commands(scope=None, language_code=None)
+
+bot.set_my_commands(
+    commands=[
+        telebot.types.BotCommand("command1", "command1 description"),
+        telebot.types.BotCommand("command2", "command2 description")
+    ],
+    # scope=telebot.types.BotCommandScopeChat(12345678)  # use for personal command for users
+    # scope=telebot.types.BotCommandScopeAllPrivateChats()  # use for all private chats
+)
+
+# check command
+cmd = bot.get_my_commands(scope=None, language_code=None)
+print([c.to_json() for c in cmd])

--- a/examples/timer_bot.py
+++ b/examples/timer_bot.py
@@ -3,7 +3,7 @@
 # This is a simple bot with schedule timer
 # https://schedule.readthedocs.io
 
-import os, time, threading, schedule
+import time, threading, schedule
 from telebot import TeleBot
 
 API_TOKEN = '<api_token>'

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1899,8 +1899,8 @@ class TeleBot:
         """
         return apihelper.delete_chat_photo(self.token, chat_id)
     
-    def get_my_commands(self, scope: Optional[types.BotCommandScope], 
-            language_code: Optional[str]) -> List[types.BotCommand]:
+    def get_my_commands(self, scope: Optional[types.BotCommandScope]=None, 
+            language_code: Optional[str]=None) -> List[types.BotCommand]:
         """
         Use this method to get the current list of the bot's commands. 
         Returns List of BotCommand on success.

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -2443,8 +2443,8 @@ class AsyncTeleBot:
         """
         return await asyncio_helper.delete_chat_photo(self.token, chat_id)
     
-    async def get_my_commands(self, scope: Optional[types.BotCommandScope], 
-            language_code: Optional[str]) -> List[types.BotCommand]:
+    async def get_my_commands(self, scope: Optional[types.BotCommandScope]=None, 
+            language_code: Optional[str]=None) -> List[types.BotCommand]:
         """
         Use this method to get the current list of the bot's commands. 
         Returns List of BotCommand on success.


### PR DESCRIPTION
Add default parameters for call bot.get_my_commands() instead bot.get_my_commands(scope=None, language_code=None)
Add examples for [issues #1414  set_my_commands problem](https://github.com/eternnoir/pyTelegramBotAPI/issues/1414 )
