### PR TITLE
Fix incorrect webhook URL port in aiohttp examples

### DIFF
--- a/examples/asynchronous_telebot/webhooks/async_webhook_aiohttp_echo_bot.py
+++ b/examples/asynchronous_telebot/webhooks/async_webhook_aiohttp_echo_bot.py
@@ -17,7 +17,7 @@ WEBHOOK_PORT = 8443  # 443, 80, 88 or 8443 (port need to be 'open')
 WEBHOOK_LISTEN = '0.0.0.0'  # In some VPS you may need to put here the IP addr
 WEBHOOK_SSL_CERT = './webhook_cert.pem'  # Path to the ssl certificate
 WEBHOOK_SSL_PRIV = './webhook_pkey.pem'  # Path to the ssl private key
-WEBHOOK_URL_BASE = "https://{}:{}".format(WEBHOOK_HOST, WEBHOOK_PORT)
+WEBHOOK_URL_BASE = "https://{}".format(WEBHOOK_HOST)
 WEBHOOK_URL_PATH = "/{}/".format(API_TOKEN)
 
 # Quick'n'dirty SSL certificate generation:

--- a/examples/webhook_examples/webhook_aiohttp_echo_bot.py
+++ b/examples/webhook_examples/webhook_aiohttp_echo_bot.py
@@ -28,7 +28,7 @@ WEBHOOK_SSL_PRIV = './webhook_pkey.pem'  # Path to the ssl private key
 # When asked for "Common Name (e.g. server FQDN or YOUR name)" you should reply
 # with the same value in you put in WEBHOOK_HOST
 
-WEBHOOK_URL_BASE = "https://{}:{}".format(WEBHOOK_HOST, WEBHOOK_PORT)
+WEBHOOK_URL_BASE = "https://{}".format(WEBHOOK_HOST)
 WEBHOOK_URL_PATH = "/{}/".format(API_TOKEN)
 
 logger = telebot.logger


### PR DESCRIPTION
## Description
Updated examples to use default port in webhook URL. Resolves issues such as [this](https://stackoverflow.com/questions/65582845/use-an-open-port-when-deploying-telegram-bot-using-pytelegrambotapi-to-heroku/73693670).

## Describe your tests
Tested by deploying on Heroku with the above change. Webhook running fine.

Python version: 3.10.7

OS: Ubuntu 20.04

## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async
