### PR TITLE
Fix backslash (\) issue in escape_markdown

### DIFF
--- a/telebot/formatting.py
+++ b/telebot/formatting.py
@@ -61,8 +61,8 @@ def escape_markdown(content: str) -> str:
     :rtype: :obj:`str`
     """
     
-    parse = re.sub(r"([_*\[\]()~`>\#\+\-=|\.!\{\}])", r"\\\1", content)
-    reparse = re.sub(r"\\\\([_*\[\]()~`>\#\+\-=|\.!\{\}])", r"\1", parse)
+    parse = re.sub(r"([_*\[\]()~`>\#\+\-=|\.!\{\}\\])", r"\\\1", content)
+    reparse = re.sub(r"\\\\([_*\[\]()~`>\#\+\-=|\.!\{\}\\])", r"\1", parse)
     return reparse 
 
 


### PR DESCRIPTION
## Fix backslash (\) issue in escape_markdown
When I was using backslash in `telebot.formatting.escape_markdown`, I was getting an error from the Telegram API.
The regex pattern inside the `escape_markdown` function was missing a `backslash` within the brackets.