### PR TITLE
Add 'web_app_data' content type to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ To start the bot, simply open up a terminal and enter `python echo_bot.py` to ru
 All types are defined in types.py. They are all completely in line with the [Telegram API's definition of the types](https://core.telegram.org/bots/api#available-types), except for the Message's `from` field, which is renamed to `from_user` (because `from` is a Python reserved token). Thus, attributes such as `message_id` can be accessed directly with `message.message_id`. Note that `message.chat` can be either an instance of `User` or `GroupChat` (see [How can I distinguish a User and a GroupChat in message.chat?](#how-can-i-distinguish-a-user-and-a-groupchat-in-messagechat)).
 
 The Message object also has a `content_type`attribute, which defines the type of the Message. `content_type` can be one of the following strings:
-`text`, `audio`, `document`, `photo`, `sticker`, `video`, `video_note`, `voice`, `location`, `contact`, `new_chat_members`, `left_chat_member`, `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`, `supergroup_chat_created`, `channel_chat_created`, `migrate_to_chat_id`, `migrate_from_chat_id`, `pinned_message`.
+`text`, `audio`, `document`, `photo`, `sticker`, `video`, `video_note`, `voice`, `location`, `contact`, `new_chat_members`, `left_chat_member`, `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`, `supergroup_chat_created`, `channel_chat_created`, `migrate_to_chat_id`, `migrate_from_chat_id`, `pinned_message`, `web_app_data`.
 
 You can use some types in one function. Example:
 


### PR DESCRIPTION
Update README to include the valid content type 'web_app_data' for Message objects.

That kind of content type is the one that WebApp bots can send from KeyboardButtons, using the sendData method (More info [here](https://core.telegram.org/bots/webapps#initializing-web-apps))

Debug info from TeleBot with the returned message (edited to avoid leaking real data):

DEBUG - TeleBot: "The server returned: 'b'{"ok":true,"result":[{"update_id":000000000,\n"message":{"m
essage_id":000,"from":{"id":00000000,"is_bot":false,"first_name":"XXX","username":"XXX","language_code":"es"},"chat":{"id":00000000,"first_name":"XXX","use
rname":"XXX","type":"private"},"date":1660260000,"web_app_data":{"button_text":"MyWebAppButton","data":"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"}}}]}''"