### PR TITLE
fixing escape()

### DIFF
--- a/telebot/util.py
+++ b/telebot/util.py
@@ -401,8 +401,7 @@ def escape(text: str) -> str:
     chars = {"&": "&amp;", "<": "&lt;", ">": "&gt;"}
     if text is None:
         return None
-    else:
-        for old, new in chars.items(): text = text.replace(old, new)
+    for old, new in chars.items(): text = text.replace(old, new)
         return text
 
 

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -399,8 +399,12 @@ def escape(text: str) -> str:
     :return: the escaped text
     """
     chars = {"&": "&amp;", "<": "&lt;", ">": "&gt;"}
-    for old, new in chars.items(): text = text.replace(old, new)
-    return text
+    if text == None:
+        return None
+    else:
+        for old, new in chars.items(): 
+            text = text.replace(old, new)
+        return text
 
 
 def user_link(user: types.User, include_id: bool=False) -> str:

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -401,8 +401,9 @@ def escape(text: str) -> str:
     chars = {"&": "&amp;", "<": "&lt;", ">": "&gt;"}
     if text is None:
         return None
-    for old, new in chars.items(): text = text.replace(old, new)
-        return text
+    for old, new in chars.items(): 
+        text = text.replace(old, new)
+    return text
 
 
 def user_link(user: types.User, include_id: bool=False) -> str:

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -399,11 +399,10 @@ def escape(text: str) -> str:
     :return: the escaped text
     """
     chars = {"&": "&amp;", "<": "&lt;", ">": "&gt;"}
-    if text == None:
+    if text is None:
         return None
     else:
-        for old, new in chars.items(): 
-            text = text.replace(old, new)
+        for old, new in chars.items(): text = text.replace(old, new)
         return text
 
 


### PR DESCRIPTION
fixing escape() as replacing a None would throw an exception 'NoneType' object has no attribute 'replace'. useful in case of escaping a None string given from message.from_user.last_name as you dont know wether the user has a last name or not