### PR TITLE
Bot API 6.8: Stories, voting as a chat, and other minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">A simple, but extensible Python implementation for the <a href="https://core.telegram.org/bots/api">Telegram Bot API</a>.</p>
 <p align="center">Both synchronous and asynchronous.</p>
 
-## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#april-21-2023">6.7</a>!
+## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#august-18-2023">6.8</a>!
 
 <h2><a href='https://pytba.readthedocs.io/en/latest/index.html'>Official documentation</a></h2>
 <h2><a href='https://pytba.readthedocs.io/ru/latest/index.html'>Official ru documentation</a></h2>

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -4571,6 +4571,24 @@ class TeleBot:
         return apihelper.answer_inline_query(self.token, inline_query_id, results, cache_time, is_personal, next_offset,
                                              button)
 
+    def unpin_all_general_forum_topic_messages(self, chat_id: Union[int, str]) -> bool:
+        """
+        Use this method to clear the list of pinned messages in a General forum topic. 
+        The bot must be an administrator in the chat for this to work and must have the
+        can_pin_messages administrator right in the supergroup.
+        Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#unpinAllGeneralForumTopicMessages
+
+        :param chat_id: Unique identifier for the target chat or username of chat
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+
+        return apihelper.unpin_all_general_forum_topic_messages(self.token, chat_id)
+
     def answer_callback_query(
             self, callback_query_id: int, 
             text: Optional[str]=None, show_alert: Optional[bool]=None, 

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1585,6 +1585,11 @@ def answer_pre_checkout_query(token, pre_checkout_query_id, ok, error_message=No
     return _make_request(token, method_url, params=payload)
 
 
+def unpin_all_general_forum_topic_messages(token, chat_id):
+    method_url = 'unpinAllGeneralForumTopicMessages'
+    payload = {'chat_id': chat_id}
+    return _make_request(token, method_url, params=payload, method='post')
+
 # InlineQuery
 
 def answer_callback_query(token, callback_query_id, text=None, show_alert=None, url=None, cache_time=None):

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -5424,6 +5424,24 @@ class AsyncTeleBot:
         return await asyncio_helper.answer_inline_query(self.token, inline_query_id, results, cache_time, is_personal, next_offset,
                                              button)
 
+    async def unpin_all_general_forum_topic_messages(self, chat_id: Union[int, str]) -> bool:
+        """
+        Use this method to clear the list of pinned messages in a General forum topic. 
+        The bot must be an administrator in the chat for this to work and must have the
+        can_pin_messages administrator right in the supergroup.
+        Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#unpinAllGeneralForumTopicMessages
+
+        :param chat_id: Unique identifier for the target chat or username of chat
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+
+        return await asyncio_helper.unpin_all_general_forum_topic_messages(self.token, chat_id)
+
     async def answer_callback_query(
             self, callback_query_id: int, 
             text: Optional[str]=None, show_alert: Optional[bool]=None, 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1575,6 +1575,11 @@ async def answer_pre_checkout_query(token, pre_checkout_query_id, ok, error_mess
     return await _process_request(token, method_url, params=payload)
 
 
+async def unpin_all_general_forum_topic_messages(token, chat_id):
+    method_url = 'unpinAllGeneralForumTopicMessages'
+    payload = {'chat_id': chat_id}
+    return await _process_request(token, method_url, params=payload, method='post')
+
 # InlineQuery
 
 async def answer_callback_query(token, callback_query_id, text=None, show_alert=None, url=None, cache_time=None):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -821,6 +821,9 @@ class Message(JsonDeserializable):
     :param sticker: Optional. Message is a sticker, information about the sticker
     :type sticker: :class:`telebot.types.Sticker`
 
+    :param story: Optional. Message is a forwarded story
+    :type story: :class:`telebot.types.Story`
+
     :param video: Optional. Message is a video, information about the video
     :type video: :class:`telebot.types.Video`
 
@@ -1177,6 +1180,9 @@ class Message(JsonDeserializable):
         if 'chat_shared' in obj:
             opts['chat_shared'] = ChatShared.de_json(obj['chat_shared'])
             content_type = 'chat_shared'
+        if 'story' in obj:
+            opts['story'] = Story.de_json(obj['story'])
+            content_type = 'story'
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
     @classmethod
@@ -1274,9 +1280,18 @@ class Message(JsonDeserializable):
         self.write_access_allowed: Optional[WriteAccessAllowed] = None
         self.user_shared: Optional[UserShared] = None
         self.chat_shared: Optional[ChatShared] = None
+        self.story: Optional[Story] = None
         for key in options:
             setattr(self, key, options[key])
         self.json = json_string
+
+    @property
+    def is_forwarded_story(self):
+        """
+        Returns True if the message is a forwarded story.
+        """
+        # TODO: In future updates this propery might require changes.
+        return True if self.story is not None else False
 
     def __html_text(self, text, entities):
         """
@@ -7743,3 +7758,18 @@ class InlineQueryResultsButton(JsonSerializable, Dictionaryable):
     
     def to_json(self) -> str:
         return json.dumps(self.to_dict())
+
+
+class Story(JsonDeserializable):
+    """
+    This object represents a message about a forwarded story in the chat.
+    Currently holds no information.
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        return cls()
+
+    def __init__(self) -> None:
+        pass
+

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -543,6 +543,10 @@ class Chat(JsonDeserializable):
         Returned only in getChat.
     :type emoji_status_custom_emoji_id: :obj:`str`
 
+    :param emoji_status_expiration_date: Optional. Expiration date of the emoji status of the other party in a private chat,
+        if any. Returned only in getChat.
+    :type emoji_status_expiration_date: :obj:`int`
+
     :param bio: Optional. Bio of the other party in a private chat. Returned only in getChat.
     :type bio: :obj:`str`
 
@@ -638,7 +642,7 @@ class Chat(JsonDeserializable):
                  can_set_sticker_set=None, linked_chat_id=None, location=None, 
                  join_to_send_messages=None, join_by_request=None, has_restricted_voice_and_video_messages=None, 
                  is_forum=None, active_usernames=None, emoji_status_custom_emoji_id=None,
-                 has_hidden_members=None, has_aggressive_anti_spam_enabled=None, **kwargs):
+                 has_hidden_members=None, has_aggressive_anti_spam_enabled=None, emoji_status_expiration_date=None, **kwargs):
         self.id: int = id
         self.type: str = type
         self.title: str = title
@@ -667,6 +671,7 @@ class Chat(JsonDeserializable):
         self.emoji_status_custom_emoji_id: str = emoji_status_custom_emoji_id
         self.has_hidden_members: bool = has_hidden_members
         self.has_aggressive_anti_spam_enabled: bool = has_aggressive_anti_spam_enabled
+        self.emoji_status_expiration_date: int = emoji_status_expiration_date
 
 
 class MessageID(JsonDeserializable):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -6695,6 +6695,9 @@ class PollAnswer(JsonSerializable, JsonDeserializable, Dictionaryable):
     :param poll_id: Unique poll identifier
     :type poll_id: :obj:`str`
 
+    :param voter_chat: Optional. The chat that changed the answer to the poll, if the voter is anonymous
+    :type voter_chat: :class:`telebot.types.Chat`
+
     :param user: The user, who changed the answer to the poll
     :type user: :class:`telebot.types.User`
 
@@ -6710,12 +6713,16 @@ class PollAnswer(JsonSerializable, JsonDeserializable, Dictionaryable):
         if (json_string is None): return None
         obj = cls.check_json(json_string)
         obj['user'] = User.de_json(obj['user'])
+        if 'voter_chat' in obj:
+            obj['voter_chat'] = Chat.de_json(obj['voter_chat'])
         return cls(**obj)
 
-    def __init__(self, poll_id, user, option_ids, **kwargs):
+    def __init__(self, poll_id, user, option_ids, voter_chat=None, **kwargs):
         self.poll_id: str = poll_id
         self.user: User = user
         self.option_ids: List[int] = option_ids
+        self.voter_chat: Optional[Chat] = voter_chat
+
 
     def to_json(self):
         return json.dumps(self.to_dict())


### PR DESCRIPTION
### August 18, 2023
### **Bot API 6.8**

- [x] Added the field story to the class [Message](https://core.telegram.org/bots/api#message) for messages with forwarded stories. Currently, it holds no information.

- [x] Added the field voter_chat to the class [PollAnswer](https://core.telegram.org/bots/api#pollanswer), to contain channel chat voters in [Polls](https://core.telegram.org/bots/api#poll). For backward compatibility, the field user in such objects will contain the user 136817688 ([@Channel_Bot](https://t.me/Channel_Bot)).
- [x] Added the field emoji_status_expiration_date to the class [Chat](https://core.telegram.org/bots/api#chat).
- [x] Added the method [unpinAllGeneralForumTopicMessages](https://core.telegram.org/bots/api#unpinallgeneralforumtopicmessages).
- [x] Increased to 512 characters the maximum length of the startapp parameter in direct Web App **links(NOT NEEDED)**