### PR TITLE
argument of 'func' parameter in handlers can be async function

### DIFF
--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -5,6 +5,7 @@ import logging
 import re
 import time
 import traceback
+import inspect
 from typing import Any, List, Optional, Union
 
 # this imports are used to avoid circular import error
@@ -593,6 +594,8 @@ class AsyncTeleBot:
         elif message_filter == 'chat_types':
             return message.chat.type in filter_value
         elif message_filter == 'func':
+            if inspect.iscoroutinefunction(filter_value):
+                return await filter_value(message)
             return filter_value(message)
         elif self.custom_filters and message_filter in self.custom_filters:
             return await self._check_filter(message_filter,filter_value,message)


### PR DESCRIPTION
Currently AsyncTelebot does not support async functions as argument for func parameter in handlers.
This pull request allows it to be either sync or async function