### PR TITLE
Fix documentation for `InlineKeyboardMarkup` and `quick_markup`

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -2432,23 +2432,29 @@ class InlineKeyboardMarkup(Dictionaryable, JsonSerializable, JsonDeserializable)
     This object represents an inline keyboard that appears right next to the message it belongs to.
 
     .. note::
-        It is recommended to use :meth:`telebot.service_utils..quick_markup` instead.
+        It is recommended to use :meth:`telebot.util.quick_markup` instead.
 
     .. code-block:: python3
         :caption: Example of a custom keyboard with buttons.
 
-        from telebot.service_utils..import quick_markup
+        from telebot.util import quick_markup
 
-        markup = quick_markup(
-            {'text': 'Press me', 'callback_data': 'press'},
-            {'text': 'Press me too', 'callback_data': 'press_too'}
-        )
+        markup = quick_markup({
+            'Twitter': {'url': 'https://twitter.com'},
+            'Facebook': {'url': 'https://facebook.com'},
+            'Back': {'callback_data': 'whatever'}
+        }, row_width=2)
+        # returns an InlineKeyboardMarkup with two buttons in a row, one leading to Twitter, the other to facebook
+        # and a back button below
 
     Telegram Documentation: https://core.telegram.org/bots/api#inlinekeyboardmarkup
 
-    :param inline_keyboard: :obj:`list` of button rows, each represented by an :obj:`list` of 
+    :param keyboard: :obj:`list` of button rows, each represented by an :obj:`list` of 
         :class:`telebot.types.InlineKeyboardButton` objects
-    :type inline_keyboard: :obj:`list` of :obj:`list` of :class:`telebot.types.InlineKeyboardButton`
+    :type keyboard: :obj:`list` of :obj:`list` of :class:`telebot.types.InlineKeyboardButton`
+
+    :param row_width: number of :class:`telebot.types.InlineKeyboardButton` objects on each row
+    :type row_width: :obj:`int`
 
     :return: Instance of the class
     :rtype: :class:`telebot.types.InlineKeyboardMarkup`

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -420,11 +420,13 @@ def quick_markup(values: Dict[str, Dict[str, Any]], row_width: int = 2) -> types
     .. code-block:: python3
         :caption: Using quick_markup:
 
-        quick_markup({
+        from telebot.util import quick_markup
+
+        markup = quick_markup({
             'Twitter': {'url': 'https://twitter.com'},
             'Facebook': {'url': 'https://facebook.com'},
             'Back': {'callback_data': 'whatever'}
-        }, row_width=2): 
+        }, row_width=2)
         # returns an InlineKeyboardMarkup with two buttons in a row, one leading to Twitter, the other to facebook
         # and a back button below
 
@@ -443,7 +445,7 @@ def quick_markup(values: Dict[str, Dict[str, Any]], row_width: int = 2) -> types
     :param values: a dict containing all buttons to create in this format: {text: kwargs} {str:}
     :type values: :obj:`dict`
 
-    :param row_width: int row width
+    :param row_width: number of :class:`telebot.types.InlineKeyboardButton` objects on each row
     :type row_width: :obj:`int`
 
     :return: InlineKeyboardMarkup


### PR DESCRIPTION
## Description

- The documentation for `InlineKeyboardMarkup` was outdated so I updated it to be in sync with what `quick_markup` provides.
- Removed the extra `: ` characters at the end of `telebot/util.py`:
  https://github.com/eternnoir/pyTelegramBotAPI/blob/da57174635cf2b22281f3d9f024fb540d0b9246e/telebot/util.py#L427
- Fixed the parameters documentation for `InlineKeyboardMarkup` and rewrite the description of the `row_width` parameter for both the class itself and the function `quick_markup`.

## Describe your tests

I built the docs using Sphinx and checked the HTML output, and the output was correct.

Python version: 3.10.4
Sphinx version: 6.1.3
OS: Ubuntu 20.04.5 LTS

## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async