### PR TITLE
added posibility to handle exception on RequestTimeout

### DIFF
--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -415,8 +415,16 @@ class AsyncTeleBot:
                 except asyncio.CancelledError:
                     return
                 except asyncio_helper.RequestTimeout as e:
-                    logger.error(str(e))
-                    if non_stop:
+                    handled = False
+                    if self.exception_handler:
+                        self.exception_handler.handle(e)
+                        handled = True
+
+                    if not handled:
+                        logger.error('Unhandled exception (full traceback for debug level): %s', str(e))
+                        logger.debug(traceback.format_exc())
+                        
+                    if non_stop or handled:
                         await asyncio.sleep(2)
                         continue
                     else:


### PR DESCRIPTION
## Description
I wanted to increment an error counter whenever the RequestTimeout occurs as an exception via the exception_handler class

## Describe your tests
How did you test your change?

Tested on my own project in which I frequently use telebot

Python version: 3.11

OS: Linux Mint

## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async
