### PR TITLE
fixes: `debug` removed from uvicorn #1767

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -451,8 +451,7 @@ class TeleBot:
                     drop_pending_updates: Optional[bool] = None,
                     timeout: Optional[int]=None,
                     secret_token: Optional[str]=None,
-                    secret_token_length: Optional[int]=20,
-                    debug: Optional[bool]=False):
+                    secret_token_length: Optional[int]=20,):
         """
         This class sets webhooks and listens to a given url and port.
 
@@ -501,9 +500,6 @@ class TeleBot:
         :param secret_token_length: Length of a secret token, defaults to 20
         :type secret_token_length: :obj:`int`, optional
 
-        :param debug: set True if you want to set debugging on for webserver, defaults to False
-        :type debug: :obj:`bool`, optional
-
         :raises ImportError: If necessary libraries were not installed.
         """
 
@@ -544,7 +540,7 @@ class TeleBot:
             from telebot.ext.sync import SyncWebhookListener
         except (NameError, ImportError):
             raise ImportError("Please install uvicorn and fastapi in order to use `run_webhooks` method.")
-        self.webhook_listener = SyncWebhookListener(self, secret_token, listen, port, ssl_context, '/'+url_path, debug)
+        self.webhook_listener = SyncWebhookListener(self, secret_token, listen, port, ssl_context, '/'+url_path)
         self.webhook_listener.run_app()
 
 

--- a/telebot/ext/aio/webhooks.py
+++ b/telebot/ext/aio/webhooks.py
@@ -29,7 +29,6 @@ class AsyncWebhookListener:
                 port: Optional[int]=443,
                 ssl_context: Optional[tuple]=None,
                 url_path: Optional[str]=None,
-                debug: Optional[bool]=False
                 ) -> None:
         """
         Aynchronous implementation of webhook listener
@@ -55,9 +54,6 @@ class AsyncWebhookListener:
         :param url_path: Webhook url path
         :type url_path: str
 
-        :param debug: Debug mode
-        :type debug: bool
-
         :raises ImportError: If FastAPI or uvicorn is not installed.
         :raises ImportError: If Starlette version is too old.
 
@@ -72,7 +68,6 @@ class AsyncWebhookListener:
         self._host = host
         self._ssl_context = ssl_context
         self._url_path = url_path
-        self._debug = debug
         self._prepare_endpoint_urls()
 
 
@@ -119,7 +114,6 @@ class AsyncWebhookListener:
         config = Config(app=self.app,
             host=self._host,
             port=self._port,
-            debug=self._debug,
             ssl_certfile=self._ssl_context[0],
             ssl_keyfile=self._ssl_context[1]
         )

--- a/telebot/ext/sync/webhooks.py
+++ b/telebot/ext/sync/webhooks.py
@@ -25,7 +25,6 @@ class SyncWebhookListener:
                 port: Optional[int]=443,
                 ssl_context: Optional[tuple]=None,
                 url_path: Optional[str]=None,
-                debug: Optional[bool]=False
                 ) -> None:
         """
         Synchronous implementation of webhook listener
@@ -51,9 +50,6 @@ class SyncWebhookListener:
         :param url_path: Webhook url path
         :type url_path: str
 
-        :param debug: Debug mode
-        :type debug: bool
-
         :raises ImportError: If FastAPI or uvicorn is not installed.
         :raises ImportError: If Starlette version is too old.
 
@@ -68,7 +64,6 @@ class SyncWebhookListener:
         self._host = host
         self._ssl_context = ssl_context
         self._url_path = url_path
-        self._debug = debug
         self._prepare_endpoint_urls()
 
 
@@ -115,7 +110,6 @@ class SyncWebhookListener:
         uvicorn.run(app=self.app,
             host=self._host,
             port=self._port,
-            debug=self._debug,
             ssl_certfile=self._ssl_context[0],
             ssl_keyfile=self._ssl_context[1]
         )


### PR DESCRIPTION
## Description
`--debug` was removed from uvicorn. See #1767.

## Describe your tests
Untested; Just removed debug as a param since that was causing `TypeError: run() got an unexpected keyword argument 'debug'` when using `run_webhooks()`.

Python version: 3.9

## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [ ] My changes won't break backward compatibility
- [x] I made changes both for sync and async
