### PR TITLE
fix: warning none_stop parameter is deprecated

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -566,7 +566,7 @@ class TeleBot:
 
         while not self.__stop_polling.is_set():
             try:
-                self.polling(none_stop=True, timeout=timeout, long_polling_timeout=long_polling_timeout,
+                self.polling(non_stop=True, timeout=timeout, long_polling_timeout=long_polling_timeout,
                              logger_level=logger_level, allowed_updates=allowed_updates, *args, **kwargs)
             except Exception as e:
                 if logger_level and logger_level >= logging.ERROR:


### PR DESCRIPTION
## Description
fix warning
```
WARNING: polling: none_stop parameter is deprecated. Use non_stop instead.
```
when using `infinity_polling `

## Describe your tests
How did you test your change?

Python version: 3.9

OS: macos

## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async
