### PR TITLE
Bot API 6.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">A simple, but extensible Python implementation for the <a href="https://core.telegram.org/bots/api">Telegram Bot API</a>.</p>
 <p align="center">Both synchronous and asynchronous.</p>
 
-## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#august-18-2023">6.8</a>!
+## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api-changelog#september-22-2023">6.9</a>!
 
 <h2><a href='https://pytba.readthedocs.io/en/latest/index.html'>Official documentation</a></h2>
 <h2><a href='https://pytba.readthedocs.io/ru/latest/index.html'>Official ru documentation</a></h2>

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -3058,7 +3058,10 @@ class TeleBot:
             can_manage_chat: Optional[bool]=None, 
             can_manage_video_chats: Optional[bool]=None,
             can_manage_voice_chats: Optional[bool]=None,
-            can_manage_topics: Optional[bool]=None) -> bool:
+            can_manage_topics: Optional[bool]=None,
+            can_post_stories: Optional[bool]=None,
+            can_edit_stories: Optional[bool]=None,
+            can_delete_stories: Optional[bool]=None) -> bool:
         """
         Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator
         in the chat for this to work and must have the appropriate admin rights.
@@ -3119,6 +3122,15 @@ class TeleBot:
             and reopen forum topics, supergroups only
         :type can_manage_topics: :obj:`bool`
 
+        :param can_post_stories: Pass True if the administrator can create the channel's stories
+        :type can_post_stories: :obj:`bool`
+
+        :param can_edit_stories: Pass True if the administrator can edit the channel's stories
+        :type can_edit_stories: :obj:`bool`
+
+        :param can_delete_stories: Pass True if the administrator can delete the channel's stories
+        :type can_delete_stories: :obj:`bool`
+
         :return: True on success.
         :rtype: :obj:`bool`
         """
@@ -3131,7 +3143,8 @@ class TeleBot:
             self.token, chat_id, user_id, can_change_info, can_post_messages,
             can_edit_messages, can_delete_messages, can_invite_users,
             can_restrict_members, can_pin_messages, can_promote_members,
-            is_anonymous, can_manage_chat, can_manage_video_chats, can_manage_topics)
+            is_anonymous, can_manage_chat, can_manage_video_chats, can_manage_topics,
+            can_post_stories, can_edit_stories, can_delete_stories)
 
     def set_chat_administrator_custom_title(
             self, chat_id: Union[int, str], user_id: int, custom_title: str) -> bool:

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -991,7 +991,8 @@ def promote_chat_member(
         can_edit_messages=None, can_delete_messages=None, can_invite_users=None,
         can_restrict_members=None, can_pin_messages=None, can_promote_members=None,
         is_anonymous=None, can_manage_chat=None, can_manage_video_chats=None,
-        can_manage_topics=None):
+        can_manage_topics=None, can_post_stories=None, can_edit_stories=None,
+        can_delete_stories=None):
     method_url = 'promoteChatMember'
     payload = {'chat_id': chat_id, 'user_id': user_id}
     if can_change_info is not None:
@@ -1018,6 +1019,12 @@ def promote_chat_member(
         payload['can_manage_video_chats'] = can_manage_video_chats
     if can_manage_topics is not None:
         payload['can_manage_topics'] = can_manage_topics
+    if can_post_stories is not None:
+        payload['can_post_stories'] = can_post_stories
+    if can_edit_stories is not None:
+        payload['can_edit_stories'] = can_edit_stories
+    if can_delete_stories is not None:
+        payload['can_delete_stories'] = can_delete_stories
     return _make_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -3921,7 +3921,10 @@ class AsyncTeleBot:
             can_manage_chat: Optional[bool]=None, 
             can_manage_video_chats: Optional[bool]=None,
             can_manage_voice_chats: Optional[bool]=None,
-            can_manage_topics: Optional[bool]=None) -> bool:
+            can_manage_topics: Optional[bool]=None,
+            can_post_stories: Optional[bool]=None,
+            can_edit_stories: Optional[bool]=None,
+            can_delete_stories: Optional[bool]=None) -> bool:
         """
         Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator
         in the chat for this to work and must have the appropriate admin rights.
@@ -3982,6 +3985,15 @@ class AsyncTeleBot:
             and reopen forum topics, supergroups only
         :type can_manage_topics: :obj:`bool`
 
+        :param can_post_stories: Pass True if the administrator can create the channel's stories
+        :type can_post_stories: :obj:`bool`
+
+        :param can_edit_stories: Pass True if the administrator can edit the channel's stories
+        :type can_edit_stories: :obj:`bool`
+
+        :param can_delete_stories: Pass True if the administrator can delete the channel's stories
+        :type can_delete_stories: :obj:`bool`
+
         :return: True on success.
         :rtype: :obj:`bool`
         """
@@ -3995,7 +4007,8 @@ class AsyncTeleBot:
             self.token, chat_id, user_id, can_change_info, can_post_messages,
             can_edit_messages, can_delete_messages, can_invite_users,
             can_restrict_members, can_pin_messages, can_promote_members,
-            is_anonymous, can_manage_chat, can_manage_video_chats, can_manage_topics)
+            is_anonymous, can_manage_chat, can_manage_video_chats, can_manage_topics,
+            can_post_stories, can_edit_stories, can_delete_stories)
 
     async def set_chat_administrator_custom_title(
             self, chat_id: Union[int, str], user_id: int, custom_title: str) -> bool:

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -983,7 +983,8 @@ async def promote_chat_member(
         token, chat_id, user_id, can_change_info=None, can_post_messages=None,
         can_edit_messages=None, can_delete_messages=None, can_invite_users=None,
         can_restrict_members=None, can_pin_messages=None, can_promote_members=None,
-        is_anonymous=None, can_manage_chat=None, can_manage_video_chats=None, can_manage_topics=None):
+        is_anonymous=None, can_manage_chat=None, can_manage_video_chats=None, can_manage_topics=None,
+        can_post_stories=None, can_edit_stories=None, can_delete_stories=None):
     method_url = 'promoteChatMember'
     payload = {'chat_id': chat_id, 'user_id': user_id}
     if can_change_info is not None:
@@ -1010,6 +1011,12 @@ async def promote_chat_member(
         payload['can_manage_video_chats'] = can_manage_video_chats
     if can_manage_topics is not None:
         payload['can_manage_topics'] = can_manage_topics
+    if can_post_stories is not None:
+        payload['can_post_stories'] = can_post_stories
+    if can_edit_stories is not None:
+        payload['can_edit_stories'] = can_edit_stories
+    if can_delete_stories is not None:
+        payload['can_delete_stories'] = can_delete_stories
     return await _process_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -2888,6 +2888,7 @@ class ChatMember(JsonDeserializable):
                  can_send_other_messages=None, can_add_web_page_previews=None,  
                  can_manage_chat=None, can_manage_video_chats=None, 
                  until_date=None, can_manage_topics=None, 
+                 can_post_stories=None, can_edit_stories=None, can_delete_stories=None,
                  **kwargs):
         self.user: User = user
         self.status: str = status
@@ -2919,6 +2920,9 @@ class ChatMember(JsonDeserializable):
         self.can_send_videos: bool = can_send_videos
         self.can_send_video_notes: bool = can_send_video_notes
         self.can_send_voice_notes: bool = can_send_voice_notes
+        self.can_post_stories: bool = can_post_stories
+        self.can_edit_stories: bool = can_edit_stories
+        self.can_delete_stories: bool = can_delete_stories
         
 
 
@@ -3005,6 +3009,15 @@ class ChatMemberAdministrator(ChatMember):
 
     :param custom_title: Optional. Custom title for this user
     :type custom_title: :obj:`str`
+
+    :param can_post_stories: Optional. True, if the administrator can post channel stories
+    :type can_post_stories: :obj:`bool`
+
+    :param can_edit_stories: Optional. True, if the administrator can edit stories
+    :type can_edit_stories: :obj:`bool`
+
+    :param can_delete_stories: Optional. True, if the administrator can delete stories of other users
+    :type can_delete_stories: :obj:`bool`
 
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatMemberAdministrator`
@@ -7179,6 +7192,15 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
     :param can_manage_topics: Optional. True, if the user is allowed to create, rename, close, and reopen forum topics; supergroups only
     :type can_manage_topics: :obj:`bool`
 
+    :param can_post_stories: Optional. True, if the administrator can post channel stories
+    :type can_post_stories: :obj:`bool`
+
+    :param can_edit_stories: Optional. True, if the administrator can edit stories
+    :type can_edit_stories: :obj:`bool`
+
+    :param can_delete_stories: Optional. True, if the administrator can delete stories of other users
+    :type can_delete_stories: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatAdministratorRights`
     """
@@ -7193,7 +7215,10 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
         can_delete_messages: bool, can_manage_video_chats: bool, can_restrict_members: bool,
         can_promote_members: bool, can_change_info: bool, can_invite_users: bool,
         can_post_messages: bool=None, can_edit_messages: bool=None,
-        can_pin_messages: bool=None, can_manage_topics: bool=None) -> None:
+        can_pin_messages: bool=None, can_manage_topics: bool=None,
+        can_post_stories: bool=None, can_edit_stories: bool=None,
+        can_delete_stories: bool=None
+        ) -> None:
         
         self.is_anonymous: bool = is_anonymous
         self.can_manage_chat: bool = can_manage_chat
@@ -7207,6 +7232,9 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
         self.can_edit_messages: bool = can_edit_messages
         self.can_pin_messages: bool = can_pin_messages
         self.can_manage_topics: bool = can_manage_topics
+        self.can_post_stories: bool = can_post_stories
+        self.can_edit_stories: bool = can_edit_stories
+        self.can_delete_stories: bool = can_delete_stories
 
     def to_dict(self):
         json_dict = {
@@ -7227,6 +7255,13 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
             json_dict['can_pin_messages'] = self.can_pin_messages
         if self.can_manage_topics is not None:
             json_dict['can_manage_topics'] = self.can_manage_topics
+        if self.can_post_stories is not None:
+            json_dict['can_post_stories'] = self.can_post_stories
+        if self.can_edit_stories is not None:
+            json_dict['can_edit_stories'] = self.can_edit_stories
+        if self.can_delete_stories is not None:
+            json_dict['can_delete_stories'] = self.can_delete_stories
+            
         return json_dict
     
     def to_json(self):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -7261,7 +7261,7 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
             json_dict['can_edit_stories'] = self.can_edit_stories
         if self.can_delete_stories is not None:
             json_dict['can_delete_stories'] = self.can_delete_stories
-            
+
         return json_dict
     
     def to_json(self):
@@ -7482,13 +7482,21 @@ class ForumTopic(JsonDeserializable):
 
 class WriteAccessAllowed(JsonDeserializable):
     """
-    This object represents a service message about a user allowed to post messages in the chat.
-    Currently holds no information.
+    This object represents a service message about a user allowing a bot to write
+    messages after adding it to the attachment menu, launching a Web App from a link,
+    or accepting an explicit request from a Web App sent by the method requestWriteAccess.
 
     Telegram documentation: https://core.telegram.org/bots/api#writeaccessallowed
 
+    :param from_request: Optional. True, if the access was granted after the user accepted an
+        explicit request from a Web App sent by the method requestWriteAccess
+    :type from_request: :obj:`bool`
+
     :param web_app_name: Optional. Name of the Web App which was launched from a link
     :type web_app_name: :obj:`str`
+
+    :param from_attachment_menu: Optional. True, if the access was granted when the bot was added to the attachment or side menu
+    :type from_attachment_menu: :obj:`bool`
     """
     @classmethod
     def de_json(cls, json_string):
@@ -7497,8 +7505,10 @@ class WriteAccessAllowed(JsonDeserializable):
         return cls(**obj)
         
 
-    def __init__(self, web_app_name: str) -> None:
+    def __init__(self, from_request: Optional[bool]=None, web_app_name: Optional[str]=None, from_attachment_menu: Optional[bool]=None) -> None:
         self.web_app_name: str = web_app_name
+        self.from_request: bool = from_request
+        self.from_attachment_menu: bool = from_attachment_menu
         
 
 


### PR DESCRIPTION
- [x] Added the new administrator privileges can_post_stories, can_edit_stories and can_delete_stories to the classes [ChatMemberAdministrator](https://core.telegram.org/bots/api#chatmemberadministrator) and [ChatAdministratorRights](https://core.telegram.org/bots/api#chatadministratorrights).
- [x] Added the parameters can_post_stories, can_edit_stories and can_delete_stories to the method [promoteChatMember](https://core.telegram.org/bots/api#promotechatmember). Currently, bots have no use for these privileges besides assigning them to other administrators.
- [x] Added the ability to set any header color for Web App using the method setHeaderColor.
- [x] Added the field CloudStorage to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).
- [x] Added the methods requestWriteAccess and requestContact to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).
- [x] Added Web App events writeAccessRequested and contactRequested.
- [x] Added the fields from_request and from_attachment_menu to the class [WriteAccessAllowed](https://core.telegram.org/bots/api#writeaccessallowed).
- [x] Added the fields added_to_attachment_menu and allows_write_to_pm to the class [WebAppUser](https://core.telegram.org/bots/webapps#webappuser).