### PR TITLE
Fix .webm upload

### DIFF
--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1612,8 +1612,6 @@ def create_new_sticker_set(
         payload[stype] = sticker
     if mask_position:
         payload['mask_position'] = mask_position.to_json()
-    if webm_sticker:
-        payload['webm_sticker'] = webm_sticker
     if sticker_type:
         payload['sticker_type'] = sticker_type
     return _make_request(token, method_url, params=payload, files=files, method='post')

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1601,8 +1601,6 @@ async def create_new_sticker_set(
         payload[stype] = sticker
     if mask_position:
         payload['mask_position'] = mask_position.to_json()
-    if webm_sticker:
-        payload['webm_sticker'] = webm_sticker
     if sticker_type:
         payload['sticker_type'] = sticker_type
     return await _process_request(token, method_url, params=payload, files=files, method='post')


### PR DESCRIPTION
No need to pass file content as a header, it causes the http error "431 Request Header Fields Too Large".