### PR TITLE
Changed behaviour of default parse mode in sync and async telebot.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ testMain.py
 #VS Code
 .vscode/
 .DS_Store
+*.code-workspace
 
 # documentation
 _build/

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -2510,6 +2510,8 @@ class TeleBot:
         if isinstance(question, types.Poll):
             raise RuntimeError("The send_poll signature was changed, please see send_poll function details.")
 
+        explanation_parse_mode = self.parse_mode if (explanation_parse_mode is None) else explanation_parse_mode
+
         return types.Message.de_json(
             apihelper.send_poll(
                 self.token, chat_id,

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -1674,6 +1674,8 @@ class AsyncTeleBot:
         :param protect_content:
         :return: API reply.
         """
+        parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
+
         return types.MessageID.de_json(
             await asyncio_helper.copy_message(self.token, chat_id, from_chat_id, message_id, caption, parse_mode, caption_entities,
                                    disable_notification, reply_to_message_id, allow_sending_without_reply, reply_markup,
@@ -3111,6 +3113,8 @@ class AsyncTeleBot:
 
         if isinstance(question, types.Poll):
             raise RuntimeError("The send_poll signature was changed, please see send_poll function details.")
+
+        explanation_parse_mode = self.parse_mode if (explanation_parse_mode is None) else explanation_parse_mode
 
         return types.Message.de_json(
             await asyncio_helper.send_poll(

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -370,7 +370,8 @@ def quick_markup(values: Dict[str, Dict[str, Any]], row_width: int=2) -> types.I
             'switch_inline_query_current_chat': None,
             'callback_game': None,
             'pay': None,
-            'login_url': None
+            'login_url': None,
+            'web_app': None
         }
     
     :param values: a dict containing all buttons to create in this format: {text: kwargs} {str:}


### PR DESCRIPTION
## Description
Include changes, new features and etc:
- Fixed send_poll's default explanation parse mode
- Fixed default parse mode in asynctelebot


## Describe your tests
How did you test your change?

Python version:

OS:

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [ ] My changes won't break backward compatibility
- [ ] I made changes both for sync and async
