### PR TITLE
Fixed async long polling

### DIFF
--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -217,11 +217,11 @@ async def get_updates(token, offset=None, limit=None,
     params = {}
     if offset:
         params['offset'] = offset
-    elif limit:
+    if limit:
         params['limit'] = limit
-    elif timeout:
+    if timeout:
         params['timeout'] = timeout
-    elif allowed_updates:
+    if allowed_updates:
         params['allowed_updates'] = allowed_updates
     return await _process_request(token, method_name, params=params, request_timeout=request_timeout)
 


### PR DESCRIPTION
Hi, looks like that there is a bug in `asyncio_helper.py`, `get_updates()`, due to which `timeout` parameter is not pass into a `getUpdates` function and as a result, short polling is used instead of a long polling.
