### PR TITLE
Fix ExceptionHandler handle() method as async for async telebot

### DIFF
--- a/examples/asynchronous_telebot/exception_handler.py
+++ b/examples/asynchronous_telebot/exception_handler.py
@@ -1,28 +1,25 @@
-
-import telebot
-from telebot.async_telebot import AsyncTeleBot
-
-
 import logging
 
-logger = telebot.logger
-telebot.logger.setLevel(logging.DEBUG) # Outputs debug messages to console.
+import telebot
+from telebot.async_telebot import AsyncTeleBot, ExceptionHandler
 
-class ExceptionHandler(telebot.ExceptionHandler):
-    def handle(self, exception):
+logger = telebot.logger
+telebot.logger.setLevel(logging.DEBUG)  # Outputs debug messages to console.
+
+
+class MyExceptionHandler(ExceptionHandler):
+    async def handle(self, exception):
         logger.error(exception)
 
-bot = AsyncTeleBot('TOKEN',exception_handler=ExceptionHandler())
 
-
+bot = AsyncTeleBot('TOKEN', exception_handler=MyExceptionHandler())
 
 
 @bot.message_handler(commands=['photo'])
 async def photo_send(message: telebot.types.Message):
     await bot.send_message(message.chat.id, 'Hi, this is an example of exception handlers.')
-    raise Exception('test') # Exception goes to ExceptionHandler if it is set
+    raise Exception('test')  # Exception goes to ExceptionHandler if it is set
     
-
 
 import asyncio
 asyncio.run(bot.polling())


### PR DESCRIPTION
issue https://github.com/eternnoir/pyTelegramBotAPI/issues/2070

## Description
Class ExceptionHandler has sync method handle() which is not compatible with async telebot in some cases.

## Describe your tests
How did you test your change?
```
export CHAT_ID='' GROUP_ID=''
cd tests
pytest
```
As a result:
2 failed, 106 passed, 2 skipped, 1 warning in 117.93s (0:01:57)

2 failed:
```
FAILED test_telebot.py::TestTeleBot::test_send_file_with_filename - telebot.apihelper.ApiTelegramException: A request to the Telegram API was unsuccessful. Error code: 400. Description: Bad Request: file must be non-empty
FAILED test_telebot.py::TestTeleBot::test_chat_commands - IndexError: list index out of range
```

Python version:
3.10

OS:
macOS 14.1

## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async
