### PR TITLE
bring back the async func message_filter

### DIFF
--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -16,7 +16,7 @@ import telebot.types
 from telebot.asyncio_storage import StateMemoryStorage, StatePickleStorage, StateStorageBase
 from telebot.asyncio_handler_backends import BaseMiddleware, CancelUpdate, SkipHandler, State, ContinueHandling
 
-from inspect import signature
+from inspect import signature, iscoroutinefunction
 
 from telebot import util, types, asyncio_helper
 import asyncio
@@ -836,6 +836,8 @@ class AsyncTeleBot:
         elif message_filter == 'chat_types':
             return message.chat.type in filter_value
         elif message_filter == 'func':
+            if iscoroutinefunction(filter_value):
+                return await filter_value(message)
             return filter_value(message)
         elif self.custom_filters and message_filter in self.custom_filters:
             return await self._check_filter(message_filter,filter_value,message)


### PR DESCRIPTION
-fixes #1974
- related commits: c84896391eac80eb08b17d0636999499e921723e f69a2ba044983fbd7b072946df7512d0e2904cd6

## Description
the `func` option now can be an async func

## Describe your tests
it's not going to break any thing but you may want to add a test for it so in the future it could not be deleted again

## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async
