### PR TITLE
raise other exceptions in antiflood function

### DIFF
--- a/telebot/util.py
+++ b/telebot/util.py
@@ -654,6 +654,10 @@ def antiflood(function: Callable, *args, **kwargs):
         if ex.error_code == 429:
             sleep(ex.result_json['parameters']['retry_after'])
             msg = function(*args, **kwargs)
+        else:
+            raise
+    except:
+        raise
     finally:
         return msg
     

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -647,19 +647,15 @@ def antiflood(function: Callable, *args, **kwargs):
     """
     from telebot.apihelper import ApiTelegramException
     from time import sleep
-    msg = None
+
     try:
-        msg = function(*args, **kwargs)
+        return function(*args, **kwargs)
     except ApiTelegramException as ex:
         if ex.error_code == 429:
             sleep(ex.result_json['parameters']['retry_after'])
-            msg = function(*args, **kwargs)
+            return function(*args, **kwargs)
         else:
             raise
-    except:
-        raise
-    finally:
-        return msg
     
     
 def parse_web_app_data(token: str, raw_init_data: str):


### PR DESCRIPTION
Other kinds of errors like `Error code: 400. Description: Bad Request: wrong file identifier/HTTP URL specified` during sending a set of photos or `urllib3.exceptions.ProxySchemeUnknown: Not supported proxy scheme 127.0.0.1` for forgetting the 'http:\\\\' may occur and should raise exceptions. 