### PR TITLE
The ability to work with from_url() method for Redis

### DIFF
--- a/telebot/storage/redis_storage.py
+++ b/telebot/storage/redis_storage.py
@@ -15,9 +15,12 @@ class StateRedisStorage(StateStorageBase):
     To use it, just pass this class to:
     TeleBot(storage=StateRedisStorage())
     """
-    def __init__(self, host='localhost', port=6379, db=0, password=None, prefix='telebot_'):
+    def __init__(self, host='localhost', port=6379, db=0, password=None, url=None, prefix='telebot_'):
         super().__init__()
-        self.redis = ConnectionPool(host=host, port=port, db=db, password=password)
+        if url:
+            self.redis = ConnectionPool.from_url(url)
+        else:
+            self.redis = ConnectionPool(host=host, port=port, db=db, password=password)
         #self.con = Redis(connection_pool=self.redis) -> use this when necessary
         #
         # {chat_id: {user_id: {'state': None, 'data': {}}, ...}, ...}


### PR DESCRIPTION
## Description
Include changes, new features and etc:
Added the ability to work with Redis URL. Now we can pass URL of Redis and from_url() method will be used for creating ConnectionPool class

## Describe your tests
How did you test your change?
Test on my bot with URL and without URL

Python version: 3.10

OS: MacOS 13.4.1 (c) M1

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async
