### PR TITLE
Import aioredis from redis module too

### DIFF
--- a/telebot/asyncio_storage/redis_storage.py
+++ b/telebot/asyncio_storage/redis_storage.py
@@ -6,7 +6,10 @@ redis_installed = True
 try:
     import aioredis
 except:
-    redis_installed = False
+    try:
+        from redis import asyncio as aioredis
+    except:
+        redis_installed = False
 
 
 class StateRedisStorage(StateStorageBase):

--- a/telebot/asyncio_storage/redis_storage.py
+++ b/telebot/asyncio_storage/redis_storage.py
@@ -5,10 +5,10 @@ import json
 redis_installed = True
 try:
     import aioredis
-except:
+except ImportError:
     try:
         from redis import asyncio as aioredis
-    except:
+    except ImportError:
         redis_installed = False
 
 


### PR DESCRIPTION
## Description
aioredis is available in redis-py as of version 4.2.0rc1: https://github.com/aio-libs/aioredis-py#-aioredis-is-now-in-redis-py-420rc1-
Try importing from the new package as well.

## Describe your tests
How did you test your change?
I tried async storage with aioredis from redis-py.

Python version: 3.10

OS: Linux

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [X] My changes won't break backward compatibility
- [ ] I made changes both for sync and async
