### PR TITLE
RuntimeError("cannot join current thread")

### DIFF
--- a/telebot/util.py
+++ b/telebot/util.py
@@ -154,7 +154,8 @@ class ThreadPool:
         for worker in self.workers:
             worker.stop()
         for worker in self.workers:
-            worker.join()
+            if worker != threading.current_thread():
+                worker.join()
 
 
 class AsyncTask:


### PR DESCRIPTION
## Description
If we send bot.stop_bot() we will get an exception before the bot is stoped,
because we cannot join current thread
It is trouble only for sync, AsyncTeleBot object has no attribute stop_bot

## Describe your tests
```
#!/usr/bin/python
import os
import telebot

bot = telebot.TeleBot(os.environ['token'])

# Handle '/stop'
@bot.message_handler(commands=['stop'])
def send_stop(message):
    bot.reply_to(message, "stop")
    bot.stop_bot()

bot.infinity_polling()
```

Python version: 3.8 (may be any)

OS: I check on windows 10 and Ubuntu 22.04.1 LTS

## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async

