### PR TITLE
Fix telebot.types.Message.html_text may contain unescaped HTML characters.

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1294,7 +1294,7 @@ class Message(JsonDeserializable):
     def __html_text(self, text, entities):
         """
         Author: @sviat9440
-        Updaters: @badiboy
+        Updaters: @badiboy, @EgorKhabarov
         Message: "*Test* parse _formatting_, [url](https://example.com), [text_mention](tg://user?id=123456) and mention @username"
 
         .. code-block:: python3
@@ -1314,7 +1314,7 @@ class Message(JsonDeserializable):
         """
 
         if not entities:
-            return text
+            return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
         _subs = {
             "bold": "<b>{text}</b>",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -295,7 +295,15 @@ def test_message_entity():
     message_4 = types.Update.de_json(sample_string_4).message
     assert message_4.html_text == '<s><u><i><b>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</b></i></u></s><tg-emoji emoji-id="5456188142006575553">😋</tg-emoji><tg-emoji emoji-id="5456188142006575553">😋</tg-emoji>'
 
-    
+
+    sample_string_5 = r'{"update_id":934522166,"message":{"message_id":1374526,"from":{"id":927266710,"is_bot":false,"first_name":">_run","username":"coder2020","language_code":"en","is_premium":true},"chat":{"id":927266710,"first_name":">_run","username":"coder2020","type":"private"},"date":1682179716,"text":"b <b>b</b> <i>i</i>","entities":[{"offset":0,"length":1,"type":"bold"}]}}'
+    message_5 = types.Update.de_json(sample_string_5).message
+    assert message_5.html_text == "<b>b</b> &lt;b&gt;b&lt;/b&gt; &lt;i&gt;i&lt;/i&gt;"
+
+
+    sample_string_6 = r'{"update_id":934522166,"message":{"message_id":1374526,"from":{"id":927266710,"is_bot":false,"first_name":">_run","username":"coder2020","language_code":"en","is_premium":true},"chat":{"id":927266710,"first_name":">_run","username":"coder2020","type":"private"},"date":1682179716,"text":"<b>b</b> <i>i</i>"}}'
+    message_6 = types.Update.de_json(sample_string_6).message
+    assert message_6.html_text == "&lt;b&gt;b&lt;/b&gt; &lt;i&gt;i&lt;/i&gt;"
 
 
 


### PR DESCRIPTION
## Description
A Telegram user could send HTML characters without markdown markup and they could end up in html_text.

## Describe your tests
The user sends `<b>b</b> <i>i</i>` (without markdown characters) and as an html string I expect to receive the escaped characters `&lt;b&gt;b&lt;/b&gt; &lt;i&gt;i&lt;/i&gt;`
If the user sends `**b** <b>b</b> <i>i</i>` (with markdown characters) then I get `<b>b</b> &lt;b&gt;b&lt;/ b&gt; &lt;i&gt;i&lt;/i&gt;`.

Python version: 3.11.6

OS: Windows 10

## Checklist:
- [X] I added/edited example on new feature/change (if exists)
- [X] My changes won't break backward compatibility
- [X] I made changes both for sync and async
