### PR TITLE
Bot API 6.3 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">A simple, but extensible Python implementation for the <a href="https://core.telegram.org/bots/api">Telegram Bot API</a>.</p>
 <p align="center">Both synchronous and asynchronous.</p>
 
-## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#august-12-2022">6.2</a>!
+## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#november-5-2022">6.3</a>!
 
 <h2><a href='https://pytba.readthedocs.io/en/latest/index.html'>Official documentation</a></h2>
 	

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1488,7 +1488,8 @@ class TeleBot:
             reply_to_message_id: Optional[int]=None, 
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
-            timeout: Optional[int]=None) -> types.Message:
+            timeout: Optional[int]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send text messages.
 
@@ -1532,6 +1533,9 @@ class TeleBot:
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
 
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -1545,13 +1549,14 @@ class TeleBot:
             apihelper.send_message(
                 self.token, chat_id, text, disable_web_page_preview, reply_to_message_id,
                 reply_markup, parse_mode, disable_notification, timeout,
-                entities, allow_sending_without_reply, protect_content=protect_content))
+                entities, allow_sending_without_reply, protect_content=protect_content, message_thread_id=message_thread_id))
 
     def forward_message(
             self, chat_id: Union[int, str], from_chat_id: Union[int, str], 
             message_id: int, disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            timeout: Optional[int]=None) -> types.Message:
+            timeout: Optional[int]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to forward messages of any kind.
 
@@ -1575,6 +1580,9 @@ class TeleBot:
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
 
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -1582,7 +1590,8 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
 
         return types.Message.de_json(
-            apihelper.forward_message(self.token, chat_id, from_chat_id, message_id, disable_notification, timeout, protect_content))
+            apihelper.forward_message(self.token, chat_id, from_chat_id, message_id, disable_notification, timeout, protect_content,
+                                      message_thread_id))
 
 
     def copy_message(
@@ -1597,7 +1606,8 @@ class TeleBot:
             reply_to_message_id: Optional[int]=None, 
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            timeout: Optional[int]=None) -> types.MessageID:
+            timeout: Optional[int]=None,
+            message_thread_id: Optional[int]=None) -> types.MessageID:
         """
         Use this method to copy messages of any kind.
 
@@ -1639,6 +1649,9 @@ class TeleBot:
 
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
+
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
         
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -1651,7 +1664,7 @@ class TeleBot:
         return types.MessageID.de_json(
             apihelper.copy_message(self.token, chat_id, from_chat_id, message_id, caption, parse_mode, caption_entities,
                                    disable_notification, reply_to_message_id, allow_sending_without_reply, reply_markup,
-                                   timeout, protect_content))
+                                   timeout, protect_content, message_thread_id))
 
     def delete_message(self, chat_id: Union[int, str], message_id: int, 
             timeout: Optional[int]=None) -> bool:
@@ -1689,7 +1702,8 @@ class TeleBot:
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send an animated emoji that will display a random value. On success, the sent Message is returned.
 
@@ -1722,6 +1736,9 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -1732,7 +1749,7 @@ class TeleBot:
         return types.Message.de_json(
             apihelper.send_dice(
                 self.token, chat_id, emoji, disable_notification, reply_to_message_id,
-                reply_markup, timeout, allow_sending_without_reply, protect_content)
+                reply_markup, timeout, allow_sending_without_reply, protect_content, message_thread_id)
         )
 
 
@@ -1745,7 +1762,8 @@ class TeleBot:
             reply_to_message_id: Optional[int]=None, 
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
-            timeout: Optional[int]=None,) -> types.Message:
+            timeout: Optional[int]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send photos. On success, the sent Message is returned.
 
@@ -1787,6 +1805,9 @@ class TeleBot:
 
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
+
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
         
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -1800,7 +1821,7 @@ class TeleBot:
             apihelper.send_photo(
                 self.token, chat_id, photo, caption, reply_to_message_id, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
-                allow_sending_without_reply, protect_content))
+                allow_sending_without_reply, protect_content, message_thread_id))
 
     # TODO: Rewrite this method like in API.
     def send_audio(
@@ -1815,7 +1836,8 @@ class TeleBot:
             thumb: Optional[Union[Any, str]]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player.
         Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size,
@@ -1876,6 +1898,9 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -1888,7 +1913,7 @@ class TeleBot:
             apihelper.send_audio(
                 self.token, chat_id, audio, caption, duration, performer, title, reply_to_message_id,
                 reply_markup, parse_mode, disable_notification, timeout, thumb,
-                caption_entities, allow_sending_without_reply, protect_content))
+                caption_entities, allow_sending_without_reply, protect_content, message_thread_id))
 
     # TODO: Rewrite this method like in API.
     def send_voice(
@@ -1901,7 +1926,8 @@ class TeleBot:
             timeout: Optional[int]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
         For this to work, your audio must be in an .OGG file encoded with OPUS (other formats may be sent as Audio or Document).
@@ -1948,6 +1974,9 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
@@ -1959,7 +1988,7 @@ class TeleBot:
             apihelper.send_voice(
                 self.token, chat_id, voice, caption, duration, reply_to_message_id, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
-                allow_sending_without_reply, protect_content))
+                allow_sending_without_reply, protect_content, message_thread_id))
 
     # TODO: Rewrite this method like in API.
     def send_document(
@@ -1976,7 +2005,7 @@ class TeleBot:
             visible_file_name: Optional[str]=None,
             disable_content_type_detection: Optional[bool]=None,
             data: Optional[Union[Any, str]]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None, message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send general files.
 
@@ -2030,6 +2059,9 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: The thread to which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2049,7 +2081,7 @@ class TeleBot:
                 disable_notification = disable_notification, timeout = timeout, caption = caption, thumb = thumb,
                 caption_entities = caption_entities, allow_sending_without_reply = allow_sending_without_reply,
                 disable_content_type_detection = disable_content_type_detection, visible_file_name = visible_file_name,
-                protect_content = protect_content))
+                protect_content = protect_content, message_thread_id = message_thread_id))
 
 
     # TODO: Rewrite this method like in API.
@@ -2062,7 +2094,8 @@ class TeleBot:
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content:Optional[bool]=None,
-            data: Union[Any, str]=None) -> types.Message:
+            data: Union[Any, str]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers.
         On success, the sent Message is returned.
@@ -2099,6 +2132,9 @@ class TeleBot:
         :param data: function typo miss compatibility: do not use it
         :type data: :obj:`str`
 
+        :param message_thread_id: The thread to which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2116,7 +2152,7 @@ class TeleBot:
                 reply_to_message_id=reply_to_message_id, reply_markup=reply_markup,
                 disable_notification=disable_notification, timeout=timeout, 
                 allow_sending_without_reply=allow_sending_without_reply,
-                protect_content=protect_content))
+                protect_content=protect_content, message_thread_id=message_thread_id))
 
     def send_video(
             self, chat_id: Union[int, str], video: Union[Any, str], 
@@ -2134,7 +2170,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
-            data: Optional[Union[Any, str]]=None) -> types.Message:
+            data: Optional[Union[Any, str]]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
         
@@ -2193,6 +2230,9 @@ class TeleBot:
         :param data: function typo miss compatibility: do not use it
         :type data: :obj:`str`
 
+        :param message_thread_id: Identifier of a message thread, in which the video will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2209,7 +2249,7 @@ class TeleBot:
             apihelper.send_video(
                 self.token, chat_id, video, duration, caption, reply_to_message_id, reply_markup,
                 parse_mode, supports_streaming, disable_notification, timeout, thumb, width, height,
-                caption_entities, allow_sending_without_reply, protect_content))
+                caption_entities, allow_sending_without_reply, protect_content, message_thread_id))
 
     def send_animation(
             self, chat_id: Union[int, str], animation: Union[Any, str], 
@@ -2225,7 +2265,8 @@ class TeleBot:
             reply_to_message_id: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            timeout: Optional[int]=None, ) -> types.Message:
+            timeout: Optional[int]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
@@ -2283,6 +2324,9 @@ class TeleBot:
         :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
         :type allow_sending_without_reply: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the video will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2295,7 +2339,7 @@ class TeleBot:
             apihelper.send_animation(
                 self.token, chat_id, animation, duration, caption, reply_to_message_id,
                 reply_markup, parse_mode, disable_notification, timeout, thumb,
-                caption_entities, allow_sending_without_reply, protect_content, width, height))
+                caption_entities, allow_sending_without_reply, protect_content, width, height, message_thread_id))
 
     # TODO: Rewrite this method like in API.
     def send_video_note(
@@ -2308,7 +2352,8 @@ class TeleBot:
             timeout: Optional[int]=None, 
             thumb: Optional[Union[Any, str]]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         As of v.4.0, Telegram clients support rounded square MPEG4 videos of up to 1 minute long.
         Use this method to send video messages. On success, the sent Message is returned.
@@ -2354,6 +2399,9 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the video note will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2364,7 +2412,7 @@ class TeleBot:
         return types.Message.de_json(
             apihelper.send_video_note(
                 self.token, chat_id, data, duration, length, reply_to_message_id, reply_markup,
-                disable_notification, timeout, thumb, allow_sending_without_reply, protect_content))
+                disable_notification, timeout, thumb, allow_sending_without_reply, protect_content, message_thread_id))
 
 
     def send_media_group(
@@ -2376,7 +2424,8 @@ class TeleBot:
             protect_content: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None, 
             timeout: Optional[int]=None,
-            allow_sending_without_reply: Optional[bool]=None) -> List[types.Message]:
+            allow_sending_without_reply: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> List[types.Message]:
         """
         Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files
         can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned.
@@ -2404,6 +2453,9 @@ class TeleBot:
         :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
         :type allow_sending_without_reply: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the media group will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, an array of Messages that were sent is returned.
         :rtype: List[types.Message]
         """
@@ -2413,7 +2465,7 @@ class TeleBot:
 
         result = apihelper.send_media_group(
             self.token, chat_id, media, disable_notification, reply_to_message_id, timeout, 
-            allow_sending_without_reply, protect_content)
+            allow_sending_without_reply, protect_content, message_thread_id)
         return [types.Message.de_json(msg) for msg in result]
 
     # TODO: Rewrite this method like in API.
@@ -2429,7 +2481,8 @@ class TeleBot:
             heading: Optional[int]=None, 
             proximity_alert_radius: Optional[int]=None, 
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send point on the map. On success, the sent Message is returned.
 
@@ -2476,6 +2529,9 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2488,7 +2544,7 @@ class TeleBot:
                 self.token, chat_id, latitude, longitude, live_period, 
                 reply_to_message_id, reply_markup, disable_notification, timeout, 
                 horizontal_accuracy, heading, proximity_alert_radius, 
-                allow_sending_without_reply, protect_content))
+                allow_sending_without_reply, protect_content, message_thread_id))
 
     def edit_message_live_location(
             self, latitude: float, longitude: float, 
@@ -2596,7 +2652,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             google_place_id: Optional[str]=None,
             google_place_type: Optional[str]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send information about a venue. On success, the sent Message is returned.
         
@@ -2651,6 +2708,9 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: The thread identifier of a message from which the reply will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2662,7 +2722,7 @@ class TeleBot:
             apihelper.send_venue(
                 self.token, chat_id, latitude, longitude, title, address, foursquare_id, foursquare_type,
                 disable_notification, reply_to_message_id, reply_markup, timeout,
-                allow_sending_without_reply, google_place_id, google_place_type, protect_content))
+                allow_sending_without_reply, google_place_id, google_place_type, protect_content, message_thread_id))
 
 
     # TODO: Rewrite this method like in API.
@@ -2675,7 +2735,7 @@ class TeleBot:
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None, message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send phone contacts. On success, the sent Message is returned.
 
@@ -2717,6 +2777,9 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: The thread identifier of a message from which the reply will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2728,7 +2791,7 @@ class TeleBot:
             apihelper.send_contact(
                 self.token, chat_id, phone_number, first_name, last_name, vcard,
                 disable_notification, reply_to_message_id, reply_markup, timeout,
-                allow_sending_without_reply, protect_content))
+                allow_sending_without_reply, protect_content, message_thread_id))
 
     def send_chat_action(
             self, chat_id: Union[int, str], action: str, timeout: Optional[int]=None) -> bool:
@@ -3643,7 +3706,8 @@ class TeleBot:
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Used to send the game.
 
@@ -3673,6 +3737,9 @@ class TeleBot:
         :param protect_content: Pass True, if content of the message needs to be protected from being viewed by the bot.
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: The identifier of a message thread, in which the game message will be sent.
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -3683,7 +3750,7 @@ class TeleBot:
         result = apihelper.send_game(
             self.token, chat_id, game_short_name, disable_notification,
             reply_to_message_id, reply_markup, timeout, 
-            allow_sending_without_reply, protect_content)
+            allow_sending_without_reply, protect_content, message_thread_id)
         return types.Message.de_json(result)
 
     def set_game_score(
@@ -3780,7 +3847,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             max_tip_amount: Optional[int] = None,
             suggested_tip_amounts: Optional[List[int]]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Sends invoice.
 
@@ -3879,6 +3947,9 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: The identifier of a message thread, in which the invoice message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -3892,7 +3963,7 @@ class TeleBot:
             photo_height, need_name, need_phone_number, need_email, need_shipping_address,
             send_phone_number_to_provider, send_email_to_provider, is_flexible, disable_notification,
             reply_to_message_id, reply_markup, provider_data, timeout, allow_sending_without_reply,
-            max_tip_amount, suggested_tip_amounts, protect_content)
+            max_tip_amount, suggested_tip_amounts, protect_content, message_thread_id)
         return types.Message.de_json(result)
 
     def create_invoice_link(self,
@@ -4016,7 +4087,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None, 
             timeout: Optional[int]=None,
             explanation_entities: Optional[List[types.MessageEntity]]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send a native poll.
         On success, the sent Message is returned.
@@ -4084,6 +4156,9 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: The identifier of a message thread, in which the poll will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -4103,7 +4178,7 @@ class TeleBot:
                 is_anonymous, type, allows_multiple_answers, correct_option_id,
                 explanation, explanation_parse_mode, open_period, close_date, is_closed,
                 disable_notification, reply_to_message_id, allow_sending_without_reply,
-                reply_markup, timeout, explanation_entities, protect_content))
+                reply_markup, timeout, explanation_entities, protect_content, message_thread_id))
 
     def stop_poll(
             self, chat_id: Union[int, str], message_id: int, 
@@ -4555,7 +4630,9 @@ class TeleBot:
         :return: On success, information about the created topic is returned as a ForumTopic object.
         :rtype: :class:`telebot.types.ForumTopic`
         """
-        return apihelper.create_forum_topic(self.token, chat_id, name, icon_color, icon_custom_emoji_id)
+        return types.ForumTopic(
+            apihelper.create_forum_topic(self.token, chat_id, name, icon_color, icon_custom_emoji_id)
+        )
 
     def edit_forum_topic(
             self, chat_id: Union[int, str],

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -2910,7 +2910,8 @@ class TeleBot:
             is_anonymous: Optional[bool]=None, 
             can_manage_chat: Optional[bool]=None, 
             can_manage_video_chats: Optional[bool]=None,
-            can_manage_voice_chats: Optional[bool]=None) -> bool:
+            can_manage_voice_chats: Optional[bool]=None,
+            can_manage_topics: Optional[bool]=None) -> bool:
         """
         Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator
         in the chat for this to work and must have the appropriate admin rights.
@@ -2967,6 +2968,10 @@ class TeleBot:
         :param can_manage_voice_chats: Deprecated, use can_manage_video_chats.
         :type can_manage_voice_chats: :obj:`bool`
 
+        :param can_manage_topics: Pass True if the user is allowed to create, rename, close,
+            and reopen forum topics, supergroups only
+        :type can_manage_topics: :obj:`bool`
+
         :return: True on success.
         :rtype: :obj:`bool`
         """
@@ -2979,7 +2984,7 @@ class TeleBot:
             self.token, chat_id, user_id, can_change_info, can_post_messages,
             can_edit_messages, can_delete_messages, can_invite_users,
             can_restrict_members, can_pin_messages, can_promote_members,
-            is_anonymous, can_manage_chat, can_manage_video_chats)
+            is_anonymous, can_manage_chat, can_manage_video_chats, can_manage_topics)
 
     def set_chat_administrator_custom_title(
             self, chat_id: Union[int, str], user_id: int, custom_title: str) -> bool:

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -4630,7 +4630,7 @@ class TeleBot:
         :return: On success, information about the created topic is returned as a ForumTopic object.
         :rtype: :class:`telebot.types.ForumTopic`
         """
-        return types.ForumTopic(
+        return types.ForumTopic.de_json(
             apihelper.create_forum_topic(self.token, chat_id, name, icon_color, icon_custom_emoji_id)
         )
 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -4530,6 +4530,150 @@ class TeleBot:
         """
         return apihelper.delete_sticker_from_set(self.token, sticker)
 
+    def create_forum_topic(self,
+            chat_id: int, name: str, icon_color: Optional[int]=None,
+            icon_custom_emoji_id: Optional[str]=None) -> types.ForumTopic:
+        """
+        Use this method to create a topic in a forum supergroup chat. The bot must be an administrator
+        in the chat for this to work and must have the can_manage_topics administrator rights.
+        Returns information about the created topic as a ForumTopic object.
+
+        Telegram documentation: https://core.telegram.org/bots/api#createforumtopic
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param name: Name of the topic, 1-128 characters
+        :type name: :obj:`str`
+
+        :param icon_color: Color of the topic icon in RGB format. Currently, must be one of 0x6FB9F0, 0xFFD67E, 0xCB86DB, 0x8EEE98, 0xFF93B2, or 0xFB6F5F
+        :type icon_color: :obj:`int`
+
+        :param icon_custom_emoji_id: Custom emoji for the topic icon. Must be an emoji of type “tgs” and must be exactly 1 character long
+        :type icon_custom_emoji_id: :obj:`str`
+
+        :return: On success, information about the created topic is returned as a ForumTopic object.
+        :rtype: :class:`telebot.types.ForumTopic`
+        """
+        return apihelper.create_forum_topic(self.token, chat_id, name, icon_color, icon_custom_emoji_id)
+
+    def edit_forum_topic(
+            self, chat_id: Union[int, str],
+            message_thread_id: int, name: str,
+            icon_custom_emoji_id: str,
+        ) -> bool:
+        """
+        Use this method to edit name and icon of a topic in a forum supergroup chat. The bot must be an
+        administrator in the chat for this to work and must have can_manage_topics administrator rights,
+        unless it is the creator of the topic. Returns True on success.
+
+        Telegram Documentation: https://core.telegram.org/bots/api#editforumtopic
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_thread_id: Identifier of the topic to edit
+        :type message_thread_id: :obj:`int`
+
+        :param name: New name of the topic, 1-128 characters
+        :type name: :obj:`str`
+
+        :param icon_custom_emoji_id: New custom emoji for the topic icon. Must be an emoji of type “tgs” and must be exactly 1 character long
+        :type icon_custom_emoji_id: :obj:`str`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.edit_forum_topic(self.token, chat_id, message_thread_id, name, icon_custom_emoji_id)
+
+    def close_forum_topic(self, chat_id: Union[str, int], message_thread_id: int) -> bool:
+        """
+        Use this method to close an open topic in a forum supergroup chat. The bot must be an administrator
+        in the chat for this to work and must have the can_manage_topics administrator rights, unless it is
+        the creator of the topic. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#closeforumtopic
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_thread_id: Identifier of the topic to close
+        :type message_thread_id: :obj:`int`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.close_forum_topic(self.token, chat_id, message_thread_id)
+
+    def reopen_forum_topic(self, chat_id: Union[str, int], message_thread_id: int) -> bool:
+        """
+        Use this method to reopen a closed topic in a forum supergroup chat. The bot must be an administrator in the chat
+        for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic.
+        Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#reopenforumtopic
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_thread_id: Identifier of the topic to reopen
+        :type message_thread_id: :obj:`int`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.reopen_forum_topic(self.token, chat_id, message_thread_id)
+
+    def delete_forum_topic(self, chat_id: Union[str, int], message_thread_id: int) -> bool:
+        """
+        Use this method to delete a topic in a forum supergroup chat. The bot must be an administrator in the chat for this
+        to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic. Returns True
+        on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#deleteforumtopic
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_thread_id: Identifier of the topic to delete
+        :type message_thread_id: :obj:`int`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.delete_forum_topic(self.token, chat_id, message_thread_id)
+
+    def unpin_all_forum_topic_messages(self, chat_id: Union[str, int], message_thread_id: int) -> bool:
+        """
+        Use this method to clear the list of pinned messages in a forum topic. The bot must be an administrator in the
+        chat for this to work and must have the can_pin_messages administrator right in the supergroup.
+        Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#unpinallforumtopicmessages
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_thread_id: Identifier of the topic
+        :type message_thread_id: :obj:`int`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.unpin_all_forum_topic_messages(self.token, chat_id, message_thread_id)
+
+    def get_forum_topic_icon_stickers(self) -> List[types.Sticker]:
+        """
+        Use this method to get custom emoji stickers, which can be used as a forum topic icon by any user.
+        Requires no parameters. Returns an Array of Sticker objects.
+
+        Telegram documentation: https://core.telegram.org/bots/api#getforumtopiciconstickers
+
+        :return: On success, a list of StickerSet objects is returned.
+        :rtype: List[:class:`telebot.types.StickerSet`]
+        """
+        return apihelper.get_forum_topic_icon_stickers(self.token)
+
     def answer_web_app_query(self, web_app_query_id: str, result: types.InlineQueryResultBase) -> types.SentWebAppMessage:
         """
         Use this method to set the result of an interaction with a Web App and
@@ -6009,7 +6153,7 @@ class TeleBot:
             class TextMatchFilter(AdvancedCustomFilter):
                 key = 'text'
 
-                async def check(self, message, text):
+                def check(self, message, text):
                     return text == message.text
 
         :param custom_filter: Class with check(message) method.

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -977,7 +977,8 @@ def promote_chat_member(
         token, chat_id, user_id, can_change_info=None, can_post_messages=None,
         can_edit_messages=None, can_delete_messages=None, can_invite_users=None,
         can_restrict_members=None, can_pin_messages=None, can_promote_members=None,
-        is_anonymous=None, can_manage_chat=None, can_manage_video_chats=None):
+        is_anonymous=None, can_manage_chat=None, can_manage_video_chats=None,
+        can_manage_topics=None):
     method_url = 'promoteChatMember'
     payload = {'chat_id': chat_id, 'user_id': user_id}
     if can_change_info is not None:
@@ -1002,6 +1003,8 @@ def promote_chat_member(
         payload['can_manage_chat'] = can_manage_chat
     if can_manage_video_chats is not None:
         payload['can_manage_video_chats'] = can_manage_video_chats
+    if can_manage_topics is not None:
+        payload['can_manage_topics'] = can_manage_topics
     return _make_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -237,23 +237,8 @@ def send_message(
         token, chat_id, text,
         disable_web_page_preview=None, reply_to_message_id=None, reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
-        entities=None, allow_sending_without_reply=None, protect_content=None):
-    """
-    Use this method to send text messages. On success, the sent Message is returned.
-    :param token:
-    :param chat_id:
-    :param text:
-    :param disable_web_page_preview:
-    :param reply_to_message_id:
-    :param reply_markup:
-    :param parse_mode:
-    :param disable_notification:
-    :param timeout:
-    :param entities:
-    :param allow_sending_without_reply:
-    :param protect_content:
-    :return:
-    """
+        entities=None, allow_sending_without_reply=None, protect_content=None,
+        message_thread_id=None):
     method_url = r'sendMessage'
     payload = {'chat_id': str(chat_id), 'text': text}
     if disable_web_page_preview is not None:
@@ -274,6 +259,8 @@ def send_message(
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload, method='post')
 
 
@@ -400,7 +387,7 @@ def get_chat_member(token, chat_id, user_id):
 
 def forward_message(
         token, chat_id, from_chat_id, message_id,
-        disable_notification=None, timeout=None, protect_content=None):
+        disable_notification=None, timeout=None, protect_content=None, message_thread_id=None):
     method_url = r'forwardMessage'
     payload = {'chat_id': chat_id, 'from_chat_id': from_chat_id, 'message_id': message_id}
     if disable_notification is not None:
@@ -409,12 +396,14 @@ def forward_message(
         payload['timeout'] = timeout
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload)
 
 
 def copy_message(token, chat_id, from_chat_id, message_id, caption=None, parse_mode=None, caption_entities=None,
                  disable_notification=None, reply_to_message_id=None, allow_sending_without_reply=None,
-                 reply_markup=None, timeout=None, protect_content=None):
+                 reply_markup=None, timeout=None, protect_content=None, message_thread_id=None):
     method_url = r'copyMessage'
     payload = {'chat_id': chat_id, 'from_chat_id': from_chat_id, 'message_id': message_id}
     if caption is not None:
@@ -435,13 +424,15 @@ def copy_message(token, chat_id, from_chat_id, message_id, caption=None, parse_m
         payload['timeout'] = timeout
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload)
 
 
 def send_dice(
         token, chat_id,
         emoji=None, disable_notification=None, reply_to_message_id=None,
-        reply_markup=None, timeout=None, allow_sending_without_reply=None, protect_content=None):
+        reply_markup=None, timeout=None, allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
     method_url = r'sendDice'
     payload = {'chat_id': chat_id}
     if emoji:
@@ -458,6 +449,8 @@ def send_dice(
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload)
 
 
@@ -465,7 +458,8 @@ def send_photo(
         token, chat_id, photo,
         caption=None, reply_to_message_id=None, reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
-        caption_entities=None, allow_sending_without_reply=None, protect_content=None):
+        caption_entities=None, allow_sending_without_reply=None, protect_content=None,
+        message_thread_id=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None
@@ -493,13 +487,15 @@ def send_photo(
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_media_group(
         token, chat_id, media,
         disable_notification=None, reply_to_message_id=None,
-        timeout=None, allow_sending_without_reply=None, protect_content=None):
+        timeout=None, allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
     method_url = r'sendMediaGroup'
     media_json, files = convert_input_media_array(media)
     payload = {'chat_id': chat_id, 'media': media_json}
@@ -513,6 +509,8 @@ def send_media_group(
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(
         token, method_url, params=payload,
         method='post' if files else 'get',
@@ -524,7 +522,8 @@ def send_location(
         live_period=None, reply_to_message_id=None, 
         reply_markup=None, disable_notification=None, 
         timeout=None, horizontal_accuracy=None, heading=None,
-        proximity_alert_radius=None, allow_sending_without_reply=None, protect_content=None):
+        proximity_alert_radius=None, allow_sending_without_reply=None, protect_content=None,
+        message_thread_id=None):
     method_url = r'sendLocation'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude}
     if live_period:
@@ -547,6 +546,8 @@ def send_location(
         payload['timeout'] = timeout
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload)
 
 
@@ -598,7 +599,7 @@ def send_venue(
         foursquare_id=None, foursquare_type=None, disable_notification=None,
         reply_to_message_id=None, reply_markup=None, timeout=None,
         allow_sending_without_reply=None, google_place_id=None,
-        google_place_type=None, protect_content=None):
+        google_place_type=None, protect_content=None, message_thread_id=None):
     method_url = r'sendVenue'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude, 'title': title, 'address': address}
     if foursquare_id:
@@ -621,13 +622,15 @@ def send_venue(
         payload['google_place_type'] = google_place_type
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload)
 
 
 def send_contact(
         token, chat_id, phone_number, first_name, last_name=None, vcard=None,
         disable_notification=None, reply_to_message_id=None, reply_markup=None, timeout=None,
-        allow_sending_without_reply=None, protect_content=None):
+        allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
     method_url = r'sendContact'
     payload = {'chat_id': chat_id, 'phone_number': phone_number, 'first_name': first_name}
     if last_name:
@@ -646,6 +649,8 @@ def send_contact(
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
 
     return _make_request(token, method_url, params=payload)
 
@@ -660,7 +665,8 @@ def send_chat_action(token, chat_id, action, timeout=None):
 
 def send_video(token, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
                parse_mode=None, supports_streaming=None, disable_notification=None, timeout=None, 
-               thumb=None, width=None, height=None, caption_entities=None, allow_sending_without_reply=None, protect_content=None):
+               thumb=None, width=None, height=None, caption_entities=None, allow_sending_without_reply=None, protect_content=None,
+               message_thread_id=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -702,13 +708,15 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_to_messa
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_animation(
         token, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None, thumb=None, caption_entities=None,
-        allow_sending_without_reply=None, protect_content=None, width=None, height=None):
+        allow_sending_without_reply=None, protect_content=None, width=None, height=None, message_thread_id=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}
     files = None
@@ -748,12 +756,14 @@ def send_animation(
         payload['width'] = width
     if height:
         payload['height'] = height
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_voice(token, chat_id, voice, caption=None, duration=None, reply_to_message_id=None, reply_markup=None,
                parse_mode=None, disable_notification=None, timeout=None, caption_entities=None,
-               allow_sending_without_reply=None, protect_content=None):
+               allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
     method_url = r'sendVoice'
     payload = {'chat_id': chat_id}
     files = None
@@ -781,11 +791,14 @@ def send_voice(token, chat_id, voice, caption=None, duration=None, reply_to_mess
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_message_id=None, reply_markup=None,
-                    disable_notification=None, timeout=None, thumb=None, allow_sending_without_reply=None, protect_content=None):
+                    disable_notification=None, timeout=None, thumb=None, allow_sending_without_reply=None, protect_content=None,
+                    message_thread_id=None):
     method_url = r'sendVideoNote'
     payload = {'chat_id': chat_id}
     files = None
@@ -819,12 +832,14 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_m
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None, reply_to_message_id=None,
                reply_markup=None, parse_mode=None, disable_notification=None, timeout=None, thumb=None,
-               caption_entities=None, allow_sending_without_reply=None, protect_content=None):
+               caption_entities=None, allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
     method_url = r'sendAudio'
     payload = {'chat_id': chat_id}
     files = None
@@ -864,13 +879,15 @@ def send_audio(token, chat_id, audio, caption=None, duration=None, performer=Non
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_markup=None, parse_mode=None,
               disable_notification=None, timeout=None, caption=None, thumb=None, caption_entities=None,
               allow_sending_without_reply=None, disable_content_type_detection=None, visible_file_name=None,
-              protect_content = None):
+              protect_content = None, message_thread_id=None):
     method_url = get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None
@@ -909,6 +926,8 @@ def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_m
         payload['protect_content'] = protect_content
     if method_url == 'sendDocument' and disable_content_type_detection is not None:
         payload['disable_content_type_detection'] = disable_content_type_detection
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1317,7 +1336,7 @@ def delete_message(token, chat_id, message_id, timeout=None):
 def send_game(
         token, chat_id, game_short_name,
         disable_notification=None, reply_to_message_id=None, reply_markup=None, timeout=None,
-        allow_sending_without_reply=None, protect_content=None):
+        allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
     method_url = r'sendGame'
     payload = {'chat_id': chat_id, 'game_short_name': game_short_name}
     if disable_notification is not None:
@@ -1332,6 +1351,8 @@ def send_game(
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload)
 
 
@@ -1397,7 +1418,7 @@ def send_invoice(
         send_phone_number_to_provider = None, send_email_to_provider = None, is_flexible=None,
         disable_notification=None, reply_to_message_id=None, reply_markup=None, provider_data=None,
         timeout=None, allow_sending_without_reply=None, max_tip_amount=None, suggested_tip_amounts=None,
-        protect_content=None):
+        protect_content=None, message_thread_id=None):
     """
     Use this method to send invoices. On success, the sent Message is returned.
     :param token: Bot's token (you don't need to fill this)
@@ -1478,6 +1499,8 @@ def send_invoice(
         payload['suggested_tip_amounts'] = json.dumps(suggested_tip_amounts)
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload)
 
 
@@ -1686,7 +1709,7 @@ def send_poll(
         is_anonymous = None, type = None, allows_multiple_answers = None, correct_option_id = None,
         explanation = None, explanation_parse_mode=None, open_period = None, close_date = None, is_closed = None,
         disable_notification=False, reply_to_message_id=None, allow_sending_without_reply=None,
-        reply_markup=None, timeout=None, explanation_entities=None, protect_content=None):
+        reply_markup=None, timeout=None, explanation_entities=None, protect_content=None, message_thread_id=None):
     method_url = r'sendPoll'
     payload = {
         'chat_id': str(chat_id),
@@ -1730,6 +1753,8 @@ def send_poll(
             types.MessageEntity.to_list_of_dicts(explanation_entities))
     if protect_content:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload)
 
 def create_forum_topic(token, chat_id, name, icon_color=None, icon_custom_emoji_id=None):

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1732,6 +1732,43 @@ def send_poll(
         payload['protect_content'] = protect_content
     return _make_request(token, method_url, params=payload)
 
+def create_forum_topic(token, chat_id, name, icon_color=None, icon_custom_emoji_id=None):
+    method_url = r'createForumTopic'
+    payload = {'chat_id': chat_id, 'name': name}
+    if icon_color:
+        payload['icon_color'] = icon_color
+    if icon_custom_emoji_id:
+        payload['icon_custom_emoji_id'] = icon_custom_emoji_id
+    return _make_request(token, method_url, params=payload)
+
+def edit_forum_topic(token, chat_id, message_thread_id, name, icon_custom_emoji_id):
+    method_url = r'editForumTopic'
+    payload = {'chat_id': chat_id, 'message_thread_id': message_thread_id, 'name': name, 'icon_custom_emoji_id': icon_custom_emoji_id}
+    return _make_request(token, method_url, params=payload)
+
+def close_forum_topic(token, chat_id, message_thread_id):
+    method_url = r'closeForumTopic'
+    payload = {'chat_id': chat_id, 'message_thread_id': message_thread_id}
+    return _make_request(token, method_url, params=payload)
+
+def reopen_forum_topic(token, chat_id, message_thread_id):
+    method_url = r'reopenForumTopic'
+    payload = {'chat_id': chat_id, 'message_thread_id': message_thread_id}
+    return _make_request(token, method_url, params=payload)
+
+def delete_forum_topic(token, chat_id, message_thread_id):
+    method_url = r'deleteForumTopic'
+    payload = {'chat_id': chat_id, 'message_thread_id': message_thread_id}
+    return _make_request(token, method_url, params=payload)
+
+def unpin_all_forum_topic_messages(token, chat_id, message_thread_id):
+    method_url = r'unpinAllForumTopicMessages'
+    payload = {'chat_id': chat_id, 'message_thread_id': message_thread_id}
+    return _make_request(token, method_url, params=payload)
+
+def get_forum_topic_icon_stickers(token):
+    method_url = r'getForumTopicIconStickers'
+    return _make_request(token, method_url)
 
 def stop_poll(token, chat_id, message_id, reply_markup=None):
     method_url = r'stopPoll'

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -2340,7 +2340,8 @@ class AsyncTeleBot:
             reply_to_message_id: Optional[int]=None, 
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
-            timeout: Optional[int]=None) -> types.Message:
+            timeout: Optional[int]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send text messages.
 
@@ -2384,6 +2385,9 @@ class AsyncTeleBot:
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
 
+        :param message_thread_id: Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2397,13 +2401,14 @@ class AsyncTeleBot:
             await asyncio_helper.send_message(
                 self.token, chat_id, text, disable_web_page_preview, reply_to_message_id,
                 reply_markup, parse_mode, disable_notification, timeout,
-                entities, allow_sending_without_reply, protect_content))
+                entities, allow_sending_without_reply, protect_content, message_thread_id))
 
     async def forward_message(
             self, chat_id: Union[int, str], from_chat_id: Union[int, str], 
             message_id: int, disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            timeout: Optional[int]=None) -> types.Message:
+            timeout: Optional[int]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to forward messages of any kind.
 
@@ -2427,6 +2432,9 @@ class AsyncTeleBot:
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
 
+        :param message_thread_id: Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2434,7 +2442,8 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
 
         return types.Message.de_json(
-            await asyncio_helper.forward_message(self.token, chat_id, from_chat_id, message_id, disable_notification, timeout, protect_content))
+            await asyncio_helper.forward_message(self.token, chat_id, from_chat_id, message_id, disable_notification, timeout, protect_content,
+                                                 message_thread_id))
 
     async def copy_message(
             self, chat_id: Union[int, str], 
@@ -2448,7 +2457,8 @@ class AsyncTeleBot:
             reply_to_message_id: Optional[int]=None, 
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            timeout: Optional[int]=None) -> types.MessageID:
+            timeout: Optional[int]=None,
+            message_thread_id: Optional[int]=None) -> types.MessageID:
         """
         Use this method to copy messages of any kind.
 
@@ -2490,6 +2500,9 @@ class AsyncTeleBot:
 
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
+
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
         
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -2502,7 +2515,7 @@ class AsyncTeleBot:
         return types.MessageID.de_json(
             await asyncio_helper.copy_message(self.token, chat_id, from_chat_id, message_id, caption, parse_mode, caption_entities,
                                    disable_notification, reply_to_message_id, allow_sending_without_reply, reply_markup,
-                                   timeout, protect_content))
+                                   timeout, protect_content, message_thread_id))
 
     async def delete_message(self, chat_id: Union[int, str], message_id: int, 
             timeout: Optional[int]=None) -> bool:
@@ -2540,7 +2553,8 @@ class AsyncTeleBot:
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send an animated emoji that will display a random value. On success, the sent Message is returned.
 
@@ -2573,6 +2587,9 @@ class AsyncTeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: The identifier of a message thread, unique within the chat to which the message with the thread identifier belongs
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2583,7 +2600,7 @@ class AsyncTeleBot:
         return types.Message.de_json(
             await asyncio_helper.send_dice(
                 self.token, chat_id, emoji, disable_notification, reply_to_message_id,
-                reply_markup, timeout, allow_sending_without_reply, protect_content)
+                reply_markup, timeout, allow_sending_without_reply, protect_content, message_thread_id)
         )
 
     async def send_photo(
@@ -2595,7 +2612,8 @@ class AsyncTeleBot:
             reply_to_message_id: Optional[int]=None, 
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
-            timeout: Optional[int]=None,) -> types.Message:
+            timeout: Optional[int]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send photos. On success, the sent Message is returned.
 
@@ -2637,6 +2655,9 @@ class AsyncTeleBot:
 
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
+
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
         
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -2650,7 +2671,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_photo(
                 self.token, chat_id, photo, caption, reply_to_message_id, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
-                allow_sending_without_reply, protect_content))
+                allow_sending_without_reply, protect_content, message_thread_id))
 
     async def send_audio(
             self, chat_id: Union[int, str], audio: Union[Any, str], 
@@ -2664,7 +2685,8 @@ class AsyncTeleBot:
             thumb: Optional[Union[Any, str]]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player.
         Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size,
@@ -2725,6 +2747,9 @@ class AsyncTeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2737,7 +2762,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_audio(
                 self.token, chat_id, audio, caption, duration, performer, title, reply_to_message_id,
                 reply_markup, parse_mode, disable_notification, timeout, thumb,
-                caption_entities, allow_sending_without_reply, protect_content))
+                caption_entities, allow_sending_without_reply, protect_content, message_thread_id))
 
     async def send_voice(
             self, chat_id: Union[int, str], voice: Union[Any, str], 
@@ -2749,7 +2774,8 @@ class AsyncTeleBot:
             timeout: Optional[int]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
         For this to work, your audio must be in an .OGG file encoded with OPUS (other formats may be sent as Audio or Document).
@@ -2796,6 +2822,9 @@ class AsyncTeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
@@ -2807,7 +2836,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_voice(
                 self.token, chat_id, voice, caption, duration, reply_to_message_id, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
-                allow_sending_without_reply, protect_content))
+                allow_sending_without_reply, protect_content, message_thread_id))
 
     async def send_document(
             self, chat_id: Union[int, str], document: Union[Any, str],
@@ -2823,7 +2852,8 @@ class AsyncTeleBot:
             visible_file_name: Optional[str]=None,
             disable_content_type_detection: Optional[bool]=None,
             data: Optional[Union[Any, str]]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send general files.
 
@@ -2877,6 +2907,9 @@ class AsyncTeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2895,7 +2928,8 @@ class AsyncTeleBot:
                 reply_to_message_id = reply_to_message_id, reply_markup = reply_markup, parse_mode = parse_mode,
                 disable_notification = disable_notification, timeout = timeout, caption = caption, thumb = thumb,
                 caption_entities = caption_entities, allow_sending_without_reply = allow_sending_without_reply,
-                disable_content_type_detection = disable_content_type_detection, visible_file_name = visible_file_name, protect_content = protect_content))
+                disable_content_type_detection = disable_content_type_detection, visible_file_name = visible_file_name, protect_content = protect_content,
+                message_thread_id = message_thread_id))
 
     async def send_sticker(
             self, chat_id: Union[int, str], sticker: Union[Any, str], 
@@ -2905,7 +2939,8 @@ class AsyncTeleBot:
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            data: Union[Any, str]=None) -> types.Message:
+            data: Union[Any, str]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers.
         On success, the sent Message is returned.
@@ -2942,6 +2977,9 @@ class AsyncTeleBot:
         :param data: function typo miss compatibility: do not use it
         :type data: :obj:`str`
 
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2959,7 +2997,8 @@ class AsyncTeleBot:
                 self.token, chat_id, sticker, 'sticker',
                 reply_to_message_id=reply_to_message_id, reply_markup=reply_markup,
                 disable_notification=disable_notification, timeout=timeout, 
-                allow_sending_without_reply=allow_sending_without_reply, protect_content=protect_content))
+                allow_sending_without_reply=allow_sending_without_reply, protect_content=protect_content,
+                message_thread_id=message_thread_id))
 
     async def send_video(
             self, chat_id: Union[int, str], video: Union[Any, str], 
@@ -2977,7 +3016,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
-            data: Optional[Union[Any, str]]=None) -> types.Message:
+            data: Optional[Union[Any, str]]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
         
@@ -3036,6 +3076,9 @@ class AsyncTeleBot:
         :param data: function typo miss compatibility: do not use it
         :type data: :obj:`str`
 
+        :param message_thread_id: Identifier of a message thread, in which the video will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3053,7 +3096,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_video(
                 self.token, chat_id, video, duration, caption, reply_to_message_id, reply_markup,
                 parse_mode, supports_streaming, disable_notification, timeout, thumb, width, height,
-                caption_entities, allow_sending_without_reply, protect_content))
+                caption_entities, allow_sending_without_reply, protect_content, message_thread_id))
 
     async def send_animation(
             self, chat_id: Union[int, str], animation: Union[Any, str], 
@@ -3069,7 +3112,8 @@ class AsyncTeleBot:
             reply_to_message_id: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            timeout: Optional[int]=None, ) -> types.Message:
+            timeout: Optional[int]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
@@ -3127,6 +3171,9 @@ class AsyncTeleBot:
         :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
         :type allow_sending_without_reply: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the video will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3139,7 +3186,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_animation(
                 self.token, chat_id, animation, duration, caption, reply_to_message_id,
                 reply_markup, parse_mode, disable_notification, timeout, thumb,
-                caption_entities, allow_sending_without_reply, width, height, protect_content))
+                caption_entities, allow_sending_without_reply, width, height, protect_content, message_thread_id))
 
     async def send_video_note(
             self, chat_id: Union[int, str], data: Union[Any, str], 
@@ -3151,7 +3198,8 @@ class AsyncTeleBot:
             timeout: Optional[int]=None, 
             thumb: Optional[Union[Any, str]]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         As of v.4.0, Telegram clients support rounded square MPEG4 videos of up to 1 minute long.
         Use this method to send video messages. On success, the sent Message is returned.
@@ -3197,6 +3245,9 @@ class AsyncTeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the video note will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3207,7 +3258,7 @@ class AsyncTeleBot:
         return types.Message.de_json(
             await asyncio_helper.send_video_note(
                 self.token, chat_id, data, duration, length, reply_to_message_id, reply_markup,
-                disable_notification, timeout, thumb, allow_sending_without_reply, protect_content))
+                disable_notification, timeout, thumb, allow_sending_without_reply, protect_content, message_thread_id))
 
     async def send_media_group(
             self, chat_id: Union[int, str], 
@@ -3218,7 +3269,8 @@ class AsyncTeleBot:
             protect_content: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None, 
             timeout: Optional[int]=None,
-            allow_sending_without_reply: Optional[bool]=None) -> List[types.Message]:
+            allow_sending_without_reply: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> List[types.Message]:
         """
         Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files
         can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned.
@@ -3246,6 +3298,9 @@ class AsyncTeleBot:
         :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
         :type allow_sending_without_reply: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the messages will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, an array of Messages that were sent is returned.
         :rtype: List[types.Message]
         """
@@ -3255,7 +3310,7 @@ class AsyncTeleBot:
 
         result = await asyncio_helper.send_media_group(
             self.token, chat_id, media, disable_notification, reply_to_message_id, timeout, 
-            allow_sending_without_reply, protect_content)
+            allow_sending_without_reply, protect_content, message_thread_id)
         return [types.Message.de_json(msg) for msg in result]
 
     async def send_location(
@@ -3270,7 +3325,8 @@ class AsyncTeleBot:
             heading: Optional[int]=None, 
             proximity_alert_radius: Optional[int]=None, 
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send point on the map. On success, the sent Message is returned.
 
@@ -3317,6 +3373,9 @@ class AsyncTeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: Identifier of a message thread, in which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3329,7 +3388,7 @@ class AsyncTeleBot:
                 self.token, chat_id, latitude, longitude, live_period, 
                 reply_to_message_id, reply_markup, disable_notification, timeout, 
                 horizontal_accuracy, heading, proximity_alert_radius, 
-                allow_sending_without_reply, protect_content))
+                allow_sending_without_reply, protect_content, message_thread_id))
 
     async def edit_message_live_location(
             self, latitude: float, longitude: float, 
@@ -3436,7 +3495,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             google_place_id: Optional[str]=None,
             google_place_type: Optional[str]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send information about a venue. On success, the sent Message is returned.
         
@@ -3491,6 +3551,9 @@ class AsyncTeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: The thread to which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3502,7 +3565,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_venue(
                 self.token, chat_id, latitude, longitude, title, address, foursquare_id, foursquare_type,
                 disable_notification, reply_to_message_id, reply_markup, timeout,
-                allow_sending_without_reply, google_place_id, google_place_type, protect_content)
+                allow_sending_without_reply, google_place_id, google_place_type, protect_content, message_thread_id)
         )
 
     async def send_contact(
@@ -3514,7 +3577,8 @@ class AsyncTeleBot:
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send phone contacts. On success, the sent Message is returned.
 
@@ -3556,6 +3620,9 @@ class AsyncTeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: The thread to which the message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3567,7 +3634,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_contact(
                 self.token, chat_id, phone_number, first_name, last_name, vcard,
                 disable_notification, reply_to_message_id, reply_markup, timeout,
-                allow_sending_without_reply, protect_content)
+                allow_sending_without_reply, protect_content, message_thread_id)
         )
 
     async def send_chat_action(
@@ -4491,7 +4558,8 @@ class AsyncTeleBot:
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Used to send the game.
 
@@ -4521,6 +4589,9 @@ class AsyncTeleBot:
         :param protect_content: Pass True, if content of the message needs to be protected from being viewed by the bot.
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: Identifier of the thread to which the message will be sent.
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -4531,7 +4602,7 @@ class AsyncTeleBot:
         result = await asyncio_helper.send_game(
             self.token, chat_id, game_short_name, disable_notification,
             reply_to_message_id, reply_markup, timeout, 
-            allow_sending_without_reply, protect_content)
+            allow_sending_without_reply, protect_content, message_thread_id)
         return types.Message.de_json(result)
 
     async def set_game_score(
@@ -4627,7 +4698,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             max_tip_amount: Optional[int] = None,
             suggested_tip_amounts: Optional[List[int]]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Sends invoice.
 
@@ -4726,6 +4798,9 @@ class AsyncTeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: The identifier of a message thread, in which the invoice message will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -4739,7 +4814,7 @@ class AsyncTeleBot:
             photo_height, need_name, need_phone_number, need_email, need_shipping_address,
             send_phone_number_to_provider, send_email_to_provider, is_flexible, disable_notification,
             reply_to_message_id, reply_markup, provider_data, timeout, allow_sending_without_reply,
-            max_tip_amount, suggested_tip_amounts, protect_content)
+            max_tip_amount, suggested_tip_amounts, protect_content, message_thread_id)
         return types.Message.de_json(result)
 
 
@@ -4863,7 +4938,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None, 
             timeout: Optional[int]=None,
             explanation_entities: Optional[List[types.MessageEntity]]=None,
-            protect_content: Optional[bool]=None) -> types.Message:
+            protect_content: Optional[bool]=None,
+            message_thread_id: Optional[int]=None) -> types.Message:
         """
         Use this method to send a native poll.
         On success, the sent Message is returned.
@@ -4931,6 +5007,9 @@ class AsyncTeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
+        :param message_thread_id: The identifier of a message thread, in which the poll will be sent
+        :type message_thread_id: :obj:`int`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -4949,7 +5028,7 @@ class AsyncTeleBot:
                 is_anonymous, type, allows_multiple_answers, correct_option_id,
                 explanation, explanation_parse_mode, open_period, close_date, is_closed,
                 disable_notification, reply_to_message_id, allow_sending_without_reply,
-                reply_markup, timeout, explanation_entities, protect_content))
+                reply_markup, timeout, explanation_entities, protect_content, message_thread_id))
 
     async def stop_poll(
             self, chat_id: Union[int, str], message_id: int, 
@@ -5403,7 +5482,9 @@ class AsyncTeleBot:
         :return: On success, information about the created topic is returned as a ForumTopic object.
         :rtype: :class:`telebot.types.ForumTopic`
         """
-        return await asyncio_helper.create_forum_topic(self.token, chat_id, name, icon_color, icon_custom_emoji_id)
+        return types.ForumTopic.de_json(
+            await asyncio_helper.create_forum_topic(self.token, chat_id, name, icon_color, icon_custom_emoji_id)
+        )
 
     async def edit_forum_topic(
             self, chat_id: Union[int, str],

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -3750,7 +3750,8 @@ class AsyncTeleBot:
             is_anonymous: Optional[bool]=None, 
             can_manage_chat: Optional[bool]=None, 
             can_manage_video_chats: Optional[bool]=None,
-            can_manage_voice_chats: Optional[bool]=None) -> bool:
+            can_manage_voice_chats: Optional[bool]=None,
+            can_manage_topics: Optional[bool]=None) -> bool:
         """
         Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator
         in the chat for this to work and must have the appropriate admin rights.
@@ -3807,6 +3808,10 @@ class AsyncTeleBot:
         :param can_manage_voice_chats: Deprecated, use can_manage_video_chats.
         :type can_manage_voice_chats: :obj:`bool`
 
+        :param can_manage_topics: Pass True if the user is allowed to create, rename, close,
+            and reopen forum topics, supergroups only
+        :type can_manage_topics: :obj:`bool`
+
         :return: True on success.
         :rtype: :obj:`bool`
         """
@@ -3820,7 +3825,7 @@ class AsyncTeleBot:
             self.token, chat_id, user_id, can_change_info, can_post_messages,
             can_edit_messages, can_delete_messages, can_invite_users,
             can_restrict_members, can_pin_messages, can_promote_members,
-            is_anonymous, can_manage_chat, can_manage_video_chats)
+            is_anonymous, can_manage_chat, can_manage_video_chats, can_manage_topics)
 
     async def set_chat_administrator_custom_title(
             self, chat_id: Union[int, str], user_id: int, custom_title: str) -> bool:

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -5378,6 +5378,149 @@ class AsyncTeleBot:
         """
         return await asyncio_helper.delete_sticker_from_set(self.token, sticker)
 
+    async def create_forum_topic(self,
+            chat_id: int, name: str, icon_color: Optional[int]=None,
+            icon_custom_emoji_id: Optional[str]=None) -> types.ForumTopic:
+        """
+        Use this method to create a topic in a forum supergroup chat. The bot must be an administrator
+        in the chat for this to work and must have the can_manage_topics administrator rights.
+        Returns information about the created topic as a ForumTopic object.
+
+        Telegram documentation: https://core.telegram.org/bots/api#createforumtopic
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param name: Name of the topic, 1-128 characters
+        :type name: :obj:`str`
+
+        :param icon_color: Color of the topic icon in RGB format. Currently, must be one of 0x6FB9F0, 0xFFD67E, 0xCB86DB, 0x8EEE98, 0xFF93B2, or 0xFB6F5F
+        :type icon_color: :obj:`int`
+
+        :param icon_custom_emoji_id: Custom emoji for the topic icon. Must be an emoji of type “tgs” and must be exactly 1 character long
+        :type icon_custom_emoji_id: :obj:`str`
+
+        :return: On success, information about the created topic is returned as a ForumTopic object.
+        :rtype: :class:`telebot.types.ForumTopic`
+        """
+        return await asyncio_helper.create_forum_topic(self.token, chat_id, name, icon_color, icon_custom_emoji_id)
+
+    async def edit_forum_topic(
+            self, chat_id: Union[int, str],
+            message_thread_id: int, name: str,
+            icon_custom_emoji_id: str,
+        ) -> bool:
+        """
+        Use this method to edit name and icon of a topic in a forum supergroup chat. The bot must be an
+        administrator in the chat for this to work and must have can_manage_topics administrator rights,
+        unless it is the creator of the topic. Returns True on success.
+
+        Telegram Documentation: https://core.telegram.org/bots/api#editforumtopic
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_thread_id: Identifier of the topic to edit
+        :type message_thread_id: :obj:`int`
+
+        :param name: New name of the topic, 1-128 characters
+        :type name: :obj:`str`
+
+        :param icon_custom_emoji_id: New custom emoji for the topic icon. Must be an emoji of type “tgs” and must be exactly 1 character long
+        :type icon_custom_emoji_id: :obj:`str`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.edit_forum_topic(self.token, chat_id, message_thread_id, name, icon_custom_emoji_id)
+
+    async def close_forum_topic(self, chat_id: Union[str, int], message_thread_id: int) -> bool:
+        """
+        Use this method to close an open topic in a forum supergroup chat. The bot must be an administrator
+        in the chat for this to work and must have the can_manage_topics administrator rights, unless it is
+        the creator of the topic. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#closeforumtopic
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_thread_id: Identifier of the topic to close
+        :type message_thread_id: :obj:`int`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.close_forum_topic(self.token, chat_id, message_thread_id)
+
+    async def reopen_forum_topic(self, chat_id: Union[str, int], message_thread_id: int) -> bool:
+        """
+        Use this method to reopen a closed topic in a forum supergroup chat. The bot must be an administrator in the chat
+        for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic.
+        Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#reopenforumtopic
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_thread_id: Identifier of the topic to reopen
+        :type message_thread_id: :obj:`int`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.reopen_forum_topic(self.token, chat_id, message_thread_id)
+
+    async def delete_forum_topic(self, chat_id: Union[str, int], message_thread_id: int) -> bool:
+        """
+        Use this method to delete a topic in a forum supergroup chat. The bot must be an administrator in the chat for this
+        to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic. Returns True
+        on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#deleteforumtopic
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_thread_id: Identifier of the topic to delete
+        :type message_thread_id: :obj:`int`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.delete_forum_topic(self.token, chat_id, message_thread_id)
+
+    async def unpin_all_forum_topic_messages(self, chat_id: Union[str, int], message_thread_id: int) -> bool:
+        """
+        Use this method to clear the list of pinned messages in a forum topic. The bot must be an administrator in the
+        chat for this to work and must have the can_pin_messages administrator right in the supergroup.
+        Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#unpinallforumtopicmessages
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_thread_id: Identifier of the topic
+        :type message_thread_id: :obj:`int`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.unpin_all_forum_topic_messages(self.token, chat_id, message_thread_id)
+
+    async def get_forum_topic_icon_stickers(self) -> List[types.Sticker]:
+        """
+        Use this method to get custom emoji stickers, which can be used as a forum topic icon by any user.
+        Requires no parameters. Returns an Array of Sticker objects.
+
+        Telegram documentation: https://core.telegram.org/bots/api#getforumtopiciconstickers
+
+        :return: On success, a list of StickerSet objects is returned.
+        :rtype: List[:class:`telebot.types.StickerSet`]
+        """
+        return await asyncio_helper.get_forum_topic_icon_stickers(self.token)
 
     async def set_state(self, user_id: int, state: Union[State, int, str], chat_id: Optional[int]=None):
         """

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1720,6 +1720,45 @@ async def send_poll(
         payload['protect_content'] = protect_content
     return await _process_request(token, method_url, params=payload)
 
+
+async def create_forum_topic(token, chat_id, name, icon_color=None, icon_custom_emoji_id=None):
+    method_url = r'createForumTopic'
+    payload = {'chat_id': chat_id, 'name': name}
+    if icon_color:
+        payload['icon_color'] = icon_color
+    if icon_custom_emoji_id:
+        payload['icon_custom_emoji_id'] = icon_custom_emoji_id
+    return await _process_request(token, method_url, params=payload)
+
+async def edit_forum_topic(token, chat_id, message_thread_id, name, icon_custom_emoji_id):
+    method_url = r'editForumTopic'
+    payload = {'chat_id': chat_id, 'message_thread_id': message_thread_id, 'name': name, 'icon_custom_emoji_id': icon_custom_emoji_id}
+    return await _process_request(token, method_url, params=payload)
+
+async def close_forum_topic(token, chat_id, message_thread_id):
+    method_url = r'closeForumTopic'
+    payload = {'chat_id': chat_id, 'message_thread_id': message_thread_id}
+    return await _process_request(token, method_url, params=payload)
+
+async def reopen_forum_topic(token, chat_id, message_thread_id):
+    method_url = r'reopenForumTopic'
+    payload = {'chat_id': chat_id, 'message_thread_id': message_thread_id}
+    return await _process_request(token, method_url, params=payload)
+
+async def delete_forum_topic(token, chat_id, message_thread_id):
+    method_url = r'deleteForumTopic'
+    payload = {'chat_id': chat_id, 'message_thread_id': message_thread_id}
+    return await _process_request(token, method_url, params=payload)
+
+async def unpin_all_forum_topic_messages(token, chat_id, message_thread_id):
+    method_url = r'unpinAllForumTopicMessages'
+    payload = {'chat_id': chat_id, 'message_thread_id': message_thread_id}
+    return await _process_request(token, method_url, params=payload)
+
+async def get_forum_topic_icon_stickers(token):
+    method_url = r'getForumTopicIconStickers'
+    return await _process_request(token, method_url)
+
 async def _convert_list_json_serializable(results):
     ret = ''
     for r in results:

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -278,23 +278,8 @@ async def send_message(
         token, chat_id, text,
         disable_web_page_preview=None, reply_to_message_id=None, reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
-        entities=None, allow_sending_without_reply=None, protect_content=None):
-    """
-    Use this method to send text messages. On success, the sent Message is returned.
-    :param token:
-    :param chat_id:
-    :param text:
-    :param disable_web_page_preview:
-    :param reply_to_message_id:
-    :param reply_markup:
-    :param parse_mode:
-    :param disable_notification:
-    :param timeout:
-    :param entities:
-    :param allow_sending_without_reply:
-    :param protect_content:
-    :return:
-    """
+        entities=None, allow_sending_without_reply=None, protect_content=None,
+        message_thread_id=None):
     method_name = 'sendMessage'
     params = {'chat_id': str(chat_id), 'text': text}
     if disable_web_page_preview is not None:
@@ -315,6 +300,8 @@ async def send_message(
         params['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         params['protect_content'] = protect_content
+    if message_thread_id:
+        params['message_thread_id'] = message_thread_id
     
     return await _process_request(token, method_name, params=params)
 
@@ -392,7 +379,8 @@ async def get_chat_member(token, chat_id, user_id):
 
 async def forward_message(
         token, chat_id, from_chat_id, message_id,
-        disable_notification=None, timeout=None, protect_content=None):
+        disable_notification=None, timeout=None, protect_content=None,
+        message_thread_id=None):
     method_url = r'forwardMessage'
     payload = {'chat_id': chat_id, 'from_chat_id': from_chat_id, 'message_id': message_id}
     if disable_notification is not None:
@@ -401,12 +389,14 @@ async def forward_message(
         payload['timeout'] = timeout
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload)
 
 
 async def copy_message(token, chat_id, from_chat_id, message_id, caption=None, parse_mode=None, caption_entities=None,
                  disable_notification=None, reply_to_message_id=None, allow_sending_without_reply=None,
-                 reply_markup=None, timeout=None, protect_content=None):
+                 reply_markup=None, timeout=None, protect_content=None, message_thread_id=None):
     method_url = r'copyMessage'
     payload = {'chat_id': chat_id, 'from_chat_id': from_chat_id, 'message_id': message_id}
     if caption is not None:
@@ -427,13 +417,16 @@ async def copy_message(token, chat_id, from_chat_id, message_id, caption=None, p
         payload['timeout'] = timeout
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload)
 
 
 async def send_dice(
         token, chat_id,
         emoji=None, disable_notification=None, reply_to_message_id=None,
-        reply_markup=None, timeout=None, allow_sending_without_reply=None, protect_content=None):
+        reply_markup=None, timeout=None, allow_sending_without_reply=None, protect_content=None,
+        message_thread_id=None):
     method_url = r'sendDice'
     payload = {'chat_id': chat_id}
     if emoji:
@@ -450,6 +443,8 @@ async def send_dice(
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -457,7 +452,8 @@ async def send_photo(
         token, chat_id, photo,
         caption=None, reply_to_message_id=None, reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
-        caption_entities=None, allow_sending_without_reply=None, protect_content=None):
+        caption_entities=None, allow_sending_without_reply=None, protect_content=None,
+        message_thread_id=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None
@@ -485,13 +481,15 @@ async def send_photo(
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_media_group(
         token, chat_id, media,
         disable_notification=None, reply_to_message_id=None,
-        timeout=None, allow_sending_without_reply=None, protect_content=None):
+        timeout=None, allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
     method_url = r'sendMediaGroup'
     media_json, files = await convert_input_media_array(media)
     payload = {'chat_id': chat_id, 'media': media_json}
@@ -505,6 +503,8 @@ async def send_media_group(
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(
         token, method_url, params=payload,
         method='post' if files else 'get',
@@ -516,7 +516,7 @@ async def send_location(
         live_period=None, reply_to_message_id=None, 
         reply_markup=None, disable_notification=None, 
         timeout=None, horizontal_accuracy=None, heading=None,
-        proximity_alert_radius=None, allow_sending_without_reply=None, protect_content=None):
+        proximity_alert_radius=None, allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
     method_url = r'sendLocation'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude}
     if live_period:
@@ -539,6 +539,8 @@ async def send_location(
         payload['timeout'] = timeout
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -590,7 +592,7 @@ async def send_venue(
         foursquare_id=None, foursquare_type=None, disable_notification=None,
         reply_to_message_id=None, reply_markup=None, timeout=None,
         allow_sending_without_reply=None, google_place_id=None,
-        google_place_type=None, protect_content=None):
+        google_place_type=None, protect_content=None, message_thread_id=None):
     method_url = r'sendVenue'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude, 'title': title, 'address': address}
     if foursquare_id:
@@ -613,13 +615,15 @@ async def send_venue(
         payload['google_place_type'] = google_place_type
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload)
 
 
 async def send_contact(
         token, chat_id, phone_number, first_name, last_name=None, vcard=None,
         disable_notification=None, reply_to_message_id=None, reply_markup=None, timeout=None,
-        allow_sending_without_reply=None, protect_content=None):
+        allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
     method_url = r'sendContact'
     payload = {'chat_id': chat_id, 'phone_number': phone_number, 'first_name': first_name}
     if last_name:
@@ -638,6 +642,8 @@ async def send_contact(
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -652,7 +658,7 @@ async def send_chat_action(token, chat_id, action, timeout=None):
 async def send_video(token, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
                parse_mode=None, supports_streaming=None, disable_notification=None, timeout=None, 
                thumb=None, width=None, height=None, caption_entities=None, allow_sending_without_reply=None,
-               protect_content=None):
+               protect_content=None, message_thread_id=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -694,13 +700,15 @@ async def send_video(token, chat_id, data, duration=None, caption=None, reply_to
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_animation(
         token, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None, thumb=None, caption_entities=None,
-        allow_sending_without_reply=None, width=None, height=None, protect_content=None):
+        allow_sending_without_reply=None, width=None, height=None, protect_content=None, message_thread_id=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}
     files = None
@@ -740,12 +748,14 @@ async def send_animation(
         payload['height'] = height
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_voice(token, chat_id, voice, caption=None, duration=None, reply_to_message_id=None, reply_markup=None,
                parse_mode=None, disable_notification=None, timeout=None, caption_entities=None,
-               allow_sending_without_reply=None, protect_content=None):
+               allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
     method_url = r'sendVoice'
     payload = {'chat_id': chat_id}
     files = None
@@ -773,11 +783,14 @@ async def send_voice(token, chat_id, voice, caption=None, duration=None, reply_t
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_message_id=None, reply_markup=None,
-                    disable_notification=None, timeout=None, thumb=None, allow_sending_without_reply=None, protect_content=None):
+                    disable_notification=None, timeout=None, thumb=None, allow_sending_without_reply=None, protect_content=None,
+                    message_thread_id=None):
     method_url = r'sendVideoNote'
     payload = {'chat_id': chat_id}
     files = None
@@ -811,12 +824,14 @@ async def send_video_note(token, chat_id, data, duration=None, length=None, repl
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None, reply_to_message_id=None,
                reply_markup=None, parse_mode=None, disable_notification=None, timeout=None, thumb=None,
-               caption_entities=None, allow_sending_without_reply=None, protect_content=None):
+               caption_entities=None, allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
     method_url = r'sendAudio'
     payload = {'chat_id': chat_id}
     files = None
@@ -856,12 +871,15 @@ async def send_audio(token, chat_id, audio, caption=None, duration=None, perform
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_markup=None, parse_mode=None,
               disable_notification=None, timeout=None, caption=None, thumb=None, caption_entities=None,
-              allow_sending_without_reply=None, disable_content_type_detection=None, visible_file_name=None, protect_content=None):
+              allow_sending_without_reply=None, disable_content_type_detection=None, visible_file_name=None, protect_content=None,
+              message_thread_id=None):
     method_url = await get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None
@@ -900,6 +918,8 @@ async def send_data(token, chat_id, data, data_type, reply_to_message_id=None, r
         payload['protect_content'] = protect_content
     if method_url == 'sendDocument' and disable_content_type_detection is not None:
         payload['disable_content_type_detection'] = disable_content_type_detection
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1306,7 +1326,7 @@ async def delete_message(token, chat_id, message_id, timeout=None):
 async def send_game(
         token, chat_id, game_short_name,
         disable_notification=None, reply_to_message_id=None, reply_markup=None, timeout=None,
-        allow_sending_without_reply=None, protect_content=None):
+        allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
     method_url = r'sendGame'
     payload = {'chat_id': chat_id, 'game_short_name': game_short_name}
     if disable_notification is not None:
@@ -1321,6 +1341,8 @@ async def send_game(
         payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -1385,7 +1407,8 @@ async def send_invoice(
         need_name=None, need_phone_number=None, need_email=None, need_shipping_address=None,
         send_phone_number_to_provider = None, send_email_to_provider = None, is_flexible=None,
         disable_notification=None, reply_to_message_id=None, reply_markup=None, provider_data=None,
-        timeout=None, allow_sending_without_reply=None, max_tip_amount=None, suggested_tip_amounts=None, protect_content=None):
+        timeout=None, allow_sending_without_reply=None, max_tip_amount=None, suggested_tip_amounts=None, protect_content=None,
+        message_thread_id=None):
     """
     Use this method to send invoices. On success, the sent Message is returned.
     :param token: Bot's token (you don't need to fill this)
@@ -1466,6 +1489,8 @@ async def send_invoice(
         payload['suggested_tip_amounts'] = json.dumps(suggested_tip_amounts)
     if protect_content is not None:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -1674,7 +1699,7 @@ async def send_poll(
         is_anonymous = None, type = None, allows_multiple_answers = None, correct_option_id = None,
         explanation = None, explanation_parse_mode=None, open_period = None, close_date = None, is_closed = None,
         disable_notification=False, reply_to_message_id=None, allow_sending_without_reply=None,
-        reply_markup=None, timeout=None, explanation_entities=None, protect_content=None):
+        reply_markup=None, timeout=None, explanation_entities=None, protect_content=None, message_thread_id=None):
     method_url = r'sendPoll'
     payload = {
         'chat_id': str(chat_id),
@@ -1718,6 +1743,8 @@ async def send_poll(
             types.MessageEntity.to_list_of_dicts(explanation_entities))
     if protect_content:
         payload['protect_content'] = protect_content
+    if message_thread_id:
+        payload['message_thread_id'] = message_thread_id
     return await _process_request(token, method_url, params=payload)
 
 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -968,7 +968,7 @@ async def promote_chat_member(
         token, chat_id, user_id, can_change_info=None, can_post_messages=None,
         can_edit_messages=None, can_delete_messages=None, can_invite_users=None,
         can_restrict_members=None, can_pin_messages=None, can_promote_members=None,
-        is_anonymous=None, can_manage_chat=None, can_manage_video_chats=None):
+        is_anonymous=None, can_manage_chat=None, can_manage_video_chats=None, can_manage_topics=None):
     method_url = 'promoteChatMember'
     payload = {'chat_id': chat_id, 'user_id': user_id}
     if can_change_info is not None:
@@ -993,6 +993,8 @@ async def promote_chat_member(
         payload['can_manage_chat'] = can_manage_chat
     if can_manage_video_chats is not None:
         payload['can_manage_video_chats'] = can_manage_video_chats
+    if can_manage_topics is not None:
+        payload['can_manage_topics'] = can_manage_topics
     return await _process_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -889,6 +889,15 @@ class Message(JsonDeserializable):
         proximity alert while sharing Live Location.
     :type proximity_alert_triggered: :class:`telebot.types.ProximityAlertTriggered`
 
+    :param forum_topic_created: Optional. Service message: forum topic created
+    :type forum_topic_created: :class:`telebot.types.ForumTopicCreated`
+
+    :param forum_topic_closed: Optional. Service message: forum topic closed
+    :type forum_topic_closed: :class:`telebot.types.ForumTopicClosed`
+
+    :param forum_topic_reopened: Optional. Service message: forum topic reopened
+    :type forum_topic_reopened: :class:`telebot.types.ForumTopicReopened`
+
     :param video_chat_scheduled: Optional. Service message: video chat scheduled
     :type video_chat_scheduled: :class:`telebot.types.VideoChatScheduled`
 
@@ -1078,6 +1087,15 @@ class Message(JsonDeserializable):
             content_type = 'message_auto_delete_timer_changed'
         if 'reply_markup' in obj:
             opts['reply_markup'] = InlineKeyboardMarkup.de_json(obj['reply_markup'])
+        if 'forum_topic_created' in obj:
+            opts['forum_topic_created'] = ForumTopicCreated.de_json(obj['forum_topic_created'])
+            content_type = 'forum_topic_created'
+        if 'forum_topic_closed' in obj:
+            opts['forum_topic_closed'] = ForumTopicClosed.de_json(obj['forum_topic_closed'])
+            content_type = 'forum_topic_closed'
+        if 'forum_topic_reopened' in obj:
+            opts['forum_topic_reopened'] = ForumTopicReopened.de_json(obj['forum_topic_reopened'])
+            content_type = 'forum_topic_reopened'
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
     @classmethod
@@ -1165,6 +1183,9 @@ class Message(JsonDeserializable):
         self.reply_markup: Optional[InlineKeyboardMarkup] = None
         self.message_thread_id: Optional[int] = None
         self.is_topic_message: Optional[bool] = None
+        self.forum_topic_created: Optional[ForumTopicCreated] = None
+        self.forum_topic_closed: Optional[ForumTopicClosed] = None
+        self.forum_topic_reopened: Optional[ForumTopicReopened] = None
         for key in options:
             setattr(self, key, options[key])
         self.json = json_string
@@ -6716,3 +6737,56 @@ class InputFile:
         File object.
         """
         return self._file
+
+
+class ForumTopicCreated(JsonDeserializable):
+    """
+    This object represents a service message about a new forum topic created in the chat.
+    
+
+    :param name: Name of the topic
+    :type name: :obj:`str`
+
+    :param icon_color: Color of the topic icon in RGB format
+    :type icon_color: :obj:`int`
+
+    :param icon_custom_emoji_id: Optional. Unique identifier of the custom emoji shown as the topic icon
+    :type icon_custom_emoji_id: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`telebot.types.ForumTopicCreated`
+    """
+    def de_json(self, json_string):
+        if json_string is None: return None
+        obj = self.check_json(json_string)
+        return self(**obj)
+
+    def __init__(self, name: str, icon_color: int, icon_custom_emoji_id: Optional[str]) -> None:
+        self.name: str = name
+        self.icon_color: int = icon_color
+        self.icon_custom_emoji_id: Optional[str] = icon_custom_emoji_id
+
+
+class ForumTopicClosed(JsonDeserializable):
+    """This object represents a service message about a forum topic closed in the chat. Currently holds no information."""
+    # for future use
+    def de_json(self, json_string):
+        return self()
+
+    def __init__(self) -> None:
+        pass
+
+
+class ForumTopicReopened(JsonDeserializable):
+    """This object represents a service message about a forum topic reopened in the chat. Currently holds no information."""
+    # for future use
+    def de_json(self, json_string):
+        return self()
+
+    def __init__(self) -> None:
+        pass
+
+
+
+
+

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -6766,6 +6766,7 @@ class ForumTopicCreated(JsonDeserializable):
     """
     This object represents a service message about a new forum topic created in the chat.
     
+    Telegram documentation: https://core.telegram.org/bots/api#forumtopiccreated
 
     :param name: Name of the topic
     :type name: :obj:`str`
@@ -6792,7 +6793,11 @@ class ForumTopicCreated(JsonDeserializable):
 
 
 class ForumTopicClosed(JsonDeserializable):
-    """This object represents a service message about a forum topic closed in the chat. Currently holds no information."""
+    """
+    This object represents a service message about a forum topic closed in the chat. Currently holds no information.
+    
+    Telegram documentation: https://core.telegram.org/bots/api#forumtopicclosed
+    """
     # for future use
     @classmethod
     def de_json(cls, json_string):
@@ -6803,7 +6808,11 @@ class ForumTopicClosed(JsonDeserializable):
 
 
 class ForumTopicReopened(JsonDeserializable):
-    """This object represents a service message about a forum topic reopened in the chat. Currently holds no information."""
+    """
+    This object represents a service message about a forum topic reopened in the chat. Currently holds no information.
+
+    Telegram documentation: https://core.telegram.org/bots/api#forumtopicreopened
+    """
     # for future use
     @classmethod
     def de_json(cls, json_string):
@@ -6817,6 +6826,8 @@ class ForumTopic(JsonDeserializable):
     """
     This object represents a forum topic.
 
+    Telegram documentation: https://core.telegram.org/bots/api#forumtopic
+
     :param message_thread_id: Unique identifier of the forum topic
     :type message_thread_id: :obj:`int`
 
@@ -6828,6 +6839,9 @@ class ForumTopic(JsonDeserializable):
 
     :param icon_custom_emoji_id: Optional. Unique identifier of the custom emoji shown as the topic icon
     :type icon_custom_emoji_id: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`telebot.types.ForumTopic`
     """
 
     @classmethod

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -521,6 +521,14 @@ class Chat(JsonDeserializable):
     :param photo: Optional. Chat photo. Returned only in getChat.
     :type photo: :class:`telebot.types.ChatPhoto`
 
+    :param active_usernames: Optional. If non-empty, the list of all active chat usernames; for private chats, supergroups and channels.
+        Returned only in getChat.
+    :type active_usernames: :obj:`list` of :obj:`str`
+
+    :param emoji_status_custom_emoji_id: Optional. Custom emoji identifier of emoji status of the other party in a private chat.
+        Returned only in getChat.
+    :type emoji_status_custom_emoji_id: :obj:`str`
+
     :param bio: Optional. Bio of the other party in a private chat. Returned only in getChat.
     :type bio: :obj:`str`
 
@@ -607,7 +615,7 @@ class Chat(JsonDeserializable):
                  message_auto_delete_time=None, has_protected_content=None, sticker_set_name=None,
                  can_set_sticker_set=None, linked_chat_id=None, location=None, 
                  join_to_send_messages=None, join_by_request=None, has_restricted_voice_and_video_messages=None, 
-                 is_forum=None, **kwargs):
+                 is_forum=None, active_usernames=None, emoji_status_custom_emoji_id=None, **kwargs):
         self.id: int = id
         self.type: str = type
         self.title: str = title
@@ -632,6 +640,8 @@ class Chat(JsonDeserializable):
         self.can_set_sticker_set: bool = can_set_sticker_set
         self.linked_chat_id: int = linked_chat_id
         self.location: ChatLocation = location
+        self.active_usernames: List[str] = active_usernames
+        self.emoji_status_custom_emoji_id: str = emoji_status_custom_emoji_id
 
 
 class MessageID(JsonDeserializable):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -515,6 +515,9 @@ class Chat(JsonDeserializable):
     :param last_name: Optional. Last name of the other party in a private chat
     :type last_name: :obj:`str`
 
+    :param is_forum: Optional. True, if the supergroup chat is a forum (has topics enabled)
+    :type is_forum: :obj:`bool`
+
     :param photo: Optional. Chat photo. Returned only in getChat.
     :type photo: :class:`telebot.types.ChatPhoto`
 
@@ -603,13 +606,15 @@ class Chat(JsonDeserializable):
                  permissions=None, slow_mode_delay=None,
                  message_auto_delete_time=None, has_protected_content=None, sticker_set_name=None,
                  can_set_sticker_set=None, linked_chat_id=None, location=None, 
-                 join_to_send_messages=None, join_by_request=None, has_restricted_voice_and_video_messages=None, **kwargs):
+                 join_to_send_messages=None, join_by_request=None, has_restricted_voice_and_video_messages=None, 
+                 is_forum=None, ,**kwargs):
         self.id: int = id
         self.type: str = type
         self.title: str = title
         self.username: str = username
         self.first_name: str = first_name
         self.last_name: str = last_name
+        self.is_forum: bool = is_forum
         self.photo: ChatPhoto = photo
         self.bio: str = bio
         self.join_to_send_messages: bool = join_to_send_messages

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -2597,7 +2597,7 @@ class ChatMember(JsonDeserializable):
                  can_send_messages=None, can_send_media_messages=None, can_send_polls=None,
                  can_send_other_messages=None, can_add_web_page_previews=None,  
                  can_manage_chat=None, can_manage_video_chats=None, 
-                 until_date=None, **kwargs):
+                 until_date=None, can_manage_topics=None, **kwargs):
         self.user: User = user
         self.status: str = status
         self.custom_title: str = custom_title
@@ -2621,6 +2621,7 @@ class ChatMember(JsonDeserializable):
         self.can_manage_video_chats: bool = can_manage_video_chats
         self.can_manage_voice_chats: bool = self.can_manage_video_chats   # deprecated, for backward compatibility
         self.until_date: int = until_date
+        self.can_manage_topics: bool = can_manage_topics
 
 
 class ChatMemberOwner(ChatMember):
@@ -2700,6 +2701,10 @@ class ChatMemberAdministrator(ChatMember):
     :param can_pin_messages: Optional. True, if the user is allowed to pin messages; groups and supergroups only
     :type can_pin_messages: :obj:`bool`
 
+    :param can_manage_topics: Optional. True, if the user is allowed to create, rename, close, and reopen forum topics;
+        supergroups only
+    :type can_manage_topics: :obj:`bool`
+
     :param custom_title: Optional. Custom title for this user
     :type custom_title: :obj:`str`
 
@@ -2750,6 +2755,9 @@ class ChatMemberRestricted(ChatMember):
 
     :param can_pin_messages: True, if the user is allowed to pin messages
     :type can_pin_messages: :obj:`bool`
+
+    :param can_manage_topics: True, if the user is allowed to create forum topics
+    :type can_manage_topics: :obj:`bool`
 
     :param can_send_messages: True, if the user is allowed to send text messages, contacts, locations and venues
     :type can_send_messages: :obj:`bool`
@@ -2853,6 +2861,10 @@ class ChatPermissions(JsonDeserializable, JsonSerializable, Dictionaryable):
     :param can_pin_messages: Optional. True, if the user is allowed to pin messages. Ignored in public supergroups
     :type can_pin_messages: :obj:`bool`
 
+    :param can_manage_topics: Optional. True, if the user is allowed to create forum topics. If omitted defaults to the
+        value of can_pin_messages
+    :type can_manage_topics: :obj:`bool`    
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatPermissions`
     """
@@ -2865,7 +2877,8 @@ class ChatPermissions(JsonDeserializable, JsonSerializable, Dictionaryable):
     def __init__(self, can_send_messages=None, can_send_media_messages=None,
                  can_send_polls=None, can_send_other_messages=None,
                  can_add_web_page_previews=None, can_change_info=None,
-                 can_invite_users=None, can_pin_messages=None, **kwargs):
+                 can_invite_users=None, can_pin_messages=None, 
+                 can_manage_topics=None, **kwargs):
         self.can_send_messages: bool = can_send_messages
         self.can_send_media_messages: bool = can_send_media_messages
         self.can_send_polls: bool = can_send_polls
@@ -2874,6 +2887,7 @@ class ChatPermissions(JsonDeserializable, JsonSerializable, Dictionaryable):
         self.can_change_info: bool = can_change_info
         self.can_invite_users: bool = can_invite_users
         self.can_pin_messages: bool = can_pin_messages
+        self.can_manage_topics: bool = can_manage_topics
 
     def to_json(self):
         return json.dumps(self.to_dict())
@@ -2896,6 +2910,9 @@ class ChatPermissions(JsonDeserializable, JsonSerializable, Dictionaryable):
             json_dict['can_invite_users'] = self.can_invite_users
         if self.can_pin_messages is not None:
             json_dict['can_pin_messages'] = self.can_pin_messages
+        if self.can_manage_topics is not None:
+            json_dict['can_manage_topics'] = self.can_manage_topics
+        
         return json_dict
 
 
@@ -6626,6 +6643,9 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
     :param can_pin_messages: Optional. True, if the user is allowed to pin messages; groups and supergroups only
     :type can_pin_messages: :obj:`bool`
 
+    :param can_manage_topics: Optional. True, if the user is allowed to create, rename, close, and reopen forum topics; supergroups only
+    :type can_manage_topics: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatAdministratorRights`
     """
@@ -6640,7 +6660,7 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
         can_delete_messages: bool, can_manage_video_chats: bool, can_restrict_members: bool,
         can_promote_members: bool, can_change_info: bool, can_invite_users: bool,
         can_post_messages: bool=None, can_edit_messages: bool=None,
-        can_pin_messages: bool=None) -> None:
+        can_pin_messages: bool=None, can_manage_topics: bool=None) -> None:
         
         self.is_anonymous: bool = is_anonymous
         self.can_manage_chat: bool = can_manage_chat
@@ -6653,6 +6673,7 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
         self.can_post_messages: bool = can_post_messages
         self.can_edit_messages: bool = can_edit_messages
         self.can_pin_messages: bool = can_pin_messages
+        self.can_manage_topics: bool = can_manage_topics
 
     def to_dict(self):
         json_dict = {
@@ -6671,6 +6692,8 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
             json_dict['can_edit_messages'] = self.can_edit_messages
         if self.can_pin_messages is not None:
             json_dict['can_pin_messages'] = self.can_pin_messages
+        if self.can_manage_topics is not None:
+            json_dict['can_manage_topics'] = self.can_manage_topics
         return json_dict
     
     def to_json(self):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -607,7 +607,7 @@ class Chat(JsonDeserializable):
                  message_auto_delete_time=None, has_protected_content=None, sticker_set_name=None,
                  can_set_sticker_set=None, linked_chat_id=None, location=None, 
                  join_to_send_messages=None, join_by_request=None, has_restricted_voice_and_video_messages=None, 
-                 is_forum=None, ,**kwargs):
+                 is_forum=None, **kwargs):
         self.id: int = id
         self.type: str = type
         self.title: str = title

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -6761,7 +6761,7 @@ class ForumTopicCreated(JsonDeserializable):
         obj = self.check_json(json_string)
         return self(**obj)
 
-    def __init__(self, name: str, icon_color: int, icon_custom_emoji_id: Optional[str]) -> None:
+    def __init__(self, name: str, icon_color: int, icon_custom_emoji_id: Optional[str]=None) -> None:
         self.name: str = name
         self.icon_color: int = icon_color
         self.icon_custom_emoji_id: Optional[str] = icon_custom_emoji_id

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -695,6 +695,9 @@ class Message(JsonDeserializable):
     :param message_id: Unique message identifier inside this chat
     :type message_id: :obj:`int`
 
+    :param message_thread_id: Optional. Unique identifier of a message thread to which the message belongs; for supergroups only
+    :type message_thread_id: :obj:`int`
+
     :param from_user: Optional. Sender of the message; empty for messages sent to channels. For backward compatibility, the 
         field contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat.
     :type from_user: :class:`telebot.types.User`
@@ -732,6 +735,9 @@ class Message(JsonDeserializable):
 
     :param forward_date: Optional. For forwarded messages, date the original message was sent in Unix time
     :type forward_date: :obj:`int`
+
+    :param is_topic_message: Optional. True, if the message is sent to a forum topic
+    :type is_topic_message: :obj:`bool`
 
     :param is_automatic_forward: Optional. :obj:`bool`, if the message is a channel post that was automatically 
         forwarded to the connected discussion group
@@ -1157,6 +1163,8 @@ class Message(JsonDeserializable):
         self.successful_payment: Optional[SuccessfulPayment] = None
         self.connected_website: Optional[str] = None
         self.reply_markup: Optional[InlineKeyboardMarkup] = None
+        self.message_thread_id: Optional[int] = None
+        self.is_topic_message: Optional[bool] = None
         for key in options:
             setattr(self, key, options[key])
         self.json = json_string

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -6779,10 +6779,11 @@ class ForumTopicCreated(JsonDeserializable):
     :return: Instance of the class
     :rtype: :class:`telebot.types.ForumTopicCreated`
     """
-    def de_json(self, json_string):
+    @classmethod
+    def de_json(cls, json_string):
         if json_string is None: return None
-        obj = self.check_json(json_string)
-        return self(**obj)
+        obj = cls.check_json(json_string)
+        return cls(**obj)
 
     def __init__(self, name: str, icon_color: int, icon_custom_emoji_id: Optional[str]=None) -> None:
         self.name: str = name
@@ -6793,8 +6794,9 @@ class ForumTopicCreated(JsonDeserializable):
 class ForumTopicClosed(JsonDeserializable):
     """This object represents a service message about a forum topic closed in the chat. Currently holds no information."""
     # for future use
-    def de_json(self, json_string):
-        return self()
+    @classmethod
+    def de_json(cls, json_string):
+        return cls()
 
     def __init__(self) -> None:
         pass
@@ -6803,11 +6805,43 @@ class ForumTopicClosed(JsonDeserializable):
 class ForumTopicReopened(JsonDeserializable):
     """This object represents a service message about a forum topic reopened in the chat. Currently holds no information."""
     # for future use
-    def de_json(self, json_string):
-        return self()
+    @classmethod
+    def de_json(cls, json_string):
+        return cls()
 
     def __init__(self) -> None:
         pass
+
+
+class ForumTopic(JsonDeserializable):
+    """
+    This object represents a forum topic.
+
+    :param message_thread_id: Unique identifier of the forum topic
+    :type message_thread_id: :obj:`int`
+
+    :param name: Name of the topic
+    :type name: :obj:`str`
+
+    :param icon_color: Color of the topic icon in RGB format
+    :type icon_color: :obj:`int`
+
+    :param icon_custom_emoji_id: Optional. Unique identifier of the custom emoji shown as the topic icon
+    :type icon_custom_emoji_id: :obj:`str`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+
+    def __init__(self, message_thread_id: int, name: str, icon_color: int, icon_custom_emoji_id: Optional[str]=None) -> None:
+        self.message_thread_id: int = message_thread_id
+        self.name: str = name
+        self.icon_color: int = icon_color
+        self.icon_custom_emoji_id: Optional[str] = icon_custom_emoji_id
+
 
 
 


### PR DESCRIPTION
- [x] Added support for [Topics in Groups](https://telegram.org/blog/topics-in-groups-collectible-usernames#topics-in-groups).
- [x] Added the field is_forum to the class [Chat](https://core.telegram.org/bots/api#chat).
- [x] Added the fields is_topic_message and message_thread_id to the class [Message](https://core.telegram.org/bots/api#message) to allow detection of messages belonging to a forum topic and their message thread identifier.
- [x] Added the classes [ForumTopicCreated](https://core.telegram.org/bots/api#forumtopiccreated), [ForumTopicClosed](https://core.telegram.org/bots/api#forumtopicclosed), and [ForumTopicReopened](https://core.telegram.org/bots/api#forumtopicreopened) and the fields forum_topic_created, forum_topic_closed, and forum_topic_reopened to the class [Message](https://core.telegram.org/bots/api#message). Note that service messages about forum topic creation can't be deleted with the [deleteMessage](https://core.telegram.org/bots/api#deletemessage) method.
- [x] Added the field can_manage_topics to the classes [ChatAdministratorRights](https://core.telegram.org/bots/api#chatadministratorrights), [ChatPermissions](https://core.telegram.org/bots/api#chatpermissions), [ChatMemberAdministrator](https://core.telegram.org/bots/api#chatmemberadministrator), and [ChatMemberRestricted](https://core.telegram.org/bots/api#chatmemberrestricted).
- [x] Added the parameter can_manage_topics to the method [promoteChatMember](https://core.telegram.org/bots/api#promotechatmember).
- [x] Added the methods [createForumTopic](https://core.telegram.org/bots/api#createforumtopic), [editForumTopic](https://core.telegram.org/bots/api#editforumtopic), [closeForumTopic](https://core.telegram.org/bots/api#closeforumtopic), [reopenForumTopic](https://core.telegram.org/bots/api#reopenforumtopic), [deleteForumTopic](https://core.telegram.org/bots/api#deleteforumtopic), [unpinAllForumTopicMessages](https://core.telegram.org/bots/api#unpinallforumtopicmessages), and [getForumTopicIconStickers](https://core.telegram.org/bots/api#getforumtopiciconstickers) for forum topic management.
- [x] Added the parameter message_thread_id to the methods [sendMessage](https://core.telegram.org/bots/api#sendmessage), [sendPhoto](https://core.telegram.org/bots/api#sendphoto), [sendVideo](https://core.telegram.org/bots/api#sendvideo), [sendAnimation](https://core.telegram.org/bots/api#sendanimation), [sendAudio](https://core.telegram.org/bots/api#sendaudio), [sendDocument](https://core.telegram.org/bots/api#senddocument), [sendSticker](https://core.telegram.org/bots/api#sendsticker), [sendVideoNote](https://core.telegram.org/bots/api#sendvideonote), [sendVoice](https://core.telegram.org/bots/api#sendvoice), [sendLocation](https://core.telegram.org/bots/api#sendlocation), [sendVenue](https://core.telegram.org/bots/api#sendvenue), [sendContact](https://core.telegram.org/bots/api#sendcontact), [sendPoll](https://core.telegram.org/bots/api#sendpoll), [sendDice](https://core.telegram.org/bots/api#senddice), [sendInvoice](https://core.telegram.org/bots/api#sendinvoice), [sendGame](https://core.telegram.org/bots/api#sendgame), [sendMediaGroup](https://core.telegram.org/bots/api#sendmediagroup), [copyMessage](https://core.telegram.org/bots/api#copymessage), [forwardMessage](https://core.telegram.org/bots/api#forwardmessage) to support sending of messages to a forum topic.
- [x] Added support for [Multiple Usernames](https://telegram.org/blog/topics-in-groups-collectible-usernames#collectible-usernames) via the field active_usernames in the class [Chat](https://core.telegram.org/bots/api#chat).
- [x] Added the field emoji_status_custom_emoji_id to the class [Chat](https://core.telegram.org/bots/api#chat).