### PR TITLE
Drop FastAPI for async and use Starlette directly.

### DIFF
--- a/examples/asynchronous_telebot/webhooks/run_webhooks.py
+++ b/examples/asynchronous_telebot/webhooks/run_webhooks.py
@@ -37,7 +37,7 @@ async def echo_message(message):
     await bot.reply_to(message, message.text)
 
 
-# it uses fastapi + uvicorn
+# it uses starlette + uvicorn
 asyncio.run(bot.run_webhooks(
     listen=DOMAIN,
     certificate=WEBHOOK_SSL_CERT,

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -1990,7 +1990,7 @@ class AsyncTeleBot:
         try:
             from telebot.ext.aio import AsyncWebhookListener
         except (NameError, ImportError):
-            raise ImportError("Please install uvicorn and fastapi in order to use `run_webhooks` method.")
+            raise ImportError("Please install starlette and uvicorn in order to use `run_webhooks` method.")
         self.webhook_listener = AsyncWebhookListener(self, secret_token, listen, port, ssl_context, '/'+url_path, debug)
         await self.webhook_listener.run_app()
 


### PR DESCRIPTION
## Description
Drop FastAPI for async and use Starlette directly.

Python version: 3.10

OS: Linux

## Checklist:
- [X] I added/edited example on new feature/change (if exists)
- [X] My changes won't break backward compatibility
