### PR TITLE
CopyMessage return type fix

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1040,7 +1040,7 @@ class TeleBot:
             reply_to_message_id: Optional[int]=None, 
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            timeout: Optional[int]=None) -> int:
+            timeout: Optional[int]=None) -> types.MessageID:
         """
         Use this method to copy messages of any kind.
 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -1654,7 +1654,7 @@ class AsyncTeleBot:
             reply_to_message_id: Optional[int]=None, 
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            timeout: Optional[int]=None) -> int:
+            timeout: Optional[int]=None) -> types.MessageID:
         """
         Use this method to copy messages of any kind.
 


### PR DESCRIPTION
## Description
[CopyMessage](https://core.telegram.org/bots/api#copymessage) returns [MessageId](https://core.telegram.org/bots/api#messageid) while in code it returned `int`

Tests [uses MessageId type already](https://github.com/eternnoir/pyTelegramBotAPI/blob/master/tests/test_telebot.py#L325)

## Checklist:
- [x] My changes won't break backend compatibility
- [x] I made changes for async and sync

