### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ def test_callback(call): # <- passes a CallbackQuery type object to your functio
 
 #### Shipping Query Handler
 Handle shipping queries
-`@bot.shipping_query_handeler() # <- passes a ShippingQuery type object to your function`
+`@bot.shipping_query_handler() # <- passes a ShippingQuery type object to your function`
 
 #### Pre Checkout Query Handler
 Handle pre checkoupt queries


### PR DESCRIPTION
## Description
Changed string @bot.shipping_query_handeler() to @bot.shipping_query_handler() in README.md

## Describe your tests
Checked that @bot.shipping_query_handler() does not exist and indeed the documentation meant @bot.shipping_query_handler().
