### PR TITLE
Make create_dir() method of StatePickleStorage cross-platform instead of POSIX only.

### DIFF
--- a/telebot/asyncio_storage/pickle_storage.py
+++ b/telebot/asyncio_storage/pickle_storage.py
@@ -28,7 +28,7 @@ class StatePickleStorage(StateStorageBase):
         """
         Create directory .save-handlers.
         """
-        dirs = self.file_path.rsplit('/', maxsplit=1)[0]
+        dirs, filename = os.path.split(self.file_path)
         os.makedirs(dirs, exist_ok=True)
         if not os.path.isfile(self.file_path):
             with open(self.file_path,'wb') as file:

--- a/telebot/storage/pickle_storage.py
+++ b/telebot/storage/pickle_storage.py
@@ -34,7 +34,7 @@ class StatePickleStorage(StateStorageBase):
         """
         Create directory .save-handlers.
         """
-        dirs = self.file_path.rsplit('/', maxsplit=1)[0]
+        dirs, filename = os.path.split(self.file_path)
         os.makedirs(dirs, exist_ok=True)
         if not os.path.isfile(self.file_path):
             with open(self.file_path,'wb') as file:

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -643,15 +643,15 @@ def validate_web_app_data(token: str, raw_init_data: str):
     return hmac.new(secret_key.digest(), data_check_string.encode(), sha256).hexdigest() == init_data_hash
 
 
-__all__ = (
-    "content_type_media", "content_type_service", "update_types",
-    "WorkerThread", "AsyncTask", "CustomRequestResponse",
-    "async_dec", "deprecated",
-    "is_bytes", "is_string", "is_dict", "is_pil_image",
-    "chunks", "generate_random_token", "pil_image_to_file",
-    "is_command", "extract_command", "extract_arguments",
-    "split_string", "smart_split", "escape", "user_link", "quick_markup",
-    "antiflood", "parse_web_app_data", "validate_web_app_data",
-    "or_set", "or_clear", "orify", "OrEvent", "per_thread",
-    "webhook_google_functions"
-)
+# __all__ = (
+#     "content_type_media", "content_type_service", "update_types",
+#     "WorkerThread", "AsyncTask", "CustomRequestResponse",
+#     "async_dec", "deprecated",
+#     "is_bytes", "is_string", "is_dict", "is_pil_image",
+#     "chunks", "generate_random_token", "pil_image_to_file",
+#     "is_command", "extract_command", "extract_arguments",
+#     "split_string", "smart_split", "escape", "user_link", "quick_markup",
+#     "antiflood", "parse_web_app_data", "validate_web_app_data",
+#     "or_set", "or_clear", "orify", "OrEvent", "per_thread",
+#     "webhook_google_functions"
+# )

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -643,15 +643,15 @@ def validate_web_app_data(token: str, raw_init_data: str):
     return hmac.new(secret_key.digest(), data_check_string.encode(), sha256).hexdigest() == init_data_hash
 
 
-# __all__ = (
-#     "content_type_media", "content_type_service", "update_types",
-#     "WorkerThread", "AsyncTask", "CustomRequestResponse",
-#     "async_dec", "deprecated",
-#     "is_bytes", "is_string", "is_dict", "is_pil_image",
-#     "chunks", "generate_random_token", "pil_image_to_file",
-#     "is_command", "extract_command", "extract_arguments",
-#     "split_string", "smart_split", "escape", "user_link", "quick_markup",
-#     "antiflood", "parse_web_app_data", "validate_web_app_data",
-#     "or_set", "or_clear", "orify", "OrEvent", "per_thread",
-#     "webhook_google_functions"
-# )
+__all__ = (
+    "content_type_media", "content_type_service", "update_types",
+    "WorkerThread", "AsyncTask", "CustomRequestResponse",
+    "async_dec", "deprecated",
+    "is_bytes", "is_string", "is_dict", "is_pil_image",
+    "chunks", "generate_random_token", "pil_image_to_file",
+    "is_command", "extract_command", "extract_arguments",
+    "split_string", "smart_split", "escape", "user_link", "quick_markup",
+    "antiflood", "parse_web_app_data", "validate_web_app_data",
+    "or_set", "or_clear", "orify", "OrEvent", "per_thread",
+    "webhook_google_functions"
+)


### PR DESCRIPTION
Fix for issue #1869 

## Description
Include changes, new features and etc:

## Describe your tests
How did you test your change?
Tried to init StatePickleStorage with Windows-like path. Works fine

Python version:

OS:

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async
