### PR TITLE
Set escape=True by default.

### DIFF
--- a/examples/asynchronous_telebot/formatting_example.py
+++ b/examples/asynchronous_telebot/formatting_example.py
@@ -10,11 +10,11 @@ async def start_message(message):
         message.chat.id,
         # function which connects all strings
         formatting.format_text(
-            formatting.mbold(message.from_user.first_name, escape=True), # pass escape=True to escape special characters
-            formatting.mitalic(message.from_user.first_name, escape=True),
-            formatting.munderline(message.from_user.first_name, escape=True),
-            formatting.mstrikethrough(message.from_user.first_name, escape=True),
-            formatting.mcode(message.from_user.first_name, escape=True),
+            formatting.mbold(message.from_user.first_name),
+            formatting.mitalic(message.from_user.first_name),
+            formatting.munderline(message.from_user.first_name),
+            formatting.mstrikethrough(message.from_user.first_name),
+            formatting.mcode(message.from_user.first_name),
             separator=" " # separator separates all strings
         ),
         parse_mode='MarkdownV2'
@@ -23,7 +23,7 @@ async def start_message(message):
     # just a bold text using markdownv2
     await bot.send_message(
         message.chat.id,
-        formatting.mbold(message.from_user.first_name, escape=True),
+        formatting.mbold(message.from_user.first_name),
         parse_mode='MarkdownV2'
     )
 
@@ -31,11 +31,11 @@ async def start_message(message):
     await bot.send_message(
         message.chat.id,
         formatting.format_text(
-            formatting.hbold(message.from_user.first_name, escape=True),
-            formatting.hitalic(message.from_user.first_name, escape=True),
-            formatting.hunderline(message.from_user.first_name, escape=True),
-            formatting.hstrikethrough(message.from_user.first_name, escape=True),
-            formatting.hcode(message.from_user.first_name, escape=True),
+            formatting.hbold(message.from_user.first_name),
+            formatting.hitalic(message.from_user.first_name),
+            formatting.hunderline(message.from_user.first_name),
+            formatting.hstrikethrough(message.from_user.first_name),
+            formatting.hcode(message.from_user.first_name),
             separator=" "
         ),
         parse_mode='HTML'
@@ -44,7 +44,7 @@ async def start_message(message):
     # just a bold text in html
     await bot.send_message(
         message.chat.id,
-        formatting.hbold(message.from_user.first_name, escape=True),
+        formatting.hbold(message.from_user.first_name),
         parse_mode='HTML'
     )
 

--- a/examples/formatting_example.py
+++ b/examples/formatting_example.py
@@ -10,11 +10,11 @@ def start_message(message):
         message.chat.id,
         # function which connects all strings
         formatting.format_text(
-            formatting.mbold(message.from_user.first_name, escape=True), # pass escape=True to escape special characters
-            formatting.mitalic(message.from_user.first_name, escape=True),
-            formatting.munderline(message.from_user.first_name, escape=True),
-            formatting.mstrikethrough(message.from_user.first_name, escape=True),
-            formatting.mcode(message.from_user.first_name, escape=True),
+            formatting.mbold(message.from_user.first_name),
+            formatting.mitalic(message.from_user.first_name),
+            formatting.munderline(message.from_user.first_name),
+            formatting.mstrikethrough(message.from_user.first_name),
+            formatting.mcode(message.from_user.first_name),
             separator=" " # separator separates all strings
         ),
         parse_mode='MarkdownV2'
@@ -23,7 +23,7 @@ def start_message(message):
     # just a bold text using markdownv2
     bot.send_message(
         message.chat.id,
-        formatting.mbold(message.from_user.first_name, escape=True),
+        formatting.mbold(message.from_user.first_name),
         parse_mode='MarkdownV2'
     )
 
@@ -31,11 +31,11 @@ def start_message(message):
     bot.send_message(
         message.chat.id,
         formatting.format_text(
-            formatting.hbold(message.from_user.first_name, escape=True),
-            formatting.hitalic(message.from_user.first_name, escape=True),
-            formatting.hunderline(message.from_user.first_name, escape=True),
-            formatting.hstrikethrough(message.from_user.first_name, escape=True),
-            formatting.hcode(message.from_user.first_name, escape=True),
+            formatting.hbold(message.from_user.first_name),
+            formatting.hitalic(message.from_user.first_name),
+            formatting.hunderline(message.from_user.first_name),
+            formatting.hstrikethrough(message.from_user.first_name),
+            formatting.hcode(message.from_user.first_name),
             separator=" "
         ),
         parse_mode='HTML'
@@ -44,7 +44,7 @@ def start_message(message):
     # just a bold text in html
     bot.send_message(
         message.chat.id,
-        formatting.hbold(message.from_user.first_name, escape=True),
+        formatting.hbold(message.from_user.first_name),
         parse_mode='HTML'
     )
 

--- a/telebot/formatting.py
+++ b/telebot/formatting.py
@@ -49,7 +49,7 @@ def escape_markdown(content: str) -> str:
     return reparse 
 
 
-def mbold(content: str, escape: bool=False) -> str:
+def mbold(content: str, escape: bool=True) -> str:
     """
     Returns a Markdown-formatted bold string.
 
@@ -59,7 +59,7 @@ def mbold(content: str, escape: bool=False) -> str:
     return '*{}*'.format(escape_markdown(content) if escape else content)
 
 
-def hbold(content: str, escape: bool=False) -> str:
+def hbold(content: str, escape: bool=True) -> str:
     """
     Returns an HTML-formatted bold string.
 
@@ -69,7 +69,7 @@ def hbold(content: str, escape: bool=False) -> str:
     return '<b>{}</b>'.format(escape_html(content) if escape else content)
 
 
-def mitalic(content: str, escape: bool=False) -> str:
+def mitalic(content: str, escape: bool=True) -> str:
     """
     Returns a Markdown-formatted italic string.
 
@@ -79,7 +79,7 @@ def mitalic(content: str, escape: bool=False) -> str:
     return '_{}_\r'.format(escape_markdown(content) if escape else content)
 
 
-def hitalic(content: str, escape: bool=False) -> str:
+def hitalic(content: str, escape: bool=True) -> str:
     """
     Returns an HTML-formatted italic string.
 
@@ -89,7 +89,7 @@ def hitalic(content: str, escape: bool=False) -> str:
     return '<i>{}</i>'.format(escape_html(content) if escape else content)
 
 
-def munderline(content: str, escape: bool=False) -> str:
+def munderline(content: str, escape: bool=True) -> str:
     """
     Returns a Markdown-formatted underline string.
 
@@ -99,7 +99,7 @@ def munderline(content: str, escape: bool=False) -> str:
     return '__{}__'.format(escape_markdown(content) if escape else content)
 
 
-def hunderline(content: str, escape: bool=False) -> str:
+def hunderline(content: str, escape: bool=True) -> str:
     """
     Returns an HTML-formatted underline string.
 
@@ -109,7 +109,7 @@ def hunderline(content: str, escape: bool=False) -> str:
     return '<u>{}</u>'.format(escape_html(content) if escape else content)
 
 
-def mstrikethrough(content: str, escape: bool=False) -> str:
+def mstrikethrough(content: str, escape: bool=True) -> str:
     """
     Returns a Markdown-formatted strikethrough string.
 
@@ -119,7 +119,7 @@ def mstrikethrough(content: str, escape: bool=False) -> str:
     return '~{}~'.format(escape_markdown(content) if escape else content)
 
 
-def hstrikethrough(content: str, escape: bool=False) -> str:
+def hstrikethrough(content: str, escape: bool=True) -> str:
     """
     Returns an HTML-formatted strikethrough string.
 
@@ -129,7 +129,7 @@ def hstrikethrough(content: str, escape: bool=False) -> str:
     return '<s>{}</s>'.format(escape_html(content) if escape else content)
 
 
-def mspoiler(content: str, escape: bool=False) -> str:
+def mspoiler(content: str, escape: bool=True) -> str:
     """
     Returns a Markdown-formatted spoiler string.
 
@@ -139,7 +139,7 @@ def mspoiler(content: str, escape: bool=False) -> str:
     return '||{}||'.format(escape_markdown(content) if escape else content)
 
 
-def hspoiler(content: str, escape: bool=False) -> str:
+def hspoiler(content: str, escape: bool=True) -> str:
     """
     Returns an HTML-formatted spoiler string.
 
@@ -149,7 +149,7 @@ def hspoiler(content: str, escape: bool=False) -> str:
     return '<tg-spoiler>{}</tg-spoiler>'.format(escape_html(content) if escape else content)
 
 
-def mlink(content: str, url: str, escape: bool=False) -> str:
+def mlink(content: str, url: str, escape: bool=True) -> str:
     """
     Returns a Markdown-formatted link string.
 
@@ -160,7 +160,7 @@ def mlink(content: str, url: str, escape: bool=False) -> str:
     return '[{}]({})'.format(escape_markdown(content), escape_markdown(url) if escape else content)
 
 
-def hlink(content: str, url: str, escape: bool=False) -> str:
+def hlink(content: str, url: str, escape: bool=True) -> str:
     """
     Returns an HTML-formatted link string.
 
@@ -171,7 +171,7 @@ def hlink(content: str, url: str, escape: bool=False) -> str:
     return '<a href="{}">{}</a>'.format(escape_html(url), escape_html(content) if escape else content)
 
 
-def mcode(content: str, language: str="", escape: bool=False) -> str:
+def mcode(content: str, language: str="", escape: bool=True) -> str:
     """
     Returns a Markdown-formatted code string.
 
@@ -181,7 +181,7 @@ def mcode(content: str, language: str="", escape: bool=False) -> str:
     return '```{}\n{}```'.format(language, escape_markdown(content) if escape else content)
 
 
-def hcode(content: str, escape: bool=False) -> str:
+def hcode(content: str, escape: bool=True) -> str:
     """
     Returns an HTML-formatted code string.
 
@@ -191,7 +191,7 @@ def hcode(content: str, escape: bool=False) -> str:
     return '<code>{}</code>'.format(escape_html(content) if escape else content)
 
 
-def hpre(content: str, escape: bool=False, language: str="") -> str:
+def hpre(content: str, escape: bool=True, language: str="") -> str:
     """
     Returns an HTML-formatted preformatted string.
 


### PR DESCRIPTION
## Description
Include changes, new features and etc:
Now, all formatting functions have escape=True by default.

## Describe your tests
How did you test your change?
Examples were tested.

Python version: 3.9.6

OS: MacOs, BigSur

## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [ ] My changes won't break backend compatibility
- [x] I made changes for async and sync

