### PR TITLE
Fix for token visibility in swagger in fastapi webhook example

### DIFF
--- a/examples/webhook_examples/webhook_fastapi_echo_bot.py
+++ b/examples/webhook_examples/webhook_fastapi_echo_bot.py
@@ -33,7 +33,7 @@ telebot.logger.setLevel(logging.INFO)
 
 bot = telebot.TeleBot(API_TOKEN)
 
-app = fastapi.FastAPI()
+app = fastapi.FastAPI(docs=None, redoc_url=None)
 
 
 # Process webhook calls

--- a/examples/webhook_examples/webhook_fastapi_echo_bot.py
+++ b/examples/webhook_examples/webhook_fastapi_echo_bot.py
@@ -6,6 +6,7 @@
 
 import logging
 import fastapi
+import uvicorn
 import telebot
 
 API_TOKEN = 'TOKEN'
@@ -36,9 +37,11 @@ bot = telebot.TeleBot(API_TOKEN)
 app = fastapi.FastAPI(docs=None, redoc_url=None)
 
 
-# Process webhook calls
 @app.post(f'/{API_TOKEN}/')
 def process_webhook(update: dict):
+    """
+    Process webhook calls
+    """
     if update:
         update = telebot.types.Update.de_json(update)
         bot.process_new_updates([update])
@@ -46,18 +49,21 @@ def process_webhook(update: dict):
         return
 
 
-
-# Handle '/start' and '/help'
 @bot.message_handler(commands=['help', 'start'])
 def send_welcome(message):
+    """
+    Handle '/start' and '/help'
+    """
     bot.reply_to(message,
                  ("Hi there, I am EchoBot.\n"
                   "I am here to echo your kind words back to you."))
 
 
-# Handle all other messages
 @bot.message_handler(func=lambda message: True, content_types=['text'])
 def echo_message(message):
+    """
+    Handle all other messages
+    """
     bot.reply_to(message, message.text)
 
 
@@ -65,11 +71,12 @@ def echo_message(message):
 bot.remove_webhook()
 
 # Set webhook
-bot.set_webhook(url=WEBHOOK_URL_BASE + WEBHOOK_URL_PATH,
-                certificate=open(WEBHOOK_SSL_CERT, 'r'))
+bot.set_webhook(
+    url=WEBHOOK_URL_BASE + WEBHOOK_URL_PATH,
+    certificate=open(WEBHOOK_SSL_CERT, 'r')
+)
 
 
-import uvicorn
 uvicorn.run(
     app,
     host=WEBHOOK_LISTEN,


### PR DESCRIPTION
## Description
FastAPI by default includes displaying swagger documentation of its methods. If it is not disabled, then in the above example / dox will see the token in the path for updates.

My edits fix this issue.

Python version:
All supported versions

OS:
All supported OS

## Checklist:
- [ x ] I added/edited example on new feature/change (if exists)
- [ x ] My changes won't break backward compatibility
- [ x ] I made changes both for sync and async
