### PR TITLE
request_timeout field for send_media_group

### DIFF
--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -3065,7 +3065,8 @@ class AsyncTeleBot:
             protect_content: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None, 
             timeout: Optional[int]=None,
-            allow_sending_without_reply: Optional[bool]=None) -> List[types.Message]:
+            allow_sending_without_reply: Optional[bool]=None,
+            request_timeout: Optional[int]=None) -> List[types.Message]:
         """
         Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files
         can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned.
@@ -3090,6 +3091,9 @@ class AsyncTeleBot:
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
 
+        :param request_timeout: Timeout in seconds for the aiohttp.ClientTimeout 'total'.
+        :type request_timeout: :obj:`int`
+
         :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
         :type allow_sending_without_reply: :obj:`bool`
 
@@ -3098,7 +3102,7 @@ class AsyncTeleBot:
         """
         result = await asyncio_helper.send_media_group(
             self.token, chat_id, media, disable_notification, reply_to_message_id, timeout, 
-            allow_sending_without_reply, protect_content)
+            allow_sending_without_reply, protect_content, request_timeout)
         return [types.Message.de_json(msg) for msg in result]
 
     async def send_location(

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -472,7 +472,7 @@ async def send_photo(
 async def send_media_group(
         token, chat_id, media,
         disable_notification=None, reply_to_message_id=None,
-        timeout=None, allow_sending_without_reply=None, protect_content=None):
+        timeout=None, allow_sending_without_reply=None, protect_content=None, request_timeout=None):
     method_url = r'sendMediaGroup'
     media_json, files = await convert_input_media_array(media)
     payload = {'chat_id': chat_id, 'media': media_json}
@@ -489,7 +489,9 @@ async def send_media_group(
     return await _process_request(
         token, method_url, params=payload,
         method='post' if files else 'get',
-        files=files if files else None)
+        files=files if files else None,
+        request_timeout=request_timeout
+    )
 
 
 async def send_location(


### PR DESCRIPTION
## Description
The problem I found is not possible to set Timeout for 'send_media_group', so there is a solution.
The method 'send_media_group' do not use 'request_timeout' of _process_request, it always stays as None.

Python version: 3.10

OS: Big Sur

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [ ] My changes won't break backward compatibility
- [ ] I made changes both for sync and async
