### PR TITLE
Bot API Huge Update - 7.0, introducing reactions, replies and some other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">A simple, but extensible Python implementation for the <a href="https://core.telegram.org/bots/api">Telegram Bot API</a>.</p>
 <p align="center">Both synchronous and asynchronous.</p>
 
-## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api-changelog#september-22-2023">6.9</a>!
+## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#december-29-2023">7.0</a>!
 
 <h2><a href='https://pytba.readthedocs.io/en/latest/index.html'>Official documentation</a></h2>
 <h2><a href='https://pytba.readthedocs.io/ru/latest/index.html'>Official ru documentation</a></h2>

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -218,6 +218,7 @@ class TeleBot:
         self.channel_post_handlers = []
         self.edited_channel_post_handlers = []
         self.message_reaction_handlers = []
+        self.message_reaction_count_handlers = []
         self.inline_handlers = []
         self.chosen_inline_handlers = []
         self.callback_query_handlers = []
@@ -672,6 +673,7 @@ class TeleBot:
         new_channel_posts = None
         new_edited_channel_posts = None
         new_message_reactions = None
+        message_reaction_counts = None
         new_inline_queries = None
         new_chosen_inline_results = None
         new_callback_queries = None
@@ -742,6 +744,9 @@ class TeleBot:
             if update.message_reaction:
                 if new_message_reactions is None: new_message_reactions = []
                 new_message_reactions.append(update.message_reaction)
+            if update.message_reaction_count:
+                if message_reaction_counts is None: message_reaction_counts = []
+                message_reaction_counts.append(update.message_reaction_count)
 
         if new_messages:
             self.process_new_messages(new_messages)
@@ -773,6 +778,8 @@ class TeleBot:
             self.process_new_chat_join_request(new_chat_join_request)
         if new_message_reactions:
             self.process_new_message_reaction(new_message_reactions)
+        if message_reaction_counts:
+            self.process_new_message_reaction_count(message_reaction_counts)
 
     def process_new_messages(self, new_messages):
         """
@@ -806,6 +813,12 @@ class TeleBot:
         :meta private:
         """
         self._notify_command_handlers(self.message_reaction_handlers, message_reactions, 'message_reaction')
+    
+    def process_new_message_reaction_count(self, message_reaction_counts):
+        """
+        :meta private:
+        """
+        self._notify_command_handlers(self.message_reaction_count_handlers, message_reaction_counts, 'message_reaction_count')
 
     def process_new_inline_query(self, new_inline_queries):
         """
@@ -6239,6 +6252,56 @@ class TeleBot:
         handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
         self.add_message_reaction_handler(handler_dict)
 
+    def message_reaction_count_handler(self, func, **kwargs):
+        """
+        Handles new incoming message reaction count.
+        As a parameter to the decorator function, it passes :class:`telebot.types.Message` object.
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return:
+        """
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
+            self.add_message_reaction_count_handler(handler_dict)
+            return handler
+
+        return decorator
+    
+    def add_message_reaction_count_handler(self, handler_dict):
+        """
+        Adds message reaction count handler
+        Note that you should use register_message_reaction_count_handler to add message_reaction_count_handler to the bot.
+
+        :meta private:
+
+        :param handler_dict:
+        :return:
+        """
+        self.message_reaction_count_handlers.append(handler_dict)
+
+    def register_message_reaction_count_handler(self, callback: Callable, func: Callable, pass_bot: Optional[bool]=False, **kwargs):
+        """
+        Registers message reaction count handler.
+
+        :param callback: function to be called
+        :type callback: :obj:`function`
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
+        :type pass_bot: :obj:`bool`
+        
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return: None
+        """
+        handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
+        self.add_message_reaction_count_handler(handler_dict)
 
     def inline_handler(self, func, **kwargs):
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1604,7 +1604,7 @@ class TeleBot:
             apihelper.send_message(
                 self.token, chat_id, text, disable_web_page_preview,
                 reply_markup, parse_mode, disable_notification, timeout,
-                entities, protect_content=protect_content, message_thread_id=message_thread_id))
+                entities, protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters))
 
     def forward_message(
             self, chat_id: Union[int, str], from_chat_id: Union[int, str], 
@@ -1847,7 +1847,8 @@ class TeleBot:
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
-            has_spoiler: Optional[bool]=None) -> types.Message:
+            has_spoiler: Optional[bool]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send photos. On success, the sent Message is returned.
 
@@ -1895,6 +1896,9 @@ class TeleBot:
 
         :param has_spoiler: Pass True, if the photo should be sent as a spoiler
         :type has_spoiler: :obj:`bool`
+
+        :param reply_parameters: Additional parameters for replies to messages
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
         
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -1936,7 +1940,7 @@ class TeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
-            reply_parameters: Optional[bool]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player.
         Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size,

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1879,8 +1879,8 @@ class TeleBot:
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
 
-        return types.MessageID.de_json(
-            apihelper.forward_messages(self.token, chat_id, from_chat_id, message_ids, disable_notification, protect_content, message_thread_id))
+        return [types.MessageID.de_json(message_id) for message_id in
+            apihelper.forward_messages(self.token, chat_id, from_chat_id, message_ids, disable_notification, protect_content, message_thread_id))]
     
     def copy_messages(self, chat_id: Union[str, int], from_chat_id: Union[str, int], message_ids: List[int],
                         disable_notification: Optional[bool] = None, message_thread_id: Optional[int] = None,

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1776,6 +1776,97 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.delete_message(self.token, chat_id, message_id, timeout)
+    
+    def delete_messages(self, chat_id: Union[int, str], message_ids: List[int]):
+        """
+        Use this method to delete multiple messages in a chat. 
+        The number of messages to be deleted must not exceed 100. 
+        If the chat is a private chat, the user must be an administrator of the chat for this to work and must have the appropriate admin rights. 
+        Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#deletemessages
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_ids: Identifiers of the messages to be deleted
+        :type message_ids: :obj:`list` of :obj:`int`
+
+        :return: Returns True on success.
+
+        """
+        return apihelper.delete_messages(self.token, chat_id, message_ids)
+    
+    def forward_messages(self, chat_id: Union[str, int], from_chat_id: Union[str, int], message_ids: List[int], disable_notification: Optional[bool]=None,
+                         message_thread_id: Optional[int]=None, protect_content: Optional[bool]=None) -> List[types.MessageID]:
+        """
+        Use this method to forward messages of any kind.
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param from_chat_id: Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
+        :type from_chat_id: :obj:`int` or :obj:`str`
+
+        :param message_ids: Message identifiers in the chat specified in from_chat_id
+        :type message_ids: :obj:`list`
+
+        :param disable_notification: Sends the message silently. Users will receive a notification with no sound
+        :type disable_notification: :obj:`bool`
+
+        :param message_thread_id: Identifier of a message thread, in which the messages will be sent
+        :type message_thread_id: :obj:`int`
+
+        :param protect_content: Protects the contents of the forwarded message from forwarding and saving
+        :type protect_content: :obj:`bool`
+
+        :return: On success, the sent Message is returned.
+        :rtype: :class:`telebot.types.MessageID`
+        """
+
+        disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
+        protect_content = self.protect_content if (protect_content is None) else protect_content
+
+        return types.MessageID.de_json(
+            apihelper.forward_messages(self.token, chat_id, from_chat_id, message_ids, disable_notification, protect_content, message_thread_id))
+    
+    def copy_messages(self, chat_id: Union[str, int], from_chat_id: Union[str, int], message_ids: List[int],
+                        disable_notification: Optional[bool] = None, message_thread_id: Optional[int] = None,
+                        protect_content: Optional[bool] = None, remove_caption: Optional[bool] = None) -> List[types.MessageID]:
+            """
+            Use this method to copy messages of any kind.
+
+            :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+            :type chat_id: :obj:`int` or :obj:`str`
+
+            :param from_chat_id: Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
+            :type from_chat_id: :obj:`int` or :obj:`str`
+
+            :param message_ids: Message identifiers in the chat specified in from_chat_id
+            :type message_ids: :obj:`list` of :obj:`int`
+
+            :param disable_notification: Sends the message silently. Users will receive a notification with no sound
+            :type disable_notification: :obj:`bool`
+
+            :param message_thread_id: Identifier of a message thread, in which the messages will be sent
+            :type message_thread_id: :obj:`int`
+
+            :param protect_content: Protects the contents of the forwarded message from forwarding and saving
+            :type protect_content: :obj:`bool`
+
+            :param remove_caption: Pass True to copy the messages without their captions
+            :type remove_caption: :obj:`bool`
+
+            :return: On success, an array of MessageId of the sent messages is returned.
+            :rtype: :obj:`list` of :class:`telebot.types.MessageID`
+            """
+            disable_notification = self.disable_notification if disable_notification is None else disable_notification
+            protect_content = self.protect_content if protect_content is None else protect_content
+
+            return [types.MessageID.de_json(message_id) for message_id in
+                    apihelper.copy_messages(self.token, chat_id, from_chat_id, message_ids, disable_notification,
+                                            protect_content, message_thread_id, remove_caption)]
+    
 
     def send_dice(
             self, chat_id: Union[int, str],

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1531,7 +1531,8 @@ class TeleBot:
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            link_preview_options : Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send text messages.
 
@@ -1581,6 +1582,9 @@ class TeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param link_preview_options: Link preview options.
+        :type link_preview_options: :class:`telebot.types.LinkPreviewOptions`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -1600,11 +1604,20 @@ class TeleBot:
                 message_id=reply_to_message_id
             )
 
+        if disable_web_page_preview:
+            # show a deprecation warning
+            logger.warning("The parameter 'disable_web_page_preview' is deprecated. Use 'link_preview_options' instead.")
+
+            # create a LinkPreviewOptions object
+            link_preview_options = types.LinkPreviewOptions(
+                disable_web_page_preview=disable_web_page_preview
+            )
+
         return types.Message.de_json(
             apihelper.send_message(
-                self.token, chat_id, text, disable_web_page_preview,
+                self.token, chat_id, text,
                 reply_markup, parse_mode, disable_notification, timeout,
-                entities, protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters))
+                entities, protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters, link_preview_options=link_preview_options))
 
     def forward_message(
             self, chat_id: Union[int, str], from_chat_id: Union[int, str], 
@@ -4050,7 +4063,8 @@ class TeleBot:
             parse_mode: Optional[str]=None,
             entities: Optional[List[types.MessageEntity]]=None,
             disable_web_page_preview: Optional[bool]=None,
-            reply_markup: Optional[types.InlineKeyboardMarkup]=None) -> Union[types.Message, bool]:
+            reply_markup: Optional[types.InlineKeyboardMarkup]=None,
+            link_preview_options : Optional[types.LinkPreviewOptions]=None) -> Union[types.Message, bool]:
         """
         Use this method to edit text and game messages.
 
@@ -4080,14 +4094,27 @@ class TeleBot:
         :param reply_markup: A JSON-serialized object for an inline keyboard.
         :type reply_markup: :obj:`InlineKeyboardMarkup`
 
+        :param link_preview_options: A JSON-serialized object for options used to automatically generate previews for links.
+        :type link_preview_options: :obj:`LinkPreviewOptions`
+
         :return: On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
         :rtype: :obj:`types.Message` or :obj:`bool`
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_web_page_preview = self.disable_web_page_preview if (disable_web_page_preview is None) else disable_web_page_preview
 
+        if disable_web_page_preview:
+            # show a deprecation warning
+            logger.warning("The parameter 'disable_web_page_preview' is deprecated. Use 'link_preview_options' instead.")
+
+            # create a LinkPreviewOptions object
+            link_preview_options = types.LinkPreviewOptions(
+                disable_web_page_preview=disable_web_page_preview
+            )
+            
+
         result = apihelper.edit_message_text(self.token, text, chat_id, message_id, inline_message_id, parse_mode,
-                                             entities, disable_web_page_preview, reply_markup)
+                                             entities, reply_markup, link_preview_options)
         if type(result) == bool:  # if edit inline message return is bool not Message.
             return result
         return types.Message.de_json(result)

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -217,6 +217,7 @@ class TeleBot:
         self.edited_message_handlers = []
         self.channel_post_handlers = []
         self.edited_channel_post_handlers = []
+        self.message_reaction_handlers = []
         self.inline_handlers = []
         self.chosen_inline_handlers = []
         self.callback_query_handlers = []
@@ -670,6 +671,7 @@ class TeleBot:
         new_edited_messages = None
         new_channel_posts = None
         new_edited_channel_posts = None
+        new_message_reactions = None
         new_inline_queries = None
         new_chosen_inline_results = None
         new_callback_queries = None
@@ -737,6 +739,9 @@ class TeleBot:
             if update.chat_join_request:
                 if new_chat_join_request is None: new_chat_join_request = []
                 new_chat_join_request.append(update.chat_join_request)
+            if update.message_reactions:
+                if new_message_reactions is None: new_message_reactions = []
+                new_message_reactions.append(update.message_reaction)
 
         if new_messages:
             self.process_new_messages(new_messages)
@@ -766,6 +771,8 @@ class TeleBot:
             self.process_new_chat_member(new_chat_members)
         if new_chat_join_request:
             self.process_new_chat_join_request(new_chat_join_request)
+        if new_message_reactions:
+            self.process_new_message_reaction(new_message_reactions)
 
     def process_new_messages(self, new_messages):
         """
@@ -793,6 +800,12 @@ class TeleBot:
         :meta private:
         """
         self._notify_command_handlers(self.edited_channel_post_handlers, edited_channel_post, 'edited_channel_post')
+
+    def process_new_message_reaction(self, message_reactions):
+        """
+        :meta private:
+        """
+        self._notify_command_handlers(self.message_reaction_handlers, message_reactions, 'message_reaction')
 
     def process_new_inline_query(self, new_inline_queries):
         """
@@ -6173,6 +6186,59 @@ class TeleBot:
                                                 pass_bot=pass_bot,
                                                 **kwargs)
         self.add_edited_channel_post_handler(handler_dict)
+
+
+    def message_reaction_handler(self, func, **kwargs):
+        """
+        Handles new incoming message reaction.
+        As a parameter to the decorator function, it passes :class:`telebot.types.Message` object.
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return:
+        """
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
+            self.add_message_reaction_handler(handler_dict)
+            return handler
+
+        return decorator
+    
+    def add_message_reaction_handler(self, handler_dict):
+        """
+        Adds message reaction handler
+        Note that you should use register_message_reaction_handler to add message_reaction_handler to the bot.
+
+        :meta private:
+
+        :param handler_dict:
+        :return:
+        """
+        self.message_reaction_handlers.append(handler_dict)
+
+    def register_message_reaction_handler(self, callback: Callable, func: Callable, pass_bot: Optional[bool]=False, **kwargs):
+        """
+        Registers message reaction handler.
+
+        :param callback: function to be called
+        :type callback: :obj:`function`
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
+        :type pass_bot: :obj:`bool`
+        
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return: None
+        """
+        handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
+        self.add_message_reaction_handler(handler_dict)
+
 
     def inline_handler(self, func, **kwargs):
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1530,7 +1530,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send text messages.
 
@@ -1577,6 +1578,9 @@ class TeleBot:
         :param message_thread_id: Identifier of a message thread, in which the message will be sent
         :type message_thread_id: :obj:`int`
 
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -1586,11 +1590,21 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             apihelper.send_message(
-                self.token, chat_id, text, disable_web_page_preview, reply_to_message_id,
+                self.token, chat_id, text, disable_web_page_preview,
                 reply_markup, parse_mode, disable_notification, timeout,
-                entities, allow_sending_without_reply, protect_content=protect_content, message_thread_id=message_thread_id))
+                entities, protect_content=protect_content, message_thread_id=message_thread_id))
 
     def forward_message(
             self, chat_id: Union[int, str], from_chat_id: Union[int, str], 
@@ -1648,7 +1662,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
-            message_thread_id: Optional[int]=None) -> types.MessageID:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.MessageID:
         """
         Use this method to copy messages of any kind.
 
@@ -1693,6 +1708,9 @@ class TeleBot:
 
         :param message_thread_id: Identifier of a message thread, in which the message will be sent
         :type message_thread_id: :obj:`int`
+
+        :param reply_parameters: Additional parameters for replies to messages
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
         
         :return: On success, the MessageId of the sent message is returned.
         :rtype: :class:`telebot.types.MessageID`
@@ -1702,10 +1720,20 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.MessageID.de_json(
             apihelper.copy_message(self.token, chat_id, from_chat_id, message_id, caption, parse_mode, caption_entities,
-                                   disable_notification, reply_to_message_id, allow_sending_without_reply, reply_markup,
-                                   timeout, protect_content, message_thread_id))
+                                   disable_notification, reply_markup,
+                                   timeout, protect_content, message_thread_id, reply_parameters))
 
     def delete_message(self, chat_id: Union[int, str], message_id: int, 
             timeout: Optional[int]=None) -> bool:
@@ -1744,7 +1772,8 @@ class TeleBot:
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send an animated emoji that will display a random value. On success, the sent Message is returned.
 
@@ -1780,6 +1809,9 @@ class TeleBot:
         :param message_thread_id: Identifier of a message thread, in which the message will be sent
         :type message_thread_id: :obj:`int`
 
+        :param reply_parameters: Additional parameters for replies to messages
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -1787,10 +1819,20 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             apihelper.send_dice(
-                self.token, chat_id, emoji, disable_notification, reply_to_message_id,
-                reply_markup, timeout, allow_sending_without_reply, protect_content, message_thread_id)
+                self.token, chat_id, emoji, disable_notification,
+                reply_markup, timeout, protect_content, message_thread_id, reply_parameters)
         )
 
 
@@ -1862,11 +1904,21 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             apihelper.send_photo(
-                self.token, chat_id, photo, caption, reply_to_message_id, reply_markup,
+                self.token, chat_id, photo, caption, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
-                allow_sending_without_reply, protect_content, message_thread_id, has_spoiler))
+                protect_content, message_thread_id, has_spoiler, reply_parameters))
 
     # TODO: Rewrite this method like in API.
     def send_audio(
@@ -1883,7 +1935,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            thumb: Optional[Union[Any, str]]=None,) -> types.Message:
+            thumb: Optional[Union[Any, str]]=None,
+            reply_parameters: Optional[bool]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player.
         Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size,
@@ -1950,6 +2003,9 @@ class TeleBot:
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
 
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -1958,15 +2014,25 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         if thumb is not None and thumbnail is None:
             thumbnail = thumb
             logger.warning('The parameter "thumb" is deprecated. Use "thumbnail" instead.')
 
         return types.Message.de_json(
             apihelper.send_audio(
-                self.token, chat_id, audio, caption, duration, performer, title, reply_to_message_id,
+                self.token, chat_id, audio, caption, duration, performer, title,
                 reply_markup, parse_mode, disable_notification, timeout, thumbnail,
-                caption_entities, allow_sending_without_reply, protect_content, message_thread_id))
+                caption_entities, protect_content, message_thread_id, reply_parameters))
 
     # TODO: Rewrite this method like in API.
     def send_voice(
@@ -1980,7 +2046,8 @@ class TeleBot:
             caption_entities: Optional[List[types.MessageEntity]]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
         For this to work, your audio must be in an .OGG file encoded with OPUS (other formats may be sent as Audio or Document).
@@ -2030,6 +2097,9 @@ class TeleBot:
         :param message_thread_id: Identifier of a message thread, in which the message will be sent
         :type message_thread_id: :obj:`int`
 
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
@@ -2037,11 +2107,21 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             apihelper.send_voice(
-                self.token, chat_id, voice, caption, duration, reply_to_message_id, reply_markup,
+                self.token, chat_id, voice, caption, duration, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
-                allow_sending_without_reply, protect_content, message_thread_id))
+                protect_content, message_thread_id, reply_parameters))
 
     # TODO: Rewrite this method like in API.
     def send_document(
@@ -2059,7 +2139,8 @@ class TeleBot:
             disable_content_type_detection: Optional[bool]=None,
             data: Optional[Union[Any, str]]=None,
             protect_content: Optional[bool]=None, message_thread_id: Optional[int]=None,
-            thumb: Optional[Union[Any, str]]=None,) -> types.Message:
+            thumb: Optional[Union[Any, str]]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send general files.
 
@@ -2119,6 +2200,9 @@ class TeleBot:
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
 
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2126,6 +2210,16 @@ class TeleBot:
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
 
         if data and (not document):
             # function typo miss compatibility
@@ -2139,11 +2233,10 @@ class TeleBot:
         return types.Message.de_json(
             apihelper.send_data(
                 self.token, chat_id, document, 'document',
-                reply_to_message_id = reply_to_message_id, reply_markup = reply_markup, parse_mode = parse_mode,
+                reply_parameters=reply_parameters, reply_markup = reply_markup, parse_mode = parse_mode,
                 disable_notification = disable_notification, timeout = timeout, caption = caption, thumbnail= thumbnail,
-                caption_entities = caption_entities, allow_sending_without_reply = allow_sending_without_reply,
-                disable_content_type_detection = disable_content_type_detection, visible_file_name = visible_file_name,
-                protect_content = protect_content, message_thread_id = message_thread_id))
+                caption_entities = caption_entities, disable_content_type_detection = disable_content_type_detection,
+                visible_file_name = visible_file_name, protect_content = protect_content, message_thread_id = message_thread_id))
 
 
     # TODO: Rewrite this method like in API.
@@ -2158,7 +2251,8 @@ class TeleBot:
             protect_content:Optional[bool]=None,
             data: Union[Any, str]=None,
             message_thread_id: Optional[int]=None,
-            emoji: Optional[str]=None) -> types.Message:
+            emoji: Optional[str]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers.
         On success, the sent Message is returned.
@@ -2201,6 +2295,9 @@ class TeleBot:
         :param emoji: Emoji associated with the sticker; only for just uploaded stickers
         :type emoji: :obj:`str`
 
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2213,13 +2310,22 @@ class TeleBot:
             logger.warning('The parameter "data" is deprecated. Use "sticker" instead.')
             sticker = data
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             apihelper.send_data(
-                self.token, chat_id, sticker, 'sticker',
-                reply_to_message_id=reply_to_message_id, reply_markup=reply_markup,
+                self.token, chat_id, sticker, 'sticker', reply_markup=reply_markup,
                 disable_notification=disable_notification, timeout=timeout, 
-                allow_sending_without_reply=allow_sending_without_reply,
-                protect_content=protect_content, message_thread_id=message_thread_id, emoji=emoji))
+                protect_content=protect_content, message_thread_id=message_thread_id, emoji=emoji,
+                reply_parameters=reply_parameters))
 
     def send_video(
             self, chat_id: Union[int, str], video: Union[Any, str], 
@@ -2240,7 +2346,8 @@ class TeleBot:
             data: Optional[Union[Any, str]]=None,
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
-            thumb: Optional[Union[Any, str]]=None,) -> types.Message:
+            thumb: Optional[Union[Any, str]]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
         
@@ -2308,6 +2415,9 @@ class TeleBot:
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
 
+        :param reply_parameters: Reply parameters
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2325,11 +2435,21 @@ class TeleBot:
             thumbnail = thumb
             logger.warning('The parameter "thumb" is deprecated. Use "thumbnail" instead.')
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             apihelper.send_video(
-                self.token, chat_id, video, duration, caption, reply_to_message_id, reply_markup,
+                self.token, chat_id, video, duration, caption, reply_markup,
                 parse_mode, supports_streaming, disable_notification, timeout, thumbnail, width, height,
-                caption_entities, allow_sending_without_reply, protect_content, message_thread_id, has_spoiler))
+                caption_entities, protect_content, message_thread_id, has_spoiler, reply_parameters))
 
     def send_animation(
             self, chat_id: Union[int, str], animation: Union[Any, str], 
@@ -2348,7 +2468,8 @@ class TeleBot:
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
-            thumb: Optional[Union[Any, str]]=None,) -> types.Message:
+            thumb: Optional[Union[Any, str]]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
@@ -2415,6 +2536,9 @@ class TeleBot:
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
 
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2423,14 +2547,24 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         if thumbnail is None and thumb is not None:
             thumbnail = thumb
             logger.warning('The parameter "thumb" is deprecated. Use "thumbnail" instead.')
         return types.Message.de_json(
             apihelper.send_animation(
-                self.token, chat_id, animation, duration, caption, reply_to_message_id,
+                self.token, chat_id, animation, duration, caption,
                 reply_markup, parse_mode, disable_notification, timeout, thumbnail,
-                caption_entities, allow_sending_without_reply, protect_content, width, height, message_thread_id, has_spoiler))
+                caption_entities, protect_content, width, height, message_thread_id, has_spoiler, reply_parameters))
 
     # TODO: Rewrite this method like in API.
     def send_video_note(
@@ -2445,7 +2579,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            thumb: Optional[Union[Any, str]]=None) -> types.Message:
+            thumb: Optional[Union[Any, str]]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         As of v.4.0, Telegram clients support rounded square MPEG4 videos of up to 1 minute long.
         Use this method to send video messages. On success, the sent Message is returned.
@@ -2495,7 +2630,11 @@ class TeleBot:
         :type message_thread_id: :obj:`int`
 
         :param thumb: Deprecated. Use thumbnail instead
-    :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
+        :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
+
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2507,10 +2646,20 @@ class TeleBot:
             thumbnail = thumb
             logger.warning('The parameter "thumb" is deprecated. Use "thumbnail" instead.')
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             apihelper.send_video_note(
-                self.token, chat_id, data, duration, length, reply_to_message_id, reply_markup,
-                disable_notification, timeout, thumbnail, allow_sending_without_reply, protect_content, message_thread_id))
+                self.token, chat_id, data, duration, length, reply_markup,
+                disable_notification, timeout, thumbnail, protect_content, message_thread_id, reply_parameters))
 
 
     def send_media_group(
@@ -2523,7 +2672,8 @@ class TeleBot:
             reply_to_message_id: Optional[int]=None, 
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> List[types.Message]:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> List[types.Message]:
         """
         Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files
         can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned.
@@ -2554,6 +2704,9 @@ class TeleBot:
         :param message_thread_id: Identifier of a message thread, in which the media group will be sent
         :type message_thread_id: :obj:`int`
 
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, an array of Messages that were sent is returned.
         :rtype: List[types.Message]
         """
@@ -2561,9 +2714,19 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         result = apihelper.send_media_group(
-            self.token, chat_id, media, disable_notification, reply_to_message_id, timeout, 
-            allow_sending_without_reply, protect_content, message_thread_id)
+            self.token, chat_id, media, disable_notification, timeout, 
+            protect_content, message_thread_id, reply_parameters)
         return [types.Message.de_json(msg) for msg in result]
 
     # TODO: Rewrite this method like in API.
@@ -2580,7 +2743,8 @@ class TeleBot:
             proximity_alert_radius: Optional[int]=None, 
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send point on the map. On success, the sent Message is returned.
 
@@ -2630,6 +2794,9 @@ class TeleBot:
         :param message_thread_id: Identifier of a message thread, in which the message will be sent
         :type message_thread_id: :obj:`int`
 
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2637,12 +2804,22 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             apihelper.send_location(
                 self.token, chat_id, latitude, longitude, live_period, 
-                reply_to_message_id, reply_markup, disable_notification, timeout, 
+                reply_markup, disable_notification, timeout, 
                 horizontal_accuracy, heading, proximity_alert_radius, 
-                allow_sending_without_reply, protect_content, message_thread_id))
+                protect_content, message_thread_id, reply_parameters))
 
     def edit_message_live_location(
             self, latitude: float, longitude: float, 
@@ -2751,7 +2928,8 @@ class TeleBot:
             google_place_id: Optional[str]=None,
             google_place_type: Optional[str]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send information about a venue. On success, the sent Message is returned.
         
@@ -2809,6 +2987,9 @@ class TeleBot:
         :param message_thread_id: The thread identifier of a message from which the reply will be sent
         :type message_thread_id: :obj:`int`
 
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2816,11 +2997,21 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             apihelper.send_venue(
                 self.token, chat_id, latitude, longitude, title, address, foursquare_id, foursquare_type,
-                disable_notification, reply_to_message_id, reply_markup, timeout,
-                allow_sending_without_reply, google_place_id, google_place_type, protect_content, message_thread_id))
+                disable_notification, reply_markup, timeout,
+                google_place_id, google_place_type, protect_content, message_thread_id, reply_parameters))
 
 
     # TODO: Rewrite this method like in API.
@@ -2833,7 +3024,8 @@ class TeleBot:
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            protect_content: Optional[bool]=None, message_thread_id: Optional[int]=None) -> types.Message:
+            protect_content: Optional[bool]=None, message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send phone contacts. On success, the sent Message is returned.
 
@@ -2878,6 +3070,9 @@ class TeleBot:
         :param message_thread_id: The thread identifier of a message from which the reply will be sent
         :type message_thread_id: :obj:`int`
 
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2885,11 +3080,21 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             apihelper.send_contact(
                 self.token, chat_id, phone_number, first_name, last_name, vcard,
-                disable_notification, reply_to_message_id, reply_markup, timeout,
-                allow_sending_without_reply, protect_content, message_thread_id))
+                disable_notification, reply_markup, timeout,
+                protect_content, message_thread_id, reply_parameters))
 
     def send_chat_action(
             self, chat_id: Union[int, str], action: str, timeout: Optional[int]=None, message_thread_id: Optional[int]=None) -> bool:
@@ -3956,7 +4161,8 @@ class TeleBot:
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Used to send the game.
 
@@ -3989,6 +4195,9 @@ class TeleBot:
         :param message_thread_id: The identifier of a message thread, in which the game message will be sent.
         :type message_thread_id: :obj:`int`
 
+        :param reply_parameters: Reply parameters
+        :type reply_parameters: :obj:`ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -3996,10 +4205,20 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         result = apihelper.send_game(
             self.token, chat_id, game_short_name, disable_notification,
-            reply_to_message_id, reply_markup, timeout, 
-            allow_sending_without_reply, protect_content, message_thread_id)
+            reply_markup, timeout, 
+            protect_content, message_thread_id, reply_parameters)
         return types.Message.de_json(result)
 
     def set_game_score(
@@ -4097,7 +4316,8 @@ class TeleBot:
             max_tip_amount: Optional[int] = None,
             suggested_tip_amounts: Optional[List[int]]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Sends invoice.
 
@@ -4199,6 +4419,9 @@ class TeleBot:
         :param message_thread_id: The identifier of a message thread, in which the invoice message will be sent
         :type message_thread_id: :obj:`int`
 
+        :param reply_parameters: Required if the message is a reply. Additional interface options.
+        :type reply_parameters: :obj:`types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -4206,13 +4429,23 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         result = apihelper.send_invoice(
             self.token, chat_id, title, description, invoice_payload, provider_token,
             currency, prices, start_parameter, photo_url, photo_size, photo_width,
             photo_height, need_name, need_phone_number, need_email, need_shipping_address,
             send_phone_number_to_provider, send_email_to_provider, is_flexible, disable_notification,
-            reply_to_message_id, reply_markup, provider_data, timeout, allow_sending_without_reply,
-            max_tip_amount, suggested_tip_amounts, protect_content, message_thread_id)
+            reply_markup, provider_data, timeout,
+            max_tip_amount, suggested_tip_amounts, protect_content, message_thread_id, reply_parameters)
         return types.Message.de_json(result)
 
     def create_invoice_link(self,
@@ -4337,7 +4570,8 @@ class TeleBot:
             timeout: Optional[int]=None,
             explanation_entities: Optional[List[types.MessageEntity]]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send a native poll.
         On success, the sent Message is returned.
@@ -4408,6 +4642,9 @@ class TeleBot:
         :param message_thread_id: The identifier of a message thread, in which the poll will be sent
         :type message_thread_id: :obj:`int`
 
+        :param reply_parameters: reply parameters.
+        :type reply_parameters: :obj:`ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -4417,6 +4654,16 @@ class TeleBot:
 
         if isinstance(question, types.Poll):
             raise RuntimeError("The send_poll signature was changed, please see send_poll function details.")
+        
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
 
         explanation_parse_mode = self.parse_mode if (explanation_parse_mode is None) else explanation_parse_mode
 
@@ -4426,8 +4673,8 @@ class TeleBot:
                 question, options,
                 is_anonymous, type, allows_multiple_answers, correct_option_id,
                 explanation, explanation_parse_mode, open_period, close_date, is_closed,
-                disable_notification, reply_to_message_id, allow_sending_without_reply,
-                reply_markup, timeout, explanation_entities, protect_content, message_thread_id))
+                disable_notification,reply_markup, timeout, explanation_entities, protect_content, message_thread_id,
+                reply_parameters))
 
     def stop_poll(
             self, chat_id: Union[int, str], message_id: int, 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -905,7 +905,7 @@ class TeleBot:
         :meta private:
         """
         self._notify_command_handlers(self.removed_chat_boost_handlers, removed_chat_boosts, 'removed_chat_boost')
-        
+
 
     def process_middlewares(self, update):
         """
@@ -5069,6 +5069,25 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.answer_callback_query(self.token, callback_query_id, text, show_alert, url, cache_time)
+    
+    def get_user_chat_boosts(self, chat_id: Union[int, str], user_id: int) -> types.UserChatBoosts:
+        """
+        Use this method to get the list of boosts added to a chat by a user. Requires administrator rights in the chat. Returns a UserChatBoosts object.
+
+        Telegram documentation: https://core.telegram.org/bots/api#getuserchatboosts
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param user_id: Unique identifier of the target user
+        :type user_id: :obj:`int`
+
+        :return: On success, a UserChatBoosts object is returned.
+        :rtype: :class:`telebot.types.UserChatBoosts`
+        """
+
+        result = apihelper.get_user_chat_boosts(self.token, chat_id, user_id)
+        return types.UserChatBoosts.de_json(result)
 
     def set_sticker_set_thumbnail(self, name: str, user_id: int, thumbnail: Union[Any, str]=None):
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -675,7 +675,7 @@ class TeleBot:
         new_channel_posts = None
         new_edited_channel_posts = None
         new_message_reactions = None
-        message_reaction_counts = None
+        new_message_reaction_counts = None
         new_inline_queries = None
         new_chosen_inline_results = None
         new_callback_queries = None
@@ -686,8 +686,8 @@ class TeleBot:
         new_my_chat_members = None
         new_chat_members = None
         new_chat_join_request = None
-        removed_chat_boosts = None
-        chat_boosts = None
+        new_chat_boosts = None
+        new_removed_chat_boosts = None
         
         for update in updates:
             if apihelper.ENABLE_MIDDLEWARE and not self.use_class_middlewares:
@@ -749,14 +749,14 @@ class TeleBot:
                 if new_message_reactions is None: new_message_reactions = []
                 new_message_reactions.append(update.message_reaction)
             if update.message_reaction_count:
-                if message_reaction_counts is None: message_reaction_counts = []
-                message_reaction_counts.append(update.message_reaction_count)
+                if new_message_reaction_counts is None: new_message_reaction_counts = []
+                new_message_reaction_counts.append(update.message_reaction_count)
             if update.chat_boost:
-                if chat_boosts is None: chat_boosts = []
-                chat_boosts.append(update.chat_boost)
+                if new_chat_boosts is None: new_chat_boosts = []
+                new_chat_boosts.append(update.chat_boost)
             if update.removed_chat_boost:
-                if removed_chat_boosts is None: removed_chat_boosts = []
-                removed_chat_boosts.append(update.removed_chat_boost)
+                if new_removed_chat_boosts is None: new_removed_chat_boosts = []
+                new_removed_chat_boosts.append(update.removed_chat_boost)
 
         if new_messages:
             self.process_new_messages(new_messages)
@@ -788,12 +788,12 @@ class TeleBot:
             self.process_new_chat_join_request(new_chat_join_request)
         if new_message_reactions:
             self.process_new_message_reaction(new_message_reactions)
-        if message_reaction_counts:
-            self.process_new_message_reaction_count(message_reaction_counts)
-        if chat_boosts:
-            self.process_new_chat_boost(chat_boosts)
-        if removed_chat_boosts:
-            self.process_new_removed_chat_boost(removed_chat_boosts)
+        if new_message_reaction_counts:
+            self.process_new_message_reaction_count(new_message_reaction_counts)
+        if new_chat_boosts:
+            self.process_new_chat_boost(new_chat_boosts)
+        if new_removed_chat_boosts:
+            self.process_new_removed_chat_boost(new_removed_chat_boosts)
 
     def process_new_messages(self, new_messages):
         """
@@ -804,35 +804,35 @@ class TeleBot:
         self.__notify_update(new_messages)
         self._notify_command_handlers(self.message_handlers, new_messages, 'message')
 
-    def process_new_edited_messages(self, edited_message):
+    def process_new_edited_messages(self, new_edited_message):
         """
         :meta private:
         """
-        self._notify_command_handlers(self.edited_message_handlers, edited_message, 'edited_message')
+        self._notify_command_handlers(self.edited_message_handlers, new_edited_message, 'edited_message')
 
-    def process_new_channel_posts(self, channel_post):
+    def process_new_channel_posts(self, new_channel_post):
         """
         :meta private:
         """
-        self._notify_command_handlers(self.channel_post_handlers, channel_post, 'channel_post')
+        self._notify_command_handlers(self.channel_post_handlers, new_channel_post, 'channel_post')
 
-    def process_new_edited_channel_posts(self, edited_channel_post):
+    def process_new_edited_channel_posts(self, new_edited_channel_post):
         """
         :meta private:
         """
-        self._notify_command_handlers(self.edited_channel_post_handlers, edited_channel_post, 'edited_channel_post')
+        self._notify_command_handlers(self.edited_channel_post_handlers, new_edited_channel_post, 'edited_channel_post')
 
-    def process_new_message_reaction(self, message_reactions):
+    def process_new_message_reaction(self, new_message_reactions):
         """
         :meta private:
         """
-        self._notify_command_handlers(self.message_reaction_handlers, message_reactions, 'message_reaction')
+        self._notify_command_handlers(self.message_reaction_handlers, new_message_reactions, 'message_reaction')
     
-    def process_new_message_reaction_count(self, message_reaction_counts):
+    def process_new_message_reaction_count(self, new_message_reaction_counts):
         """
         :meta private:
         """
-        self._notify_command_handlers(self.message_reaction_count_handlers, message_reaction_counts, 'message_reaction_count')
+        self._notify_command_handlers(self.message_reaction_count_handlers, new_message_reaction_counts, 'message_reaction_count')
 
     def process_new_inline_query(self, new_inline_queries):
         """
@@ -858,53 +858,53 @@ class TeleBot:
         """
         self._notify_command_handlers(self.shipping_query_handlers, new_shipping_queries, 'shipping_query')
 
-    def process_new_pre_checkout_query(self, pre_checkout_queries):
+    def process_new_pre_checkout_query(self, new_pre_checkout_queries):
         """
         :meta private:
         """
-        self._notify_command_handlers(self.pre_checkout_query_handlers, pre_checkout_queries, 'pre_checkout_query')
+        self._notify_command_handlers(self.pre_checkout_query_handlers, new_pre_checkout_queries, 'pre_checkout_query')
 
-    def process_new_poll(self, polls):
+    def process_new_poll(self, new_polls):
         """
         :meta private:
         """
-        self._notify_command_handlers(self.poll_handlers, polls, 'poll')
+        self._notify_command_handlers(self.poll_handlers, new_polls, 'poll')
 
-    def process_new_poll_answer(self, poll_answers):
+    def process_new_poll_answer(self, new_poll_answers):
         """
         :meta private:
         """
-        self._notify_command_handlers(self.poll_answer_handlers, poll_answers, 'poll_answer')
+        self._notify_command_handlers(self.poll_answer_handlers, new_poll_answers, 'poll_answer')
     
-    def process_new_my_chat_member(self, my_chat_members):
+    def process_new_my_chat_member(self, new_my_chat_members):
         """
         :meta private:
         """
-        self._notify_command_handlers(self.my_chat_member_handlers, my_chat_members, 'my_chat_member')
+        self._notify_command_handlers(self.my_chat_member_handlers, new_my_chat_members, 'my_chat_member')
 
-    def process_new_chat_member(self, chat_members):
+    def process_new_chat_member(self, new_chat_members):
         """
         :meta private:
         """
-        self._notify_command_handlers(self.chat_member_handlers, chat_members, 'chat_member')
+        self._notify_command_handlers(self.chat_member_handlers, new_chat_members, 'chat_member')
 
-    def process_new_chat_join_request(self, chat_join_request):
+    def process_new_chat_join_request(self, new_chat_join_request):
         """
         :meta private:
         """
-        self._notify_command_handlers(self.chat_join_request_handlers, chat_join_request, 'chat_join_request')
+        self._notify_command_handlers(self.chat_join_request_handlers, new_chat_join_request, 'chat_join_request')
 
-    def process_new_chat_boost(self, chat_boosts):
+    def process_new_chat_boost(self, new_chat_boosts):
         """
         :meta private:
         """
-        self._notify_command_handlers(self.chat_boost_handlers, chat_boosts, 'chat_boost')
+        self._notify_command_handlers(self.chat_boost_handlers, new_chat_boosts, 'chat_boost')
 
-    def process_new_removed_chat_boost(self, removed_chat_boosts):
+    def process_new_removed_chat_boost(self, new_removed_chat_boosts):
         """
         :meta private:
         """
-        self._notify_command_handlers(self.removed_chat_boost_handlers, removed_chat_boosts, 'removed_chat_boost')
+        self._notify_command_handlers(self.removed_chat_boost_handlers, new_removed_chat_boosts, 'removed_chat_boost')
 
 
     def process_middlewares(self, update):

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -229,6 +229,8 @@ class TeleBot:
         self.my_chat_member_handlers = []
         self.chat_member_handlers = []
         self.chat_join_request_handlers = []
+        self.chat_boost_handlers = []
+        self.removed_chat_boost_handlers = []
         self.custom_filters = {}
         self.state_handlers = []
 
@@ -684,6 +686,8 @@ class TeleBot:
         new_my_chat_members = None
         new_chat_members = None
         new_chat_join_request = None
+        removed_chat_boosts = None
+        chat_boosts = None
         
         for update in updates:
             if apihelper.ENABLE_MIDDLEWARE and not self.use_class_middlewares:
@@ -747,6 +751,12 @@ class TeleBot:
             if update.message_reaction_count:
                 if message_reaction_counts is None: message_reaction_counts = []
                 message_reaction_counts.append(update.message_reaction_count)
+            if update.chat_boost:
+                if chat_boosts is None: chat_boosts = []
+                chat_boosts.append(update.chat_boost)
+            if update.removed_chat_boost:
+                if removed_chat_boosts is None: removed_chat_boosts = []
+                removed_chat_boosts.append(update.removed_chat_boost)
 
         if new_messages:
             self.process_new_messages(new_messages)
@@ -780,6 +790,10 @@ class TeleBot:
             self.process_new_message_reaction(new_message_reactions)
         if message_reaction_counts:
             self.process_new_message_reaction_count(message_reaction_counts)
+        if chat_boosts:
+            self.process_new_chat_boost(chat_boosts)
+        if removed_chat_boosts:
+            self.process_new_removed_chat_boost(removed_chat_boosts)
 
     def process_new_messages(self, new_messages):
         """
@@ -879,6 +893,19 @@ class TeleBot:
         :meta private:
         """
         self._notify_command_handlers(self.chat_join_request_handlers, chat_join_request, 'chat_join_request')
+
+    def process_new_chat_boost(self, chat_boosts):
+        """
+        :meta private:
+        """
+        self._notify_command_handlers(self.chat_boost_handlers, chat_boosts, 'chat_boost')
+
+    def process_new_removed_chat_boost(self, removed_chat_boosts):
+        """
+        :meta private:
+        """
+        self._notify_command_handlers(self.removed_chat_boost_handlers, removed_chat_boosts, 'removed_chat_boost')
+        
 
     def process_middlewares(self, update):
         """
@@ -7208,6 +7235,105 @@ class TeleBot:
         """
         handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
         self.add_chat_join_request_handler(handler_dict)
+
+    def chat_boost_handler(self, func=None, **kwargs):
+        """
+        Handles new incoming chat boost state. 
+        it passes :class:`telebot.types.ChatBoostUpdated` object.
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+        :return: None
+        """
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
+            self.add_chat_boost_handler(handler_dict)
+            return handler
+
+        return decorator
+    
+    def add_chat_boost_handler(self, handler_dict):
+        """
+        Adds a chat_boost handler.
+        Note that you should use register_chat_boost_handler to add chat_boost_handler to the bot.
+
+        :meta private:
+
+        :param handler_dict:
+        :return:
+        """
+        self.chat_boost_handlers.append(handler_dict)
+
+    def register_chat_boost_handler(self, callback: Callable, func: Optional[Callable]=None, pass_bot:Optional[bool]=False, **kwargs):
+        """
+        Registers chat boost handler.
+
+        :param callback: function to be called
+        :type callback: :obj:`function`
+        
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
+
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return: None
+        """
+        handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
+        self.add_chat_boost_handler(handler_dict)
+
+    def removed_chat_boost_handler(self, func=None, **kwargs):
+        """
+        Handles new incoming chat boost state. 
+        it passes :class:`telebot.types.ChatBoostRemoved` object.
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+        :return: None
+        """
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
+            self.add_removed_chat_boost_handler(handler_dict)
+            return handler
+
+        return decorator
+    
+    def add_removed_chat_boost_handler(self, handler_dict):
+        """
+        Adds a removed_chat_boost handler.
+        Note that you should use register_removed_chat_boost_handler to add removed_chat_boost_handler to the bot.
+
+        :meta private:
+
+        :param handler_dict:
+        :return:
+        """
+        self.removed_chat_boost_handlers.append(handler_dict)
+
+    def register_removed_chat_boost_handler(self, callback: Callable, func: Optional[Callable]=None, pass_bot:Optional[bool]=False, **kwargs):
+        """
+        Registers removed chat boost handler.
+
+        :param callback: function to be called
+        :type callback: :obj:`function`
+        
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
+
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return: None
+        """
+        handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
+        self.add_removed_chat_boost_handler(handler_dict)
+    
 
     def _test_message_handler(self, message_handler, message):
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1553,13 +1553,13 @@ class TeleBot:
             disable_web_page_preview: Optional[bool]=None, 
             disable_notification: Optional[bool]=None, 
             protect_content: Optional[bool]=None,
-            reply_to_message_id: Optional[int]=None, 
-            allow_sending_without_reply: Optional[bool]=None,
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            link_preview_options : Optional[types.ReplyParameters]=None) -> types.Message:
+            link_preview_options : Optional[types.LinkPreviewOptions]=None) -> types.Message:
         """
         Use this method to send text messages.
 
@@ -1590,10 +1590,10 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
         :type reply_to_message_id: :obj:`int`
 
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
         :type allow_sending_without_reply: :obj:`bool`
 
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
@@ -1619,17 +1619,27 @@ class TeleBot:
         disable_web_page_preview = self.disable_web_page_preview if (disable_web_page_preview is None) else disable_web_page_preview
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         if disable_web_page_preview:
             # show a deprecation warning
@@ -1698,9 +1708,8 @@ class TeleBot:
             caption_entities: Optional[List[types.MessageEntity]]=None,
             disable_notification: Optional[bool]=None, 
             protect_content: Optional[bool]=None,
-            reply_to_message_id: Optional[int]=None, 
-            allow_sending_without_reply: Optional[bool]=None,
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None) -> types.MessageID:
@@ -1732,10 +1741,10 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
         :type reply_to_message_id: :obj:`int`
 
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
         :type allow_sending_without_reply: :obj:`bool`
 
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard
@@ -1758,17 +1767,27 @@ class TeleBot:
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         return types.MessageID.de_json(
             apihelper.copy_message(self.token, chat_id, from_chat_id, message_id, caption, parse_mode, caption_entities,
@@ -1898,10 +1917,10 @@ class TeleBot:
     def send_dice(
             self, chat_id: Union[int, str],
             emoji: Optional[str]=None, disable_notification: Optional[bool]=None, 
-            reply_to_message_id: Optional[int]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             timeout: Optional[int]=None,
-            allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
@@ -1920,19 +1939,19 @@ class TeleBot:
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`bool`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
-        :type reply_to_message_id: :obj:`int`
-
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
             to remove reply keyboard or to force a reply from the user.
         :type reply_markup: :class:`telebot.types.InlineKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardRemove`
             or :class:`telebot.types.ForceReply`
 
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
+        :type reply_to_message_id: :obj:`int`
+
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
+        :type allow_sending_without_reply: :obj:`bool`
+
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
-
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
-        :type allow_sending_without_reply: :obj:`bool`
 
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
@@ -1948,17 +1967,27 @@ class TeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         return types.Message.de_json(
             apihelper.send_dice(
@@ -1973,8 +2002,8 @@ class TeleBot:
             caption_entities: Optional[List[types.MessageEntity]]=None,
             disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            reply_to_message_id: Optional[int]=None, 
-            allow_sending_without_reply: Optional[bool]=None,
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
@@ -2008,10 +2037,10 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
         :type reply_to_message_id: :obj:`int`
 
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
         :type allow_sending_without_reply: :obj:`bool`
 
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
@@ -2037,17 +2066,27 @@ class TeleBot:
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         return types.Message.de_json(
             apihelper.send_photo(
@@ -2060,14 +2099,14 @@ class TeleBot:
             self, chat_id: Union[int, str], audio: Union[Any, str], 
             caption: Optional[str]=None, duration: Optional[int]=None, 
             performer: Optional[str]=None, title: Optional[str]=None,
-            reply_to_message_id: Optional[int]=None, 
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             parse_mode: Optional[str]=None, 
             disable_notification: Optional[bool]=None,
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             timeout: Optional[int]=None, 
             thumbnail: Optional[Union[Any, str]]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
-            allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
@@ -2101,9 +2140,6 @@ class TeleBot:
         :param title: Track name
         :type title: :obj:`str`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
-        :type reply_to_message_id: :obj:`int`
-
         :param reply_markup:
         :type reply_markup: :class:`telebot.types.InlineKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardRemove`
             or :class:`telebot.types.ForceReply`
@@ -2113,6 +2149,12 @@ class TeleBot:
 
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`bool`
+
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
+        :type reply_to_message_id: :obj:`int`
+
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
+        :type allow_sending_without_reply: :obj:`bool`
 
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
@@ -2125,9 +2167,6 @@ class TeleBot:
 
         :param caption_entities: A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
         :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
-
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
-        :type allow_sending_without_reply: :obj:`bool`
 
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
@@ -2147,17 +2186,27 @@ class TeleBot:
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         if thumb is not None and thumbnail is None:
             thumbnail = thumb
@@ -2173,13 +2222,13 @@ class TeleBot:
     def send_voice(
             self, chat_id: Union[int, str], voice: Union[Any, str], 
             caption: Optional[str]=None, duration: Optional[int]=None, 
-            reply_to_message_id: Optional[int]=None, 
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             parse_mode: Optional[str]=None, 
             disable_notification: Optional[bool]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             timeout: Optional[int]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
-            allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
@@ -2203,9 +2252,6 @@ class TeleBot:
         :param duration: Duration of the voice message in seconds
         :type duration: :obj:`int`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
-        :type reply_to_message_id: :obj:`int`
-
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
             to remove reply keyboard or to force a reply from the user.
         :type reply_markup: :class:`telebot.types.InlineKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardRemove`
@@ -2217,14 +2263,17 @@ class TeleBot:
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`bool`
 
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
+        :type reply_to_message_id: :obj:`int`
+
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
+        :type allow_sending_without_reply: :obj:`bool`
+
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
 
         :param caption_entities: A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
         :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
-
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
-        :type allow_sending_without_reply: :obj:`bool`
 
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
@@ -2240,17 +2289,27 @@ class TeleBot:
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         return types.Message.de_json(
             apihelper.send_voice(
@@ -2261,15 +2320,15 @@ class TeleBot:
     # TODO: Rewrite this method like in API.
     def send_document(
             self, chat_id: Union[int, str], document: Union[Any, str],
-            reply_to_message_id: Optional[int]=None, 
             caption: Optional[str]=None, 
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             parse_mode: Optional[str]=None, 
             disable_notification: Optional[bool]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             timeout: Optional[int]=None, 
             thumbnail: Optional[Union[Any, str]]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
-            allow_sending_without_reply: Optional[bool]=None,
             visible_file_name: Optional[str]=None,
             disable_content_type_detection: Optional[bool]=None,
             data: Optional[Union[Any, str]]=None,
@@ -2288,9 +2347,6 @@ class TeleBot:
             String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data
         :type document: :obj:`str` or :class:`telebot.types.InputFile`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
-        :type reply_to_message_id: :obj:`int`
-
         :param caption: Document caption (may also be used when resending documents by file_id), 0-1024 characters after entities parsing
         :type caption: :obj:`str`
 
@@ -2305,6 +2361,12 @@ class TeleBot:
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`bool`
 
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
+        :type reply_to_message_id: :obj:`int`
+
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
+        :type allow_sending_without_reply: :obj:`bool`
+
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
 
@@ -2313,9 +2375,6 @@ class TeleBot:
 
         :param caption_entities: A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
         :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
-
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
-        :type allow_sending_without_reply: :obj:`bool`
 
         :param visible_file_name: allows to define file name that will be visible in the Telegram instead of original file name
         :type visible_file_name: :obj:`str`
@@ -2344,17 +2403,27 @@ class TeleBot:
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         if data and (not document):
             # function typo miss compatibility
@@ -2378,11 +2447,11 @@ class TeleBot:
     def send_sticker(
             self, chat_id: Union[int, str],
             sticker: Union[Any, str],
-            reply_to_message_id: Optional[int]=None, 
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             disable_notification: Optional[bool]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             timeout: Optional[int]=None,
-            allow_sending_without_reply: Optional[bool]=None,
             protect_content:Optional[bool]=None,
             data: Union[Any, str]=None,
             message_thread_id: Optional[int]=None,
@@ -2401,9 +2470,6 @@ class TeleBot:
             as a String for Telegram to get a .webp file from the Internet, or upload a new one using multipart/form-data.
         :type sticker: :obj:`str` or :class:`telebot.types.InputFile`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
-        :type reply_to_message_id: :obj:`int`
-
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard
             or to force a reply from the user.
         :type reply_markup: :class:`telebot.types.InlineKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardRemove`
@@ -2412,11 +2478,14 @@ class TeleBot:
         :param disable_notification: to disable the notification
         :type disable_notification: :obj:`bool`
 
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
+        :type reply_to_message_id: :obj:`int`
+
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
+        :type allow_sending_without_reply: :obj:`bool`
+
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
-
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
-        :type allow_sending_without_reply: :obj:`bool`
 
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
@@ -2438,23 +2507,33 @@ class TeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+
+        if allow_sending_without_reply is not None:
+            # show a deprecation warning
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
+
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         if data and (not sticker):
             # function typo miss compatibility
             logger.warning('The parameter "data" is deprecated. Use "sticker" instead.')
             sticker = data
-
-        if allow_sending_without_reply or reply_to_message_id:
-            # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
-
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
-
+            
         return types.Message.de_json(
             apihelper.send_data(
                 self.token, chat_id, sticker, 'sticker', reply_markup=reply_markup,
@@ -2474,8 +2553,8 @@ class TeleBot:
             supports_streaming: Optional[bool]=None, 
             disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            reply_to_message_id: Optional[int]=None, 
-            allow_sending_without_reply: Optional[bool]=None,
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             data: Optional[Union[Any, str]]=None,
@@ -2524,10 +2603,10 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
         :type reply_to_message_id: :obj:`int`
 
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
         :type allow_sending_without_reply: :obj:`bool`
 
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard
@@ -2559,7 +2638,27 @@ class TeleBot:
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+
+        if allow_sending_without_reply is not None:
+            # show a deprecation warning
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
+
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         if data and (not video):
             # function typo miss compatibility
@@ -2569,16 +2668,6 @@ class TeleBot:
         if thumb is not None and thumbnail is None:
             thumbnail = thumb
             logger.warning('The parameter "thumb" is deprecated. Use "thumbnail" instead.')
-
-        if allow_sending_without_reply or reply_to_message_id:
-            # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
-
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
 
         return types.Message.de_json(
             apihelper.send_video(
@@ -2597,8 +2686,8 @@ class TeleBot:
             caption_entities: Optional[List[types.MessageEntity]]=None,
             disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            reply_to_message_id: Optional[int]=None,
-            allow_sending_without_reply: Optional[bool]=None,
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
@@ -2642,8 +2731,11 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
         :type reply_to_message_id: :obj:`int`
+
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
+        :type allow_sending_without_reply: :obj:`bool`
 
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard
             or to force a reply from the user.
@@ -2658,9 +2750,6 @@ class TeleBot:
 
         :param caption_entities: List of special entities that appear in the caption, which can be specified instead of parse_mode
         :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
-
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
-        :type allow_sending_without_reply: :obj:`bool`
 
         :param message_thread_id: Identifier of a message thread, in which the video will be sent
         :type message_thread_id: :obj:`int`
@@ -2680,17 +2769,27 @@ class TeleBot:
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         if thumbnail is None and thumb is not None:
             thumbnail = thumb
@@ -2706,12 +2805,12 @@ class TeleBot:
             self, chat_id: Union[int, str], data: Union[Any, str], 
             duration: Optional[int]=None, 
             length: Optional[int]=None,
-            reply_to_message_id: Optional[int]=None, 
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             disable_notification: Optional[bool]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             timeout: Optional[int]=None, 
             thumbnail: Optional[Union[Any, str]]=None,
-            allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
@@ -2735,9 +2834,6 @@ class TeleBot:
         :param length: Video width and height, i.e. diameter of the video message
         :type length: :obj:`int`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
-        :type reply_to_message_id: :obj:`int`
-
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard
             or to force a reply from the user.
         :type reply_markup: :class:`telebot.types.InlineKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardRemove`
@@ -2745,6 +2841,12 @@ class TeleBot:
 
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`bool`
+
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
+        :type reply_to_message_id: :obj:`int`
+
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
+        :type allow_sending_without_reply: :obj:`bool`
 
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
@@ -2754,9 +2856,6 @@ class TeleBot:
             Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file,
             so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. 
         :type thumbnail: :obj:`str` or :class:`telebot.types.InputFile`
-
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
-        :type allow_sending_without_reply: :obj:`bool`
 
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
@@ -2775,21 +2874,31 @@ class TeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+
+        if allow_sending_without_reply is not None:
+            # show a deprecation warning
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
+
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         if thumbnail is None and thumb is not None:
             thumbnail = thumb
             logger.warning('The parameter "thumb" is deprecated. Use "thumbnail" instead.')
-
-        if allow_sending_without_reply or reply_to_message_id:
-            # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
-
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
 
         return types.Message.de_json(
             apihelper.send_video_note(
@@ -2804,9 +2913,9 @@ class TeleBot:
                 types.InputMediaPhoto, types.InputMediaVideo]],
             disable_notification: Optional[bool]=None, 
             protect_content: Optional[bool]=None,
-            reply_to_message_id: Optional[int]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             timeout: Optional[int]=None,
-            allow_sending_without_reply: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None) -> List[types.Message]:
         """
@@ -2827,14 +2936,14 @@ class TeleBot:
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
         :type reply_to_message_id: :obj:`int`
+
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
+        :type allow_sending_without_reply: :obj:`bool`
 
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
-
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
-        :type allow_sending_without_reply: :obj:`bool`
 
         :param message_thread_id: Identifier of a message thread, in which the media group will be sent
         :type message_thread_id: :obj:`int`
@@ -2847,17 +2956,27 @@ class TeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         result = apihelper.send_media_group(
             self.token, chat_id, media, disable_notification, timeout, 
@@ -2869,14 +2988,14 @@ class TeleBot:
             self, chat_id: Union[int, str], 
             latitude: float, longitude: float, 
             live_period: Optional[int]=None, 
-            reply_to_message_id: Optional[int]=None, 
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             disable_notification: Optional[bool]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             timeout: Optional[int]=None,
             horizontal_accuracy: Optional[float]=None, 
             heading: Optional[int]=None, 
             proximity_alert_radius: Optional[int]=None, 
-            allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
@@ -2897,9 +3016,6 @@ class TeleBot:
         :param live_period: Period in seconds for which the location will be updated (see Live Locations, should be between 60 and 86400.
         :type live_period: :obj:`int`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
-        :type reply_to_message_id: :obj:`int`
-
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard
             or to force a reply from the user.
         :type reply_markup: :class:`telebot.types.InlineKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardRemove`
@@ -2907,6 +3023,12 @@ class TeleBot:
 
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`bool`
+
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
+        :type reply_to_message_id: :obj:`int`
+
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
+        :type allow_sending_without_reply: :obj:`bool`
 
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
@@ -2920,9 +3042,6 @@ class TeleBot:
         :param proximity_alert_radius: For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
         :type proximity_alert_radius: :obj:`int`
 
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
-        :type allow_sending_without_reply: :obj:`bool`
-        
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
@@ -2937,17 +3056,27 @@ class TeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         return types.Message.de_json(
             apihelper.send_location(
@@ -3056,10 +3185,10 @@ class TeleBot:
             foursquare_id: Optional[str]=None, 
             foursquare_type: Optional[str]=None,
             disable_notification: Optional[bool]=None, 
-            reply_to_message_id: Optional[int]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
-            allow_sending_without_reply: Optional[bool]=None,
             google_place_id: Optional[str]=None,
             google_place_type: Optional[str]=None,
             protect_content: Optional[bool]=None,
@@ -3095,8 +3224,11 @@ class TeleBot:
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`bool`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
         :type reply_to_message_id: :obj:`int`
+
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
+        :type allow_sending_without_reply: :obj:`bool`
 
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard,
             custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
@@ -3105,10 +3237,6 @@ class TeleBot:
 
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
-
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if one of the specified
-            replied-to messages is not found.
-        :type allow_sending_without_reply: :obj:`bool`
 
         :param google_place_id: Google Places identifier of the venue
         :type google_place_id: :obj:`str`
@@ -3130,17 +3258,27 @@ class TeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         return types.Message.de_json(
             apihelper.send_venue(
@@ -3155,10 +3293,10 @@ class TeleBot:
             first_name: str, last_name: Optional[str]=None, 
             vcard: Optional[str]=None,
             disable_notification: Optional[bool]=None, 
-            reply_to_message_id: Optional[int]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
-            allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None, message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
@@ -3184,8 +3322,11 @@ class TeleBot:
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`bool`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
         :type reply_to_message_id: :obj:`int`
+
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
+        :type allow_sending_without_reply: :obj:`bool`
 
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard,
             custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
@@ -3194,10 +3335,6 @@ class TeleBot:
 
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
-
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if one of the specified
-            replied-to messages is not found.
-        :type allow_sending_without_reply: :obj:`bool`
 
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
@@ -3213,17 +3350,27 @@ class TeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         return types.Message.de_json(
             apihelper.send_contact(
@@ -4305,10 +4452,10 @@ class TeleBot:
     def send_game(
             self, chat_id: Union[int, str], game_short_name: str, 
             disable_notification: Optional[bool]=None,
-            reply_to_message_id: Optional[int]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
-            allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
@@ -4326,17 +4473,17 @@ class TeleBot:
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`bool`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message 
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
         :type reply_to_message_id: :obj:`int`
+
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
+        :type allow_sending_without_reply: :obj:`bool`
 
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
         :type reply_markup: :obj:`InlineKeyboardMarkup` or :obj:`ReplyKeyboardMarkup` or :obj:`ReplyKeyboardRemove` or :obj:`ForceReply`
 
         :param timeout: Timeout in seconds for waiting for a response from the bot.
         :type timeout: :obj:`int`
-
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if one of the specified replied-to messages is not found.
-        :type allow_sending_without_reply: :obj:`bool`
 
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
@@ -4352,17 +4499,27 @@ class TeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         result = apihelper.send_game(
             self.token, chat_id, game_short_name, disable_notification,
@@ -4457,11 +4614,11 @@ class TeleBot:
             send_email_to_provider: Optional[bool]=None, 
             is_flexible: Optional[bool]=None,
             disable_notification: Optional[bool]=None, 
-            reply_to_message_id: Optional[int]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             provider_data: Optional[str]=None, 
             timeout: Optional[int]=None,
-            allow_sending_without_reply: Optional[bool]=None,
             max_tip_amount: Optional[int] = None,
             suggested_tip_amounts: Optional[List[int]]=None,
             protect_content: Optional[bool]=None,
@@ -4537,8 +4694,11 @@ class TeleBot:
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`bool`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
         :type reply_to_message_id: :obj:`int`
+
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
+        :type allow_sending_without_reply: :obj:`bool`
 
         :param reply_markup: A JSON-serialized object for an inline keyboard. If empty,
             one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button
@@ -4550,9 +4710,6 @@ class TeleBot:
 
         :param timeout: Timeout of a request, defaults to None
         :type timeout: :obj:`int`
-
-        :param allow_sending_without_reply: Pass True, if the message should be sent even if the specified replied-to message is not found
-        :type allow_sending_without_reply: :obj:`bool`
 
         :param max_tip_amount: The maximum accepted amount for tips in the smallest units of the currency
         :type max_tip_amount: :obj:`int`
@@ -4576,17 +4733,27 @@ class TeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
-        if allow_sending_without_reply or reply_to_message_id:
+        if allow_sending_without_reply is not None:
             # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
 
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         result = apihelper.send_invoice(
             self.token, chat_id, title, description, invoice_payload, provider_token,
@@ -4713,9 +4880,9 @@ class TeleBot:
             close_date: Optional[Union[int, datetime]]=None, 
             is_closed: Optional[bool]=None,
             disable_notification: Optional[bool]=False,
-            reply_to_message_id: Optional[int]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            allow_sending_without_reply: Optional[bool]=None, 
             timeout: Optional[int]=None,
             explanation_entities: Optional[List[types.MessageEntity]]=None,
             protect_content: Optional[bool]=None,
@@ -4768,10 +4935,10 @@ class TeleBot:
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`bool`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
+        :param reply_to_message_id: deprecated. If the message is a reply, ID of the original message
         :type reply_to_message_id: :obj:`int`
 
-        :param allow_sending_without_reply: Pass True, if the poll allows multiple options to be voted simultaneously.
+        :param allow_sending_without_reply: deprecated. Pass True, if the message should be sent even if the specified replied-to message is not found
         :type allow_sending_without_reply: :obj:`bool`
 
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard,
@@ -4799,20 +4966,30 @@ class TeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+
+        if allow_sending_without_reply is not None:
+            # show a deprecation warning
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
+
+        if reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
+
+            if reply_parameters:
+                # show a conflict warning
+                logger.warning("Both 'reply_parameters' and 'reply_to_message_id' parameters are set: conflicting, 'reply_to_message_id' is deprecated")
+            else:
+                # create a ReplyParameters object
+                reply_parameters = types.ReplyParameters(
+                    reply_to_message_id,
+                    allow_sending_without_reply=self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+                )
+
+        if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
+            reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         if isinstance(question, types.Poll):
             raise RuntimeError("The send_poll signature was changed, please see send_poll function details.")
-        
-        if allow_sending_without_reply or reply_to_message_id:
-            # show a deprecation warning
-            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
-
-            # create a ReplyParameters object
-            reply_parameters = types.ReplyParameters(
-                allow_sending_without_reply=allow_sending_without_reply,
-                message_id=reply_to_message_id
-            )
 
         explanation_parse_mode = self.parse_mode if (explanation_parse_mode is None) else explanation_parse_mode
 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6830,7 +6830,7 @@ class TeleBot:
     def message_reaction_handler(self, func=None, **kwargs):
         """
         Handles new incoming message reaction.
-        As a parameter to the decorator function, it passes :class:`telebot.types.Message` object.
+        As a parameter to the decorator function, it passes :class:`telebot.types.MessageReactionUpdated` object.
 
         :param func: Function executed as a filter
         :type func: :obj:`function`
@@ -6881,7 +6881,7 @@ class TeleBot:
     def message_reaction_count_handler(self, func=None, **kwargs):
         """
         Handles new incoming message reaction count.
-        As a parameter to the decorator function, it passes :class:`telebot.types.Message` object.
+        As a parameter to the decorator function, it passes :class:`telebot.types.MessageReactionCountUpdated` object.
 
         :param func: Function executed as a filter
         :type func: :obj:`function`

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1550,7 +1550,7 @@ class TeleBot:
             self, chat_id: Union[int, str], text: str, 
             parse_mode: Optional[str]=None, 
             entities: Optional[List[types.MessageEntity]]=None,
-            disable_web_page_preview: Optional[bool]=None, 
+            disable_web_page_preview: Optional[bool]=None,    # deprecated, for backward compatibility
             disable_notification: Optional[bool]=None, 
             protect_content: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
@@ -1581,7 +1581,7 @@ class TeleBot:
         :param entities: List of special entities that appear in message text, which can be specified instead of parse_mode
         :type entities: Array of :class:`telebot.types.MessageEntity`
 
-        :param disable_web_page_preview: Disables link previews for links in this message
+        :param disable_web_page_preview: deprecated. Disables link previews for links in this message
         :type disable_web_page_preview: :obj:`bool`
 
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
@@ -1616,7 +1616,6 @@ class TeleBot:
         :rtype: :class:`telebot.types.Message`
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
-        disable_web_page_preview = self.disable_web_page_preview if (disable_web_page_preview is None) else disable_web_page_preview
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
 
@@ -1641,14 +1640,21 @@ class TeleBot:
         if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
             reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
-        if disable_web_page_preview:
+        if disable_web_page_preview is not None:
             # show a deprecation warning
             logger.warning("The parameter 'disable_web_page_preview' is deprecated. Use 'link_preview_options' instead.")
 
-            # create a LinkPreviewOptions object
-            link_preview_options = types.LinkPreviewOptions(
-                disable_web_page_preview=disable_web_page_preview
-            )
+            if link_preview_options:
+                # show a conflict warning
+                logger.warning("Both 'link_preview_options' and 'disable_web_page_preview' parameters are set: conflicting, 'disable_web_page_preview' is deprecated")
+            else:
+                # create a LinkPreviewOptions object
+                link_preview_options = types.LinkPreviewOptions(
+                    disable_web_page_preview=disable_web_page_preview
+                )
+
+        if link_preview_options and (link_preview_options.disable_web_page_preview is None):
+            link_preview_options.disable_web_page_preview = self.disable_web_page_preview
 
         return types.Message.de_json(
             apihelper.send_message(
@@ -4327,7 +4333,7 @@ class TeleBot:
             inline_message_id: Optional[str]=None, 
             parse_mode: Optional[str]=None,
             entities: Optional[List[types.MessageEntity]]=None,
-            disable_web_page_preview: Optional[bool]=None,
+            disable_web_page_preview: Optional[bool]=None,        # deprecated, for backward compatibility
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             link_preview_options : Optional[types.LinkPreviewOptions]=None) -> Union[types.Message, bool]:
         """
@@ -4353,7 +4359,7 @@ class TeleBot:
         :param entities: List of special entities that appear in the message text, which can be specified instead of parse_mode
         :type entities: List of :obj:`telebot.types.MessageEntity`
 
-        :param disable_web_page_preview: Disables link previews for links in this message
+        :param disable_web_page_preview: deprecated. Disables link previews for links in this message
         :type disable_web_page_preview: :obj:`bool`
 
         :param reply_markup: A JSON-serialized object for an inline keyboard.
@@ -4366,17 +4372,22 @@ class TeleBot:
         :rtype: :obj:`types.Message` or :obj:`bool`
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
-        disable_web_page_preview = self.disable_web_page_preview if (disable_web_page_preview is None) else disable_web_page_preview
-
-        if disable_web_page_preview:
+                
+        if disable_web_page_preview is not None:
             # show a deprecation warning
             logger.warning("The parameter 'disable_web_page_preview' is deprecated. Use 'link_preview_options' instead.")
 
-            # create a LinkPreviewOptions object
-            link_preview_options = types.LinkPreviewOptions(
-                disable_web_page_preview=disable_web_page_preview
-            )
-            
+            if link_preview_options:
+                # show a conflict warning
+                logger.warning("Both 'link_preview_options' and 'disable_web_page_preview' parameters are set: conflicting, 'disable_web_page_preview' is deprecated")
+            else:
+                # create a LinkPreviewOptions object
+                link_preview_options = types.LinkPreviewOptions(
+                    disable_web_page_preview=disable_web_page_preview
+                )
+
+        if link_preview_options and (link_preview_options.disable_web_page_preview is None):
+            link_preview_options.disable_web_page_preview = self.disable_web_page_preview
 
         result = apihelper.edit_message_text(self.token, text, chat_id, message_id, inline_message_id, parse_mode,
                                              entities, reply_markup, link_preview_options)

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6639,7 +6639,7 @@ class TeleBot:
         self.add_edited_channel_post_handler(handler_dict)
 
 
-    def message_reaction_handler(self, func, **kwargs):
+    def message_reaction_handler(self, func=None, **kwargs):
         """
         Handles new incoming message reaction.
         As a parameter to the decorator function, it passes :class:`telebot.types.Message` object.
@@ -6670,7 +6670,7 @@ class TeleBot:
         """
         self.message_reaction_handlers.append(handler_dict)
 
-    def register_message_reaction_handler(self, callback: Callable, func: Callable, pass_bot: Optional[bool]=False, **kwargs):
+    def register_message_reaction_handler(self, callback: Callable, func: Callable=None, pass_bot: Optional[bool]=False, **kwargs):
         """
         Registers message reaction handler.
 
@@ -6690,7 +6690,7 @@ class TeleBot:
         handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
         self.add_message_reaction_handler(handler_dict)
 
-    def message_reaction_count_handler(self, func, **kwargs):
+    def message_reaction_count_handler(self, func=None, **kwargs):
         """
         Handles new incoming message reaction count.
         As a parameter to the decorator function, it passes :class:`telebot.types.Message` object.
@@ -6721,7 +6721,7 @@ class TeleBot:
         """
         self.message_reaction_count_handlers.append(handler_dict)
 
-    def register_message_reaction_count_handler(self, callback: Callable, func: Callable, pass_bot: Optional[bool]=False, **kwargs):
+    def register_message_reaction_count_handler(self, callback: Callable, func: Callable=None, pass_bot: Optional[bool]=False, **kwargs):
         """
         Registers message reaction count handler.
 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1329,6 +1329,29 @@ class TeleBot:
         :return: :obj:`bool`
         """
         return apihelper.close(self.token)
+    
+    def set_message_reaction(self, chat_id: Union[int, str], message_id: int, reaction: Optional[List[types.ReactionType]]=None, is_big: Optional[bool]=None) -> bool:
+        """
+        Use this method to set a reaction to a message in a chat. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setmessagereaction
+
+        :param chat_id: Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_id: Identifier of the message to set reaction to
+        :type message_id: :obj:`int`
+
+        :param reaction: New list of reaction types to set on the message. Currently, as non-premium users, bots can set up to one reaction per message.
+            A custom emoji reaction can be used if it is either already present on the message or explicitly allowed by chat administrators.
+        :type reaction: :obj:`list` of :class:`telebot.types.ReactionType`
+
+        :param is_big: Pass True to set the reaction with a big animation
+        :type is_big: :obj:`bool`
+
+        :return: :obj:`bool`
+        """
+        return apihelper.set_message_reaction(self.token, chat_id, message_id, reaction, is_big)
 
 
     def get_user_profile_photos(self, user_id: int, offset: Optional[int]=None, 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1880,7 +1880,7 @@ class TeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
 
         return [types.MessageID.de_json(message_id) for message_id in
-            apihelper.forward_messages(self.token, chat_id, from_chat_id, message_ids, disable_notification, protect_content, message_thread_id))]
+            apihelper.forward_messages(self.token, chat_id, from_chat_id, message_ids, disable_notification, protect_content, message_thread_id)]
     
     def copy_messages(self, chat_id: Union[str, int], from_chat_id: Union[str, int], message_ids: List[int],
                         disable_notification: Optional[bool] = None, message_thread_id: Optional[int] = None,

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -739,7 +739,7 @@ class TeleBot:
             if update.chat_join_request:
                 if new_chat_join_request is None: new_chat_join_request = []
                 new_chat_join_request.append(update.chat_join_request)
-            if update.message_reactions:
+            if update.message_reaction:
                 if new_message_reactions is None: new_message_reactions = []
                 new_message_reactions.append(update.message_reaction)
 

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1616,6 +1616,11 @@ def answer_callback_query(token, callback_query_id, text=None, show_alert=None, 
     return _make_request(token, method_url, params=payload, method='post')
 
 
+def get_user_chat_boosts(token, chat_id, user_id):
+    method_url = 'getUserChatBoosts'
+    payload = {'chat_id': chat_id, 'user_id': user_id}
+    return _make_request(token, method_url, params=payload)
+
 def answer_inline_query(token, inline_query_id, results, cache_time=None, is_personal=None, next_offset=None,
                         button=None):
     method_url = 'answerInlineQuery'

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -260,8 +260,7 @@ def send_message(
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload, method='post')
 
 
@@ -426,8 +425,7 @@ def copy_message(token, chat_id, from_chat_id, message_id, caption=None, parse_m
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     if timeout:
         payload['timeout'] = timeout
     if protect_content is not None:
@@ -456,8 +454,7 @@ def send_dice(
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload)
 
 
@@ -495,8 +492,7 @@ def send_photo(
     if has_spoiler is not None:
         payload['has_spoiler'] = has_spoiler
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -516,8 +512,7 @@ def send_media_group(
     if message_thread_id is not None:
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(
         token, method_url, params=payload,
         method='post' if files else 'get',
@@ -552,8 +547,7 @@ def send_location(
     if message_thread_id is not None:
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload)
 
 
@@ -626,8 +620,7 @@ def send_venue(
     if message_thread_id is not None:
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload)
 
 
@@ -652,8 +645,7 @@ def send_contact(
     if message_thread_id is not None:
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
 
     return _make_request(token, method_url, params=payload)
 
@@ -714,8 +706,7 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_markup=N
     if has_spoiler is not None:
         payload['has_spoiler'] = has_spoiler
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -764,8 +755,7 @@ def send_animation(
     if has_spoiler is not None:
         payload['has_spoiler'] = has_spoiler
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -798,8 +788,7 @@ def send_voice(token, chat_id, voice, caption=None, duration=None, reply_markup=
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -838,8 +827,7 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_mark
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -884,8 +872,7 @@ def send_audio(token, chat_id, audio, caption=None, duration=None, performer=Non
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -932,8 +919,7 @@ def send_data(token, chat_id, data, data_type, reply_markup=None, parse_mode=Non
     if emoji:
         payload['emoji'] = emoji
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1397,8 +1383,7 @@ def send_game(
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload)
 
 
@@ -1545,8 +1530,7 @@ def send_invoice(
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload)
 
 
@@ -1832,8 +1816,7 @@ def send_poll(
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = reply_parameters.to_json()
     return _make_request(token, method_url, params=payload)
 
 def create_forum_topic(token, chat_id, name, icon_color=None, icon_custom_emoji_id=None):

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -261,7 +261,7 @@ def send_message(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload, method='post')
 
 
@@ -427,7 +427,7 @@ def copy_message(token, chat_id, from_chat_id, message_id, caption=None, parse_m
         payload['disable_notification'] = disable_notification
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if timeout:
         payload['timeout'] = timeout
     if protect_content is not None:
@@ -449,7 +449,7 @@ def send_dice(
         payload['disable_notification'] = disable_notification
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if timeout:
@@ -496,7 +496,7 @@ def send_photo(
         payload['has_spoiler'] = has_spoiler
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -511,7 +511,7 @@ def send_media_group(
         payload['disable_notification'] = disable_notification
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if timeout:
         payload['timeout'] = timeout
     if protect_content is not None:
@@ -553,7 +553,7 @@ def send_location(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload)
 
 
@@ -650,7 +650,7 @@ def send_contact(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
 
     return _make_request(token, method_url, params=payload)
 
@@ -712,7 +712,7 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_markup=N
         payload['has_spoiler'] = has_spoiler
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -752,7 +752,7 @@ def send_animation(
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if width:
@@ -796,7 +796,7 @@ def send_voice(token, chat_id, voice, caption=None, duration=None, reply_markup=
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -832,7 +832,7 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_mark
             payload['thumbnail'] = thumbnail
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
@@ -882,7 +882,7 @@ def send_audio(token, chat_id, audio, caption=None, duration=None, performer=Non
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
 
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
@@ -923,7 +923,7 @@ def send_data(token, chat_id, data, data_type, reply_markup=None, parse_mode=Non
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if method_url == 'sendDocument' and disable_content_type_detection is not None:
@@ -1392,7 +1392,7 @@ def send_game(
         payload['timeout'] = timeout
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
@@ -1544,7 +1544,7 @@ def send_invoice(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         # to json
-        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload)
 
 

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -237,14 +237,14 @@ def download_file(token, file_path):
 
 def send_message(
         token, chat_id, text,
-        disable_web_page_preview=None, reply_markup=None,
+         reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
         entities=None, protect_content=None,
-        message_thread_id=None, reply_parameters=None):
+        message_thread_id=None, reply_parameters=None, link_preview_options=None):
     method_url = r'sendMessage'
     payload = {'chat_id': str(chat_id), 'text': text}
-    if disable_web_page_preview is not None:
-        payload['disable_web_page_preview'] = disable_web_page_preview
+    if link_preview_options is not None:
+        payload['link_preview'] = link_preview_options.to_json()
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if parse_mode:
@@ -1300,7 +1300,7 @@ def unpin_all_chat_messages(token, chat_id):
 # Updating messages
 
 def edit_message_text(token, text, chat_id=None, message_id=None, inline_message_id=None, parse_mode=None,
-                      entities = None, disable_web_page_preview=None, reply_markup=None):
+                      entities = None, reply_markup=None, link_preview_options=None):
     method_url = r'editMessageText'
     payload = {'text': text}
     if chat_id:
@@ -1313,10 +1313,10 @@ def edit_message_text(token, text, chat_id=None, message_id=None, inline_message
         payload['parse_mode'] = parse_mode
     if entities:
         payload['entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(entities))
-    if disable_web_page_preview is not None:
-        payload['disable_web_page_preview'] = disable_web_page_preview
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
+    if link_preview_options is not None:
+        payload['link_preview'] = link_preview_options.to_json()
     return _make_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -447,9 +447,6 @@ def send_dice(
         payload['emoji'] = emoji
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if timeout:
@@ -458,6 +455,9 @@ def send_dice(
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload)
 
 
@@ -509,15 +509,15 @@ def send_media_group(
     payload = {'chat_id': chat_id, 'media': media_json}
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if timeout:
         payload['timeout'] = timeout
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id is not None:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(
         token, method_url, params=payload,
         method='post' if files else 'get',
@@ -625,6 +625,9 @@ def send_venue(
         payload['protect_content'] = protect_content
     if message_thread_id is not None:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload)
 
 
@@ -750,9 +753,6 @@ def send_animation(
             payload['thumbnail'] = thumbnail
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if width:
@@ -763,6 +763,9 @@ def send_animation(
         payload['message_thread_id'] = message_thread_id
     if has_spoiler is not None:
         payload['has_spoiler'] = has_spoiler
+    if reply_parameters is not None:
+        # to json
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -830,13 +833,13 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_mark
                 files = {'thumbnail': thumbnail}
         else:
             payload['thumbnail'] = thumbnail
-    if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -883,7 +886,6 @@ def send_audio(token, chat_id, audio, caption=None, duration=None, performer=Non
     if reply_parameters is not None:
         # to json
         payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
-
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -921,9 +923,6 @@ def send_data(token, chat_id, data, data_type, reply_markup=None, parse_mode=Non
             payload['thumbnail'] = thumbnail
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if method_url == 'sendDocument' and disable_content_type_detection is not None:
@@ -932,6 +931,9 @@ def send_data(token, chat_id, data, data_type, reply_markup=None, parse_mode=Non
         payload['message_thread_id'] = message_thread_id
     if emoji:
         payload['emoji'] = emoji
+    if reply_parameters is not None:
+        # to json
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1390,13 +1392,13 @@ def send_game(
         payload['reply_markup'] = _convert_markup(reply_markup)
     if timeout:
         payload['timeout'] = timeout
-    if reply_parameters is not None:
-        # to json
-        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload)
 
 
@@ -1786,9 +1788,8 @@ def create_invoice_link(token, title, description, payload, provider_token,
 def send_poll(
         token, chat_id,
         question, options,
-        is_anonymous = None, type = None, allows_multiple_answers = None, correct_option_id = None,
-        explanation = None, explanation_parse_mode=None, open_period = None, close_date = None, is_closed = None,
-        disable_notification=False,
+        is_anonymous = None, type = None, allows_multiple_answers = None, correct_option_id = None, explanation = None,
+        explanation_parse_mode=None, open_period = None, close_date = None, is_closed = None, disable_notification=False,
         reply_markup=None, timeout=None, explanation_entities=None, protect_content=None, message_thread_id=None, reply_parameters=None):
     method_url = r'sendPoll'
     payload = {
@@ -1817,11 +1818,8 @@ def send_poll(
             payload['close_date'] = close_date
     if is_closed is not None:
         payload['is_closed'] = is_closed
-
     if disable_notification:
         payload['disable_notification'] = disable_notification
-    if reply_parameters is not None:
-        payload['reply_parameters'] = reply_parameters.to_json()
     if reply_markup is not None:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if timeout:
@@ -1833,6 +1831,9 @@ def send_poll(
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload)
 
 def create_forum_topic(token, chat_id, name, icon_color=None, icon_custom_emoji_id=None):
@@ -1931,9 +1932,7 @@ def forward_messages(token, chat_id, from_chat_id, message_ids, disable_notifica
         payload['message_thread_id'] = message_thread_id
     if protect_content is not None:
         payload['protect_content'] = protect_content
-    
-    result = _make_request(token, method_url, params=payload)
-    return result
+    return _make_request(token, method_url, params=payload)
 
 def copy_messages(token, chat_id, from_chat_id, message_ids, disable_notification=None,
                         message_thread_id=None, protect_content=None, remove_caption=None):
@@ -1951,9 +1950,7 @@ def copy_messages(token, chat_id, from_chat_id, message_ids, disable_notificatio
         payload['protect_content'] = protect_content
     if remove_caption is not None:
         payload['remove_caption'] = remove_caption
-    
-    result = _make_request(token, method_url, params=payload)
-    return result
+    return _make_request(token, method_url, params=payload)
 
 
 def _convert_list_json_serializable(results):

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -237,16 +237,14 @@ def download_file(token, file_path):
 
 def send_message(
         token, chat_id, text,
-        disable_web_page_preview=None, reply_to_message_id=None, reply_markup=None,
+        disable_web_page_preview=None, reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
-        entities=None, allow_sending_without_reply=None, protect_content=None,
-        message_thread_id=None):
+        entities=None, protect_content=None,
+        message_thread_id=None, reply_parameters=None):
     method_url = r'sendMessage'
     payload = {'chat_id': str(chat_id), 'text': text}
     if disable_web_page_preview is not None:
         payload['disable_web_page_preview'] = disable_web_page_preview
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if parse_mode:
@@ -257,12 +255,13 @@ def send_message(
         payload['timeout'] = timeout
     if entities:
         payload['entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(entities))
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload, method='post')
 
 
@@ -414,8 +413,8 @@ def forward_message(
 
 
 def copy_message(token, chat_id, from_chat_id, message_id, caption=None, parse_mode=None, caption_entities=None,
-                 disable_notification=None, reply_to_message_id=None, allow_sending_without_reply=None,
-                 reply_markup=None, timeout=None, protect_content=None, message_thread_id=None):
+                 disable_notification=None, reply_markup=None, timeout=None, protect_content=None, message_thread_id=None,
+                 reply_parameters=None):
     method_url = r'copyMessage'
     payload = {'chat_id': chat_id, 'from_chat_id': from_chat_id, 'message_id': message_id}
     if caption is not None:
@@ -426,12 +425,9 @@ def copy_message(token, chat_id, from_chat_id, message_id, caption=None, parse_m
         payload['caption_entities'] = _convert_entites(caption_entities)
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
-    if reply_markup is not None:
-        payload['reply_markup'] = _convert_markup(reply_markup)
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
     if timeout:
         payload['timeout'] = timeout
     if protect_content is not None:
@@ -443,22 +439,21 @@ def copy_message(token, chat_id, from_chat_id, message_id, caption=None, parse_m
 
 def send_dice(
         token, chat_id,
-        emoji=None, disable_notification=None, reply_to_message_id=None,
-        reply_markup=None, timeout=None, allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
+        emoji=None, disable_notification=None,
+        reply_markup=None, timeout=None, protect_content=None, message_thread_id=None, reply_parameters=None):
     method_url = r'sendDice'
     payload = {'chat_id': chat_id}
     if emoji:
         payload['emoji'] = emoji
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if timeout:
         payload['timeout'] = timeout
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
@@ -468,10 +463,10 @@ def send_dice(
 
 def send_photo(
         token, chat_id, photo,
-        caption=None, reply_to_message_id=None, reply_markup=None,
+        caption=None, reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
-        caption_entities=None, allow_sending_without_reply=None, protect_content=None,
-        message_thread_id=None, has_spoiler=None):
+        caption_entities=None, protect_content=None,
+        message_thread_id=None, has_spoiler=None,, reply_parameters=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None
@@ -483,8 +478,6 @@ def send_photo(
         files = {'photo': photo}
     if caption:
         payload['caption'] = caption
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if parse_mode:
@@ -495,32 +488,32 @@ def send_photo(
         payload['timeout'] = timeout
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id is not None:
         payload['message_thread_id'] = message_thread_id
     if has_spoiler is not None:
         payload['has_spoiler'] = has_spoiler
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_media_group(
         token, chat_id, media,
-        disable_notification=None, reply_to_message_id=None,
-        timeout=None, allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
+        disable_notification=None,
+        timeout=None, protect_content=None, message_thread_id=None, reply_parameters=None):
     method_url = r'sendMediaGroup'
     media_json, files = convert_input_media_array(media)
     payload = {'chat_id': chat_id, 'media': media_json}
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
     if timeout:
         payload['timeout'] = timeout
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id is not None:
@@ -533,11 +526,11 @@ def send_media_group(
 
 def send_location(
         token, chat_id, latitude, longitude,
-        live_period=None, reply_to_message_id=None, 
+        live_period=None,
         reply_markup=None, disable_notification=None, 
         timeout=None, horizontal_accuracy=None, heading=None,
-        proximity_alert_radius=None, allow_sending_without_reply=None, protect_content=None,
-        message_thread_id=None):
+        proximity_alert_radius=None, protect_content=None,
+        message_thread_id=None, reply_parameters=None):
     method_url = r'sendLocation'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude}
     if live_period:
@@ -548,10 +541,6 @@ def send_location(
         payload['heading'] = heading
     if proximity_alert_radius:
         payload['proximity_alert_radius'] = proximity_alert_radius
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if disable_notification is not None:
@@ -562,6 +551,9 @@ def send_location(
         payload['protect_content'] = protect_content
     if message_thread_id is not None:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload)
 
 
@@ -611,9 +603,8 @@ def stop_message_live_location(
 def send_venue(
         token, chat_id, latitude, longitude, title, address,
         foursquare_id=None, foursquare_type=None, disable_notification=None,
-        reply_to_message_id=None, reply_markup=None, timeout=None,
-        allow_sending_without_reply=None, google_place_id=None,
-        google_place_type=None, protect_content=None, message_thread_id=None):
+        reply_markup=None, timeout=None, google_place_id=None,
+        google_place_type=None, protect_content=None, message_thread_id=None, reply_parameters=None):
     method_url = r'sendVenue'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude, 'title': title, 'address': address}
     if foursquare_id:
@@ -622,14 +613,10 @@ def send_venue(
         payload['foursquare_type'] = foursquare_type
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if timeout:
         payload['timeout'] = timeout
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if google_place_id:
         payload['google_place_id'] = google_place_id
     if google_place_type:
@@ -643,8 +630,8 @@ def send_venue(
 
 def send_contact(
         token, chat_id, phone_number, first_name, last_name=None, vcard=None,
-        disable_notification=None, reply_to_message_id=None, reply_markup=None, timeout=None,
-        allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
+        disable_notification=None, reply_markup=None, timeout=None,
+        protect_content=None, message_thread_id=None, reply_parameters=None):
     method_url = r'sendContact'
     payload = {'chat_id': chat_id, 'phone_number': phone_number, 'first_name': first_name}
     if last_name:
@@ -653,18 +640,17 @@ def send_contact(
         payload['vcard'] = vcard
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if timeout:
         payload['timeout'] = timeout
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id is not None:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
 
     return _make_request(token, method_url, params=payload)
 
@@ -679,10 +665,10 @@ def send_chat_action(token, chat_id, action, timeout=None, message_thread_id=Non
     return _make_request(token, method_url, params=payload)
 
 
-def send_video(token, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
+def send_video(token, chat_id, data, duration=None, caption=None, reply_markup=None,
                parse_mode=None, supports_streaming=None, disable_notification=None, timeout=None,
-               thumbnail=None, width=None, height=None, caption_entities=None, allow_sending_without_reply=None, protect_content=None,
-               message_thread_id=None, has_spoiler=None):
+               thumbnail=None, width=None, height=None, caption_entities=None, protect_content=None,
+               message_thread_id=None, has_spoiler=None, reply_parameters=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -694,8 +680,6 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_to_messa
         payload['duration'] = duration
     if caption:
         payload['caption'] = caption
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if parse_mode:
@@ -720,21 +704,22 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_to_messa
         payload['height'] = height
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
     if has_spoiler is not None:
         payload['has_spoiler'] = has_spoiler
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_animation(
-        token, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
+        token, chat_id, data, duration=None, caption=None,  reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None, thumbnail=None, caption_entities=None,
-        allow_sending_without_reply=None, protect_content=None, width=None, height=None, message_thread_id=None,
+        protect_content=None, width=None, height=None, message_thread_id=None, reply_parameters=None
         has_spoiler=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}
@@ -747,8 +732,6 @@ def send_animation(
         payload['duration'] = duration
     if caption:
         payload['caption'] = caption
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if parse_mode:
@@ -767,8 +750,9 @@ def send_animation(
             payload['thumbnail'] = thumbnail
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if width:
@@ -782,9 +766,9 @@ def send_animation(
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
-def send_voice(token, chat_id, voice, caption=None, duration=None, reply_to_message_id=None, reply_markup=None,
+def send_voice(token, chat_id, voice, caption=None, duration=None, reply_markup=None,
                parse_mode=None, disable_notification=None, timeout=None, caption_entities=None,
-               allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
+                 protect_content=None, message_thread_id=None, reply_parameters=None):
     method_url = r'sendVoice'
     payload = {'chat_id': chat_id}
     files = None
@@ -796,8 +780,6 @@ def send_voice(token, chat_id, voice, caption=None, duration=None, reply_to_mess
         payload['caption'] = caption
     if duration:
         payload['duration'] = duration
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if parse_mode:
@@ -808,18 +790,19 @@ def send_voice(token, chat_id, voice, caption=None, duration=None, reply_to_mess
         payload['timeout'] = timeout
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
-def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_message_id=None, reply_markup=None,
-                    disable_notification=None, timeout=None, thumbnail=None, allow_sending_without_reply=None, protect_content=None,
-                    message_thread_id=None):
+def send_video_note(token, chat_id, data, duration=None, length=None, reply_markup=None,
+                    disable_notification=None, timeout=None, thumbnail=None, protect_content=None,
+                    message_thread_id=None, reply_parameters=None):
     method_url = r'sendVideoNote'
     payload = {'chat_id': chat_id}
     files = None
@@ -833,8 +816,6 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_m
         payload['length'] = length
     else:
         payload['length'] = 639  # seems like it is MAX length size
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if disable_notification is not None:
@@ -849,8 +830,9 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_m
                 files = {'thumbnail': thumbnail}
         else:
             payload['thumbnail'] = thumbnail
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
@@ -858,9 +840,9 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_m
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
-def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None, reply_to_message_id=None,
+def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None,
                reply_markup=None, parse_mode=None, disable_notification=None, timeout=None, thumbnail=None,
-               caption_entities=None, allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
+               caption_entities=None, protect_content=None, message_thread_id=None, reply_parameters=None):
     method_url = r'sendAudio'
     payload = {'chat_id': chat_id}
     files = None
@@ -876,8 +858,6 @@ def send_audio(token, chat_id, audio, caption=None, duration=None, performer=Non
         payload['performer'] = performer
     if title:
         payload['title'] = title
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if parse_mode:
@@ -896,19 +876,21 @@ def send_audio(token, chat_id, audio, caption=None, duration=None, performer=Non
             payload['thumbnail'] = thumbnail
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
+
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
-def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_markup=None, parse_mode=None,
+def send_data(token, chat_id, data, data_type, reply_markup=None, parse_mode=None,
               disable_notification=None, timeout=None, caption=None, thumbnail=None, caption_entities=None,
-              allow_sending_without_reply=None, disable_content_type_detection=None, visible_file_name=None,
-              protect_content = None, message_thread_id=None, emoji=None):
+              disable_content_type_detection=None, visible_file_name=None,
+              protect_content = None, message_thread_id=None, emoji=None, reply_parameters=None):
     method_url = get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None
@@ -919,8 +901,6 @@ def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_m
         files = {data_type: file_data}
     else:
         payload[data_type] = data
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if parse_mode and data_type == 'document':
@@ -941,8 +921,9 @@ def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_m
             payload['thumbnail'] = thumbnail
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if method_url == 'sendDocument' and disable_content_type_detection is not None:
@@ -1399,20 +1380,19 @@ def delete_message(token, chat_id, message_id, timeout=None):
 
 def send_game(
         token, chat_id, game_short_name,
-        disable_notification=None, reply_to_message_id=None, reply_markup=None, timeout=None,
-        allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
+        disable_notification=None, reply_markup=None, timeout=None,
+       protect_content=None, message_thread_id=None, reply_parameters=None):
     method_url = r'sendGame'
     payload = {'chat_id': chat_id, 'game_short_name': game_short_name}
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if timeout:
         payload['timeout'] = timeout
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
@@ -1480,9 +1460,9 @@ def send_invoice(
         start_parameter = None, photo_url=None, photo_size=None, photo_width=None, photo_height=None,
         need_name=None, need_phone_number=None, need_email=None, need_shipping_address=None,
         send_phone_number_to_provider = None, send_email_to_provider = None, is_flexible=None,
-        disable_notification=None, reply_to_message_id=None, reply_markup=None, provider_data=None,
-        timeout=None, allow_sending_without_reply=None, max_tip_amount=None, suggested_tip_amounts=None,
-        protect_content=None, message_thread_id=None):
+        disable_notification=None, reply_markup=None, provider_data=None,
+        timeout=None, max_tip_amount=None, suggested_tip_amounts=None,
+        protect_content=None, message_thread_id=None, reply_parameters=None):
     """
     Use this method to send invoices. On success, the sent Message is returned.
     :param token: Bot's token (you don't need to fill this)
@@ -1548,16 +1528,12 @@ def send_invoice(
         payload['is_flexible'] = is_flexible
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if provider_data:
         payload['provider_data'] = provider_data
     if timeout:
         payload['timeout'] = timeout
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if max_tip_amount is not None:
         payload['max_tip_amount'] = max_tip_amount
     if suggested_tip_amounts is not None:
@@ -1566,6 +1542,9 @@ def send_invoice(
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        # to json
+        payload['reply_markup'] = json.dumps(reply_parameters.to_dict())
     return _make_request(token, method_url, params=payload)
 
 
@@ -1804,8 +1783,8 @@ def send_poll(
         question, options,
         is_anonymous = None, type = None, allows_multiple_answers = None, correct_option_id = None,
         explanation = None, explanation_parse_mode=None, open_period = None, close_date = None, is_closed = None,
-        disable_notification=False, reply_to_message_id=None, allow_sending_without_reply=None,
-        reply_markup=None, timeout=None, explanation_entities=None, protect_content=None, message_thread_id=None):
+        disable_notification=False,
+        reply_markup=None, timeout=None, explanation_entities=None, protect_content=None, message_thread_id=None, reply_parameters=None):
     method_url = r'sendPoll'
     payload = {
         'chat_id': str(chat_id),
@@ -1836,10 +1815,8 @@ def send_poll(
 
     if disable_notification:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id is not None:
-        payload['reply_to_message_id'] = reply_to_message_id
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
+    if reply_parameters is not None:
+        payload['reply_parameters'] = reply_parameters.to_json()
     if reply_markup is not None:
         payload['reply_markup'] = _convert_markup(reply_markup)
     if timeout:

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1904,6 +1904,52 @@ def unhide_general_forum_topic(token, chat_id):
     payload = {'chat_id': chat_id}
     return _make_request(token, method_url, params=payload)
 
+def delete_messages(token, chat_id, message_ids):
+    method_url = 'deleteMessages'
+    payload = {
+        'chat_id': chat_id,
+        'message_ids': message_ids
+    }
+    return _make_request(token, method_url, params=payload)
+
+def forward_messages(token, chat_id, from_chat_id, message_ids, disable_notification=None,
+                            message_thread_id=None, protect_content=None):
+    method_url = 'forwardMessages'
+    payload = {
+        'chat_id': chat_id,
+        'from_chat_id': from_chat_id,
+        'message_ids': message_ids,
+    }
+    if disable_notification is not None:
+        payload['disable_notification'] = disable_notification
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
+    if protect_content is not None:
+        payload['protect_content'] = protect_content
+    
+    result = _make_request(token, method_url, params=payload)
+    return result
+
+def copy_messages(token, chat_id, from_chat_id, message_ids, disable_notification=None,
+                        message_thread_id=None, protect_content=None, remove_caption=None):
+    method_url = 'copyMessages'
+    payload = {
+        'chat_id': chat_id,
+        'from_chat_id': from_chat_id,
+        'message_ids': message_ids,
+    }
+    if disable_notification is not None:
+        payload['disable_notification'] = disable_notification
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
+    if protect_content is not None:
+        payload['protect_content'] = protect_content
+    if remove_caption is not None:
+        payload['remove_caption'] = remove_caption
+    
+    result = _make_request(token, method_url, params=payload)
+    return result
+
 
 def _convert_list_json_serializable(results):
     ret = ''

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -719,7 +719,7 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_markup=N
 def send_animation(
         token, chat_id, data, duration=None, caption=None,  reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None, thumbnail=None, caption_entities=None,
-        protect_content=None, width=None, height=None, message_thread_id=None, reply_parameters=None
+        protect_content=None, width=None, height=None, message_thread_id=None, reply_parameters=None,
         has_spoiler=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -335,7 +335,7 @@ def set_message_reaction(token, chat_id, message_id, reaction=None, is_big=None)
     method_url = r'setMessageReaction'
     payload = {'chat_id': chat_id, 'message_id': message_id}
     if reaction:
-        payload['reaction'] = reaction
+        payload['reaction'] = json.dumps([r.to_dict() for r in reaction])
     if is_big is not None:
         payload['is_big'] = is_big
     return _make_request(token, method_url, params=payload)

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -332,6 +332,16 @@ def get_user_profile_photos(token, user_id, offset=None, limit=None):
         payload['limit'] = limit
     return _make_request(token, method_url, params=payload)
 
+def set_message_reaction(token, chat_id, message_id, reaction=None, is_big=None):
+    method_url = r'setMessageReaction'
+    payload = {'chat_id': chat_id, 'message_id': message_id}
+    if reaction:
+        payload['reaction'] = reaction
+    if is_big is not None:
+        payload['is_big'] = is_big
+    return _make_request(token, method_url, params=payload)
+
+
 
 def get_chat(token, chat_id):
     method_url = r'getChat'

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -466,7 +466,7 @@ def send_photo(
         caption=None, reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
         caption_entities=None, protect_content=None,
-        message_thread_id=None, has_spoiler=None,, reply_parameters=None):
+        message_thread_id=None, has_spoiler=None, reply_parameters=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6135,6 +6135,33 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.answer_callback_query(self.token, callback_query_id, text, show_alert, url, cache_time)
+    
+# getUserChatBoosts
+# Use this method to get the list of boosts added to a chat by a user. Requires administrator rights in the chat. Returns a UserChatBoosts object.
+
+# Parameter	Type	Required	Description
+# chat_id	Integer or String	Yes	Unique identifier for the chat or username of the channel (in the format @channelusername)
+# user_id	Integer	Yes	Unique identifier of the target user
+    
+    async def get_user_chat_boosts(self, chat_id: Union[int, str], user_id: int) -> types.UserChatBoosts:
+        """
+        Use this method to get the list of boosts added to a chat by a user. Requires administrator rights in the chat. Returns a UserChatBoosts object.
+
+        Telegram documentation: https://core.telegram.org/bots/api#getuserchatboosts
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param user_id: Unique identifier of the target user
+        :type user_id: :obj:`int`
+
+        :return: On success, a UserChatBoosts object is returned.
+        :rtype: :class:`telebot.types.UserChatBoosts`
+        """
+
+        result = await asyncio_helper.get_user_chat_boosts(self.token, chat_id, user_id)
+        return types.UserChatBoosts.de_json(result)
+    
 
     async def set_sticker_set_thumbnail(self, name: str, user_id: int, thumbnail: Union[Any, str]=None):
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -171,6 +171,8 @@ class AsyncTeleBot:
         self.my_chat_member_handlers = []
         self.chat_member_handlers = []
         self.chat_join_request_handlers = []
+        self.removed_chat_boost_handlers = []
+        self.chat_boost_handlers = []
         self.custom_filters = {}
         self.state_handlers = []
         self.middlewares = []
@@ -590,6 +592,8 @@ class AsyncTeleBot:
         new_my_chat_members = None
         new_chat_members = None
         chat_join_request = None
+        removed_chat_boost_handlers = None
+        chat_boost_handlers = None
         for update in updates:
             logger.debug('Processing updates: {0}'.format(update))
             if update.message:
@@ -640,6 +644,12 @@ class AsyncTeleBot:
             if update.message_reaction_count:
                 if new_message_reaction_count_handlers is None: new_message_reaction_count_handlers = []
                 new_message_reaction_count_handlers.append(update.message_reaction_count)
+            if update.chat_boost:
+                if chat_boost_handlers is None: chat_boost_handlers = []
+                chat_boost_handlers.append(update.chat_boost)
+            if update.removed_chat_boost:
+                if removed_chat_boost_handlers is None: removed_chat_boost_handlers = []
+                removed_chat_boost_handlers.append(update.removed_chat_boost)
 
 
         if new_messages:
@@ -674,6 +684,8 @@ class AsyncTeleBot:
             await self.process_new_message_reaction(new_message_reactions)
         if new_message_reaction_count_handlers:
             await self.process_new_message_reaction_count(new_message_reaction_count_handlers)
+        if chat_boost_handlers:
+            await self.process_new_chat_boost(chat_boost_handlers)
 
     async def process_new_messages(self, new_messages):
         """
@@ -771,6 +783,18 @@ class AsyncTeleBot:
         :meta private:
         """
         await self._process_updates(self.chat_join_request_handlers, chat_join_request, 'chat_join_request')
+
+    async def process_new_chat_boost(self, chat_boost):
+        """
+        :meta private:
+        """
+        await self._process_updates(self.chat_boost_handlers, chat_boost, 'chat_boost')
+
+    async def process_new_removed_chat_boost(self, removed_chat_boost):
+        """
+        :meta private:
+        """
+        await self._process_updates(self.removed_chat_boost_handlers, removed_chat_boost, 'removed_chat_boost')
 
     async def _get_middlewares(self, update_type):
         """
@@ -2001,6 +2025,105 @@ class AsyncTeleBot:
         """
         handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
         self.add_chat_join_request_handler(handler_dict)
+
+
+    def chat_boost_handler(self, func=None, **kwargs):
+        """
+        Handles new incoming chat boost state. 
+        it passes :class:`telebot.types.ChatBoostUpdated` object.
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+        :return: None
+        """
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
+            self.add_chat_boost_handler(handler_dict)
+            return handler
+
+        return decorator
+    
+    def add_chat_boost_handler(self, handler_dict):
+        """
+        Adds a chat_boost handler.
+        Note that you should use register_chat_boost_handler to add chat_boost_handler to the bot.
+
+        :meta private:
+
+        :param handler_dict:
+        :return:
+        """
+        self.chat_boost_handlers.append(handler_dict)
+
+    def register_chat_boost_handler(self, callback: Callable, func: Optional[Callable]=None, pass_bot:Optional[bool]=False, **kwargs):
+        """
+        Registers chat boost handler.
+
+        :param callback: function to be called
+        :type callback: :obj:`function`
+        
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
+
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return: None
+        """
+        handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
+        self.add_chat_boost_handler(handler_dict)
+
+    def removed_chat_boost_handler(self, func=None, **kwargs):
+        """
+        Handles new incoming chat boost state. 
+        it passes :class:`telebot.types.ChatBoostRemoved` object.
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+        :return: None
+        """
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
+            self.add_removed_chat_boost_handler(handler_dict)
+            return handler
+
+        return decorator
+    
+    def add_removed_chat_boost_handler(self, handler_dict):
+        """
+        Adds a removed_chat_boost handler.
+        Note that you should use register_removed_chat_boost_handler to add removed_chat_boost_handler to the bot.
+
+        :meta private:
+
+        :param handler_dict:
+        :return:
+        """
+        self.removed_chat_boost_handlers.append(handler_dict)
+
+    def register_removed_chat_boost_handler(self, callback: Callable, func: Optional[Callable]=None, pass_bot:Optional[bool]=False, **kwargs):
+        """
+        Registers removed chat boost handler.
+
+        :param callback: function to be called
+        :type callback: :obj:`function`
+        
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
+
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return: None
+        """
+        handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
+        self.add_removed_chat_boost_handler(handler_dict)
 
     @staticmethod
     def _build_handler_dict(handler, pass_bot=False, **filters):

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -2515,7 +2515,8 @@ class AsyncTeleBot:
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            link_preview_options: Optional[types.LinkPreviewOptions]=None) -> types.Message:
         """
         Use this method to send text messages.
 
@@ -2565,6 +2566,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param link_preview_options: Options for previewing links.
+        :type link_preview_options: :class:`telebot.types.LinkPreviewOptions`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2583,12 +2587,20 @@ class AsyncTeleBot:
                 allow_sending_without_reply=allow_sending_without_reply,
                 message_id=reply_to_message_id
             )
+        if disable_web_page_preview:
+            # show a deprecation warning
+            logger.warning("The parameter 'disable_web_page_preview' is deprecated. Use 'link_preview_options' instead.")
+
+            # create a LinkPreviewOptions object
+            link_preview_options = types.LinkPreviewOptions(
+                disable_web_page_preview=disable_web_page_preview
+            )
 
         return types.Message.de_json(
             await asyncio_helper.send_message(
-                self.token, chat_id, text, disable_web_page_preview,
+                self.token, chat_id, text,
                 reply_markup, parse_mode, disable_notification, timeout,
-                entities, protect_content, message_thread_id, reply_parameters))
+                entities, protect_content, message_thread_id, reply_parameters, link_preview_options))
 
     async def forward_message(
             self, chat_id: Union[int, str], from_chat_id: Union[int, str], 
@@ -5025,7 +5037,8 @@ class AsyncTeleBot:
             parse_mode: Optional[str]=None,
             entities: Optional[List[types.MessageEntity]]=None,
             disable_web_page_preview: Optional[bool]=None,
-            reply_markup: Optional[types.InlineKeyboardMarkup]=None) -> Union[types.Message, bool]:
+            reply_markup: Optional[types.InlineKeyboardMarkup]=None,
+            link_preview_options: Optional[types.LinkPreviewOptions]=None) -> Union[types.Message, bool]:
         """
         Use this method to edit text and game messages.
 
@@ -5055,14 +5068,26 @@ class AsyncTeleBot:
         :param reply_markup: A JSON-serialized object for an inline keyboard.
         :type reply_markup: :obj:`InlineKeyboardMarkup`
 
+        :param link_preview_options: A JSON-serialized object for options used to automatically generate Telegram link previews for messages.
+        :type link_preview_options: :obj:`LinkPreviewOptions`
+
         :return: On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
         :rtype: :obj:`types.Message` or :obj:`bool`
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_web_page_preview = self.disable_web_page_preview if (disable_web_page_preview is None) else disable_web_page_preview
 
+        if disable_web_page_preview:
+            # show a deprecation warning
+            logger.warning("The parameter 'disable_web_page_preview' is deprecated. Use 'link_preview_options' instead.")
+
+            # create a LinkPreviewOptions object
+            link_preview_options = types.LinkPreviewOptions(
+                disable_web_page_preview=disable_web_page_preview
+            )
+
         result = await asyncio_helper.edit_message_text(self.token, text, chat_id, message_id, inline_message_id, parse_mode,
-                                             entities, disable_web_page_preview, reply_markup)
+                                             entities, reply_markup, link_preview_options)
         if type(result) == bool:  # if edit inline message return is bool not Message.
             return result
         return types.Message.de_json(result)

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -1400,7 +1400,7 @@ class AsyncTeleBot:
     def message_reaction_handler(self, func=None, **kwargs):
         """
         Handles new incoming message reaction.
-        As a parameter to the decorator function, it passes :class:`telebot.types.Message` object.
+        As a parameter to the decorator function, it passes :class:`telebot.types.MessageReactionUpdated` object.
 
         :param func: Function executed as a filter
         :type func: :obj:`function`
@@ -1452,7 +1452,7 @@ class AsyncTeleBot:
     def message_reaction_count_handler(self, func=None, **kwargs):
         """
         Handles new incoming message reaction count.
-        As a parameter to the decorator function, it passes :class:`telebot.types.Message` object.
+        As a parameter to the decorator function, it passes :class:`telebot.types.MessageReactionCountUpdated` object.
 
         :param func: Function executed as a filter
         :type func: :obj:`function`

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -581,7 +581,7 @@ class AsyncTeleBot:
         new_channel_posts = None
         new_edited_channel_posts = None
         new_message_reactions = None
-        mew_message_reaction_count_handlers = None
+        new_message_reaction_count_handlers = None
         new_inline_queries = None
         new_chosen_inline_results = None
         new_callback_queries = None

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -2758,6 +2758,96 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.delete_message(self.token, chat_id, message_id, timeout)
+    
+    async def delete_messages(self, chat_id: Union[int, str], message_ids: List[int]):
+        """
+        Use this method to delete multiple messages in a chat. 
+        The number of messages to be deleted must not exceed 100. 
+        If the chat is a private chat, the user must be an administrator of the chat for this to work and must have the appropriate admin rights. 
+        Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#deletemessages
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_ids: Identifiers of the messages to be deleted
+        :type message_ids: :obj:`list` of :obj:`int`
+
+        :return: Returns True on success.
+
+        """
+        return await asyncio_helper.delete_messages(self.token, chat_id, message_ids)
+    
+    async def forward_messages(self, chat_id: Union[str, int], from_chat_id: Union[str, int], message_ids: List[int], disable_notification: Optional[bool]=None,
+                         message_thread_id: Optional[int]=None, protect_content: Optional[bool]=None) -> List[types.MessageID]:
+        """
+        Use this method to forward messages of any kind.
+
+        :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param from_chat_id: Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
+        :type from_chat_id: :obj:`int` or :obj:`str`
+
+        :param message_ids: Message identifiers in the chat specified in from_chat_id
+        :type message_ids: :obj:`list`
+
+        :param disable_notification: Sends the message silently. Users will receive a notification with no sound
+        :type disable_notification: :obj:`bool`
+
+        :param message_thread_id: Identifier of a message thread, in which the messages will be sent
+        :type message_thread_id: :obj:`int`
+
+        :param protect_content: Protects the contents of the forwarded message from forwarding and saving
+        :type protect_content: :obj:`bool`
+
+        :return: On success, the sent Message is returned.
+        :rtype: :class:`telebot.types.MessageID`
+        """
+
+        disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
+        protect_content = self.protect_content if (protect_content is None) else protect_content
+        result = await asyncio_helper.forward_messages(self.token, chat_id, from_chat_id, message_ids, disable_notification, protect_content, message_thread_id)
+        return types.MessageID.de_json(
+            result)
+    
+    async def copy_messages(self, chat_id: Union[str, int], from_chat_id: Union[str, int], message_ids: List[int],
+                        disable_notification: Optional[bool] = None, message_thread_id: Optional[int] = None,
+                        protect_content: Optional[bool] = None, remove_caption: Optional[bool] = None) -> List[types.MessageID]:
+            """
+            Use this method to copy messages of any kind.
+
+            :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+            :type chat_id: :obj:`int` or :obj:`str`
+
+            :param from_chat_id: Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
+            :type from_chat_id: :obj:`int` or :obj:`str`
+
+            :param message_ids: Message identifiers in the chat specified in from_chat_id
+            :type message_ids: :obj:`list` of :obj:`int`
+
+            :param disable_notification: Sends the message silently. Users will receive a notification with no sound
+            :type disable_notification: :obj:`bool`
+
+            :param message_thread_id: Identifier of a message thread, in which the messages will be sent
+            :type message_thread_id: :obj:`int`
+
+            :param protect_content: Protects the contents of the forwarded message from forwarding and saving
+            :type protect_content: :obj:`bool`
+
+            :param remove_caption: Pass True to copy the messages without their captions
+            :type remove_caption: :obj:`bool`
+
+            :return: On success, an array of MessageId of the sent messages is returned.
+            :rtype: :obj:`list` of :class:`telebot.types.MessageID`
+            """
+            disable_notification = self.disable_notification if disable_notification is None else disable_notification
+            protect_content = self.protect_content if protect_content is None else protect_content
+            result = await asyncio_helper.copy_messages(self.token, chat_id, from_chat_id, message_ids, disable_notification,
+                                            protect_content, message_thread_id, remove_caption)
+            return [types.MessageID.de_json(message_id) for message_id in
+                    result]
 
     async def send_dice(
             self, chat_id: Union[int, str],

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -1397,7 +1397,7 @@ class AsyncTeleBot:
                                                 **kwargs)
         self.add_edited_channel_post_handler(handler_dict)
 
-    def messsage_reaction_handler(self, func, **kwargs):
+    def message_reaction_handler(self, func=None, **kwargs):
         """
         Handles new incoming message reaction.
         As a parameter to the decorator function, it passes :class:`telebot.types.Message` object.
@@ -1429,7 +1429,7 @@ class AsyncTeleBot:
         """
         self.message_reaction_handlers.append(handler_dict)
 
-    def register_message_reaction_handler(self, callback: Callable[[Any], Awaitable], func: Callable, pass_bot: Optional[bool]=False, **kwargs):
+    def register_message_reaction_handler(self, callback: Callable[[Any], Awaitable], func: Callable=None, pass_bot: Optional[bool]=False, **kwargs):
         """
         Registers message reaction handler.
 
@@ -1449,7 +1449,7 @@ class AsyncTeleBot:
         handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
         self.add_message_reaction_handler(handler_dict)
 
-    def message_reaction_count_handler(self, func, **kwargs):
+    def message_reaction_count_handler(self, func=None, **kwargs):
         """
         Handles new incoming message reaction count.
         As a parameter to the decorator function, it passes :class:`telebot.types.Message` object.
@@ -1481,7 +1481,7 @@ class AsyncTeleBot:
         """
         self.message_reaction_count_handlers.append(handler_dict)
 
-    def register_message_reaction_count_handler(self, callback: Callable[[Any], Awaitable], func: Callable, pass_bot: Optional[bool]=False, **kwargs):
+    def register_message_reaction_count_handler(self, callback: Callable[[Any], Awaitable], func: Callable=None, pass_bot: Optional[bool]=False, **kwargs):
         """
         Registers message reaction count handler.
 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -2514,7 +2514,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send text messages.
 
@@ -2561,6 +2562,9 @@ class AsyncTeleBot:
         :param message_thread_id: Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
         :type message_thread_id: :obj:`int`
 
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2570,11 +2574,21 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             await asyncio_helper.send_message(
-                self.token, chat_id, text, disable_web_page_preview, reply_to_message_id,
+                self.token, chat_id, text, disable_web_page_preview,
                 reply_markup, parse_mode, disable_notification, timeout,
-                entities, allow_sending_without_reply, protect_content, message_thread_id))
+                entities, protect_content, message_thread_id, reply_parameters))
 
     async def forward_message(
             self, chat_id: Union[int, str], from_chat_id: Union[int, str], 
@@ -2631,7 +2645,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
-            message_thread_id: Optional[int]=None) -> types.MessageID:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.MessageID:
         """
         Use this method to copy messages of any kind.
 
@@ -2677,6 +2692,9 @@ class AsyncTeleBot:
         :param message_thread_id: Identifier of a message thread, in which the message will be sent
         :type message_thread_id: :obj:`int`
         
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+        
         :return: On success, the MessageId of the sent message is returned.
         :rtype: :class:`telebot.types.MessageID`
         """
@@ -2685,10 +2703,20 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.MessageID.de_json(
             await asyncio_helper.copy_message(self.token, chat_id, from_chat_id, message_id, caption, parse_mode, caption_entities,
-                                   disable_notification, reply_to_message_id, allow_sending_without_reply, reply_markup,
-                                   timeout, protect_content, message_thread_id))
+                                   disable_notification, reply_markup,
+                                   timeout, protect_content, message_thread_id, reply_parameters))
 
     async def delete_message(self, chat_id: Union[int, str], message_id: int, 
             timeout: Optional[int]=None) -> bool:
@@ -2727,7 +2755,8 @@ class AsyncTeleBot:
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send an animated emoji that will display a random value. On success, the sent Message is returned.
 
@@ -2762,6 +2791,9 @@ class AsyncTeleBot:
 
         :param message_thread_id: The identifier of a message thread, unique within the chat to which the message with the thread identifier belongs
         :type message_thread_id: :obj:`int`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -2770,10 +2802,20 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             await asyncio_helper.send_dice(
-                self.token, chat_id, emoji, disable_notification, reply_to_message_id,
-                reply_markup, timeout, allow_sending_without_reply, protect_content, message_thread_id)
+                self.token, chat_id, emoji, disable_notification,
+                reply_markup, timeout, protect_content, message_thread_id, reply_parameters)
         )
 
     async def send_photo(
@@ -2787,7 +2829,8 @@ class AsyncTeleBot:
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
-            has_spoiler: Optional[bool]=None) -> types.Message:
+            has_spoiler: Optional[bool]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send photos. On success, the sent Message is returned.
 
@@ -2836,6 +2879,9 @@ class AsyncTeleBot:
         :param has_spoiler: Pass True, if the photo should be sent as a spoiler
         :type has_spoiler: :obj:`bool`
         
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+        
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2844,11 +2890,21 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             await asyncio_helper.send_photo(
-                self.token, chat_id, photo, caption, reply_to_message_id, reply_markup,
+                self.token, chat_id, photo, caption, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
-                allow_sending_without_reply, protect_content, message_thread_id, has_spoiler))
+                protect_content, message_thread_id, has_spoiler, reply_parameters))
 
     async def send_audio(
             self, chat_id: Union[int, str], audio: Union[Any, str], 
@@ -2864,7 +2920,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            thumb: Optional[Union[Any, str]]=None) -> types.Message:
+            thumb: Optional[Union[Any, str]]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player.
         Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size,
@@ -2930,6 +2987,9 @@ class AsyncTeleBot:
 
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -2943,11 +3003,21 @@ class AsyncTeleBot:
             thumbnail = thumb
             logger.warning('The parameter "thumb" is deprecated, use "thumbnail" instead')
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             await asyncio_helper.send_audio(
-                self.token, chat_id, audio, caption, duration, performer, title, reply_to_message_id,
+                self.token, chat_id, audio, caption, duration, performer, title,
                 reply_markup, parse_mode, disable_notification, timeout, thumbnail,
-                caption_entities, allow_sending_without_reply, protect_content, message_thread_id))
+                caption_entities, protect_content, message_thread_id, reply_parameters))
 
     async def send_voice(
             self, chat_id: Union[int, str], voice: Union[Any, str], 
@@ -2960,7 +3030,8 @@ class AsyncTeleBot:
             caption_entities: Optional[List[types.MessageEntity]]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
         For this to work, your audio must be in an .OGG file encoded with OPUS (other formats may be sent as Audio or Document).
@@ -3009,6 +3080,9 @@ class AsyncTeleBot:
 
         :param message_thread_id: Identifier of a message thread, in which the message will be sent
         :type message_thread_id: :obj:`int`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         """
@@ -3017,11 +3091,21 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             await asyncio_helper.send_voice(
-                self.token, chat_id, voice, caption, duration, reply_to_message_id, reply_markup,
+                self.token, chat_id, voice, caption, duration, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
-                allow_sending_without_reply, protect_content, message_thread_id))
+                protect_content, message_thread_id, reply_parameters))
 
     async def send_document(
             self, chat_id: Union[int, str], document: Union[Any, str],
@@ -3039,7 +3123,8 @@ class AsyncTeleBot:
             data: Optional[Union[Any, str]]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            thumb: Optional[Union[Any, str]]=None) -> types.Message:
+            thumb: Optional[Union[Any, str]]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send general files.
 
@@ -3098,6 +3183,9 @@ class AsyncTeleBot:
 
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -3116,14 +3204,24 @@ class AsyncTeleBot:
             thumbnail = thumb
             logger.warning('The parameter "thumb" is deprecated. Use "thumbnail" instead.')
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             await asyncio_helper.send_data(
                 self.token, chat_id, document, 'document',
-                reply_to_message_id = reply_to_message_id, reply_markup = reply_markup, parse_mode = parse_mode,
+                reply_markup = reply_markup, parse_mode = parse_mode,
                 disable_notification = disable_notification, timeout = timeout, caption = caption, thumbnail= thumbnail,
-                caption_entities = caption_entities, allow_sending_without_reply = allow_sending_without_reply,
+                caption_entities = caption_entities,
                 disable_content_type_detection = disable_content_type_detection, visible_file_name = visible_file_name, protect_content = protect_content,
-                message_thread_id = message_thread_id))
+                message_thread_id = message_thread_id, reply_parameters=reply_parameters))
 
     async def send_sticker(
             self, chat_id: Union[int, str], sticker: Union[Any, str], 
@@ -3135,7 +3233,8 @@ class AsyncTeleBot:
             protect_content: Optional[bool]=None,
             data: Union[Any, str]=None,
             message_thread_id: Optional[int]=None,
-            emoji: Optional[str]=None) -> types.Message:
+            emoji: Optional[str]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers.
         On success, the sent Message is returned.
@@ -3177,6 +3276,9 @@ class AsyncTeleBot:
 
         :param emoji: Emoji associated with the sticker; only for just uploaded stickers
         :type emoji: :obj:`str`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -3190,13 +3292,23 @@ class AsyncTeleBot:
             logger.warning('The parameter "data" is deprecated. Use "sticker" instead.')
             sticker = data
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             await asyncio_helper.send_data(
                 self.token, chat_id, sticker, 'sticker',
-                reply_to_message_id=reply_to_message_id, reply_markup=reply_markup,
+                reply_markup=reply_markup,
                 disable_notification=disable_notification, timeout=timeout, 
-                allow_sending_without_reply=allow_sending_without_reply, protect_content=protect_content,
-                message_thread_id=message_thread_id, emoji=emoji))
+                protect_content=protect_content,
+                message_thread_id=message_thread_id, emoji=emoji, reply_parameters=reply_parameters))
 
     async def send_video(
             self, chat_id: Union[int, str], video: Union[Any, str], 
@@ -3217,7 +3329,8 @@ class AsyncTeleBot:
             data: Optional[Union[Any, str]]=None,
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
-            thumb: Optional[Union[Any, str]]=None) -> types.Message:
+            thumb: Optional[Union[Any, str]]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
         
@@ -3284,6 +3397,9 @@ class AsyncTeleBot:
 
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -3292,6 +3408,16 @@ class AsyncTeleBot:
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
+
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
 
         if data and not(video):
             # function typo miss compatibility
@@ -3304,9 +3430,9 @@ class AsyncTeleBot:
 
         return types.Message.de_json(
             await asyncio_helper.send_video(
-                self.token, chat_id, video, duration, caption, reply_to_message_id, reply_markup,
+                self.token, chat_id, video, duration, caption, reply_markup,
                 parse_mode, supports_streaming, disable_notification, timeout, thumbnail, width, height,
-                caption_entities, allow_sending_without_reply, protect_content, message_thread_id, has_spoiler))
+                caption_entities, protect_content, message_thread_id, has_spoiler, reply_parameters))
 
     async def send_animation(
             self, chat_id: Union[int, str], animation: Union[Any, str], 
@@ -3325,7 +3451,8 @@ class AsyncTeleBot:
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
-            thumb: Optional[Union[Any, str]]=None) -> types.Message:
+            thumb: Optional[Union[Any, str]]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
@@ -3391,6 +3518,9 @@ class AsyncTeleBot:
 
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -3400,15 +3530,25 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         if thumb is not None and thumbnail is None:
             thumbnail = thumb
             logger.warning('The parameter "thumb" is deprecated. Use "thumbnail" instead.')
 
         return types.Message.de_json(
             await asyncio_helper.send_animation(
-                self.token, chat_id, animation, duration, caption, reply_to_message_id,
+                self.token, chat_id, animation, duration, caption,
                 reply_markup, parse_mode, disable_notification, timeout, thumbnail,
-                caption_entities, allow_sending_without_reply, width, height, protect_content, message_thread_id, has_spoiler))
+                caption_entities, width, height, protect_content, message_thread_id, has_spoiler, reply_parameters))
 
     async def send_video_note(
             self, chat_id: Union[int, str], data: Union[Any, str], 
@@ -3422,7 +3562,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            thumb: Optional[Union[Any, str]]=None) -> types.Message:
+            thumb: Optional[Union[Any, str]]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         As of v.4.0, Telegram clients support rounded square MPEG4 videos of up to 1 minute long.
         Use this method to send video messages. On success, the sent Message is returned.
@@ -3473,6 +3614,9 @@ class AsyncTeleBot:
 
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -3481,14 +3625,24 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         if thumb is not None and thumbnail is None:
             thumbnail = thumb
             logger.warning('The parameter "thumb" is deprecated. Use "thumbnail" instead.')
 
         return types.Message.de_json(
             await asyncio_helper.send_video_note(
-                self.token, chat_id, data, duration, length, reply_to_message_id, reply_markup,
-                disable_notification, timeout, thumbnail, allow_sending_without_reply, protect_content, message_thread_id))
+                self.token, chat_id, data, duration, length, reply_markup,
+                disable_notification, timeout, thumbnail, protect_content, message_thread_id, reply_parameters))
 
     async def send_media_group(
             self, chat_id: Union[int, str], 
@@ -3500,7 +3654,8 @@ class AsyncTeleBot:
             reply_to_message_id: Optional[int]=None, 
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> List[types.Message]:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> List[types.Message]:
         """
         Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files
         can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned.
@@ -3530,6 +3685,9 @@ class AsyncTeleBot:
 
         :param message_thread_id: Identifier of a message thread, in which the messages will be sent
         :type message_thread_id: :obj:`int`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, an array of Messages that were sent is returned.
         :rtype: List[types.Message]
@@ -3538,9 +3696,18 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         result = await asyncio_helper.send_media_group(
-            self.token, chat_id, media, disable_notification, reply_to_message_id, timeout, 
-            allow_sending_without_reply, protect_content, message_thread_id)
+            self.token, chat_id, media, disable_notification, timeout, protect_content, message_thread_id, reply_parameters)
         return [types.Message.de_json(msg) for msg in result]
 
     async def send_location(
@@ -3556,7 +3723,8 @@ class AsyncTeleBot:
             proximity_alert_radius: Optional[int]=None, 
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send point on the map. On success, the sent Message is returned.
 
@@ -3605,6 +3773,9 @@ class AsyncTeleBot:
 
         :param message_thread_id: Identifier of a message thread, in which the message will be sent
         :type message_thread_id: :obj:`int`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -3613,12 +3784,22 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             await asyncio_helper.send_location(
                 self.token, chat_id, latitude, longitude, live_period, 
-                reply_to_message_id, reply_markup, disable_notification, timeout, 
+                reply_markup, disable_notification, timeout, 
                 horizontal_accuracy, heading, proximity_alert_radius, 
-                allow_sending_without_reply, protect_content, message_thread_id))
+                protect_content, message_thread_id, reply_parameters))
 
     async def edit_message_live_location(
             self, latitude: float, longitude: float, 
@@ -3726,7 +3907,8 @@ class AsyncTeleBot:
             google_place_id: Optional[str]=None,
             google_place_type: Optional[str]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send information about a venue. On success, the sent Message is returned.
         
@@ -3783,6 +3965,9 @@ class AsyncTeleBot:
 
         :param message_thread_id: The thread to which the message will be sent
         :type message_thread_id: :obj:`int`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -3791,11 +3976,21 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             await asyncio_helper.send_venue(
                 self.token, chat_id, latitude, longitude, title, address, foursquare_id, foursquare_type,
-                disable_notification, reply_to_message_id, reply_markup, timeout,
-                allow_sending_without_reply, google_place_id, google_place_type, protect_content, message_thread_id)
+                disable_notification, reply_markup, timeout,
+                google_place_id, google_place_type, protect_content, message_thread_id, reply_parameters)
         )
 
     async def send_contact(
@@ -3808,7 +4003,8 @@ class AsyncTeleBot:
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send phone contacts. On success, the sent Message is returned.
 
@@ -3852,6 +4048,9 @@ class AsyncTeleBot:
 
         :param message_thread_id: The thread to which the message will be sent
         :type message_thread_id: :obj:`int`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -3860,11 +4059,21 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         return types.Message.de_json(
             await asyncio_helper.send_contact(
                 self.token, chat_id, phone_number, first_name, last_name, vcard,
-                disable_notification, reply_to_message_id, reply_markup, timeout,
-                allow_sending_without_reply, protect_content, message_thread_id)
+                disable_notification, reply_markup, timeout,
+                protect_content, message_thread_id, reply_parameters)
         )
 
     async def send_chat_action(
@@ -4931,7 +5140,8 @@ class AsyncTeleBot:
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Used to send the game.
 
@@ -4963,6 +5173,9 @@ class AsyncTeleBot:
 
         :param message_thread_id: Identifier of the thread to which the message will be sent.
         :type message_thread_id: :obj:`int`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
@@ -4971,10 +5184,20 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         result = await asyncio_helper.send_game(
             self.token, chat_id, game_short_name, disable_notification,
-            reply_to_message_id, reply_markup, timeout, 
-            allow_sending_without_reply, protect_content, message_thread_id)
+            reply_markup, timeout, 
+            protect_content, message_thread_id, reply_parameters)
         return types.Message.de_json(result)
 
     async def set_game_score(
@@ -5071,7 +5294,8 @@ class AsyncTeleBot:
             max_tip_amount: Optional[int] = None,
             suggested_tip_amounts: Optional[List[int]]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Sends invoice.
 
@@ -5172,6 +5396,9 @@ class AsyncTeleBot:
 
         :param message_thread_id: The identifier of a message thread, in which the invoice message will be sent
         :type message_thread_id: :obj:`int`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
@@ -5180,13 +5407,23 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
 
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
+
         result = await asyncio_helper.send_invoice(
             self.token, chat_id, title, description, invoice_payload, provider_token,
             currency, prices, start_parameter, photo_url, photo_size, photo_width,
             photo_height, need_name, need_phone_number, need_email, need_shipping_address,
             send_phone_number_to_provider, send_email_to_provider, is_flexible, disable_notification,
-            reply_to_message_id, reply_markup, provider_data, timeout, allow_sending_without_reply,
-            max_tip_amount, suggested_tip_amounts, protect_content, message_thread_id)
+            reply_markup, provider_data, timeout,
+            max_tip_amount, suggested_tip_amounts, protect_content, message_thread_id, reply_parameters)
         return types.Message.de_json(result)
 
 
@@ -5311,7 +5548,8 @@ class AsyncTeleBot:
             timeout: Optional[int]=None,
             explanation_entities: Optional[List[types.MessageEntity]]=None,
             protect_content: Optional[bool]=None,
-            message_thread_id: Optional[int]=None) -> types.Message:
+            message_thread_id: Optional[int]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
         """
         Use this method to send a native poll.
         On success, the sent Message is returned.
@@ -5381,6 +5619,9 @@ class AsyncTeleBot:
 
         :param message_thread_id: The identifier of a message thread, in which the poll will be sent
         :type message_thread_id: :obj:`int`
+        
+        :param reply_parameters: Reply parameters.
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
@@ -5389,6 +5630,16 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         allow_sending_without_reply = self.allow_sending_without_reply if (allow_sending_without_reply is None) else allow_sending_without_reply
         explanation_parse_mode = self.parse_mode if (explanation_parse_mode is None) else explanation_parse_mode
+
+        if allow_sending_without_reply or reply_to_message_id:
+            # show a deprecation warning
+            logger.warning("The parameters 'allow_sending_without_reply' and 'reply_to_message_id' are deprecated. Use 'reply_parameters' instead.")
+
+            # create a ReplyParameters object
+            reply_parameters = types.ReplyParameters(
+                allow_sending_without_reply=allow_sending_without_reply,
+                message_id=reply_to_message_id
+            )
 
         if isinstance(question, types.Poll):
             raise RuntimeError("The send_poll signature was changed, please see send_poll function details.")
@@ -5399,8 +5650,8 @@ class AsyncTeleBot:
                 question, options,
                 is_anonymous, type, allows_multiple_answers, correct_option_id,
                 explanation, explanation_parse_mode, open_period, close_date, is_closed,
-                disable_notification, reply_to_message_id, allow_sending_without_reply,
-                reply_markup, timeout, explanation_entities, protect_content, message_thread_id))
+                disable_notification,
+                reply_markup, timeout, explanation_entities, protect_content, message_thread_id, reply_parameters))
 
     async def stop_poll(
             self, chat_id: Union[int, str], message_id: int, 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -160,6 +160,7 @@ class AsyncTeleBot:
         self.channel_post_handlers = []
         self.edited_channel_post_handlers = []
         self.message_reaction_handlers = []
+        self.message_reaction_count_handlers = []
         self.inline_handlers = []
         self.chosen_inline_handlers = []
         self.callback_query_handlers = []
@@ -578,6 +579,7 @@ class AsyncTeleBot:
         new_channel_posts = None
         new_edited_channel_posts = None
         new_message_reactions = None
+        mew_message_reaction_count_handlers = None
         new_inline_queries = None
         new_chosen_inline_results = None
         new_callback_queries = None
@@ -635,6 +637,10 @@ class AsyncTeleBot:
             if update.message_reaction:
                 if new_message_reactions is None: new_message_reactions = []
                 new_message_reactions.append(update.message_reaction)
+            if update.message_reaction_count:
+                if new_message_reaction_count_handlers is None: new_message_reaction_count_handlers = []
+                new_message_reaction_count_handlers.append(update.message_reaction_count)
+
 
         if new_messages:
             await self.process_new_messages(new_messages)
@@ -666,6 +672,8 @@ class AsyncTeleBot:
             await self.process_chat_join_request(chat_join_request)
         if new_message_reactions:
             await self.process_new_message_reaction(new_message_reactions)
+        if new_message_reaction_count_handlers:
+            await self.process_new_message_reaction_count(new_message_reaction_count_handlers)
 
     async def process_new_messages(self, new_messages):
         """
@@ -697,6 +705,12 @@ class AsyncTeleBot:
         :meta private:
         """
         await self._process_updates(self.message_reaction_handlers, message_reaction, 'message_reaction')
+
+    async def process_new_message_reaction_count(self, message_reaction_count):
+        """
+        :meta private:
+        """
+        await self._process_updates(self.message_reaction_count_handlers, message_reaction_count, 'message_reaction_count')
 
     async def process_new_inline_query(self, new_inline_queries):
         """
@@ -1410,6 +1424,58 @@ class AsyncTeleBot:
         """
         handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
         self.add_message_reaction_handler(handler_dict)
+
+    def message_reaction_count_handler(self, func, **kwargs):
+        """
+        Handles new incoming message reaction count.
+        As a parameter to the decorator function, it passes :class:`telebot.types.Message` object.
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return:
+        """
+
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
+            self.add_message_reaction_count_handler(handler_dict)
+            return handler
+
+        return decorator
+    
+    def add_message_reaction_count_handler(self, handler_dict):
+        """
+        Adds message reaction count handler
+        Note that you should use register_message_reaction_count_handler to add message_reaction_count_handler to the bot.
+
+        :meta private:
+
+        :param handler_dict:
+        :return:
+        """
+        self.message_reaction_count_handlers.append(handler_dict)
+
+    def register_message_reaction_count_handler(self, callback: Callable[[Any], Awaitable], func: Callable, pass_bot: Optional[bool]=False, **kwargs):
+        """
+        Registers message reaction count handler.
+
+        :param callback: function to be called
+        :type callback: :obj:`Awaitable`
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
+        :type pass_bot: :obj:`bool`
+        
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return: None
+        """
+        handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
+        self.add_message_reaction_count_handler(handler_dict)
 
 
     def inline_handler(self, func, **kwargs):

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -2297,6 +2297,30 @@ class AsyncTeleBot:
         result = await asyncio_helper.get_webhook_info(self.token, timeout)
         return types.WebhookInfo.de_json(result)
 
+    async def set_message_reaction(self, chat_id: Union[int, str], message_id: int, reaction: Optional[List[types.ReactionType]]=None, is_big: Optional[bool]=None) -> bool:
+        """
+        Use this method to set a reaction to a message in a chat. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setmessagereaction
+
+        :param chat_id: Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param message_id: Identifier of the message to set reaction to
+        :type message_id: :obj:`int`
+
+        :param reaction: New list of reaction types to set on the message. Currently, as non-premium users, bots can set up to one reaction per message.
+            A custom emoji reaction can be used if it is either already present on the message or explicitly allowed by chat administrators.
+        :type reaction: :obj:`list` of :class:`telebot.types.ReactionType`
+
+        :param is_big: Pass True to set the reaction with a big animation
+        :type is_big: :obj:`bool`
+
+        :return: :obj:`bool`
+        """
+        result = await asyncio_helper.set_message_reaction(self.token, chat_id, message_id, reaction, is_big)
+        return result
+
     async def get_user_profile_photos(self, user_id: int, offset: Optional[int]=None, 
             limit: Optional[int]=None) -> types.UserProfilePhotos:
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -2932,8 +2932,7 @@ class AsyncTeleBot:
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
         result = await asyncio_helper.forward_messages(self.token, chat_id, from_chat_id, message_ids, disable_notification, protect_content, message_thread_id)
-        return types.MessageID.de_json(
-            result)
+        return [types.MessageID.de_json(message_id) for message_id in result]
     
     async def copy_messages(self, chat_id: Union[str, int], from_chat_id: Union[str, int], message_ids: List[int],
                         disable_notification: Optional[bool] = None, message_thread_id: Optional[int] = None,
@@ -2969,8 +2968,7 @@ class AsyncTeleBot:
             protect_content = self.protect_content if protect_content is None else protect_content
             result = await asyncio_helper.copy_messages(self.token, chat_id, from_chat_id, message_ids, disable_notification,
                                             protect_content, message_thread_id, remove_caption)
-            return [types.MessageID.de_json(message_id) for message_id in
-                    result]
+            return [types.MessageID.de_json(message_id) for message_id in result]
 
     async def send_dice(
             self, chat_id: Union[int, str],

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1591,6 +1591,10 @@ async def answer_callback_query(token, callback_query_id, text=None, show_alert=
         payload['cache_time'] = cache_time
     return await _process_request(token, method_url, params=payload, method='post')
 
+async def get_user_chat_boosts(token, chat_id, user_id):
+    method_url = 'getUserChatBoosts'
+    payload = {'chat_id': chat_id, 'user_id': user_id}
+    return await _process_request(token, method_url, params=payload)
 
 async def answer_inline_query(token, inline_query_id, results, cache_time=None, is_personal=None, next_offset=None,
                         button=None):

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -278,16 +278,14 @@ async def _check_result(method_name, result: aiohttp.ClientResponse):
 
 async def send_message(
         token, chat_id, text,
-        disable_web_page_preview=None, reply_to_message_id=None, reply_markup=None,
+        disable_web_page_preview=None, reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
-        entities=None, allow_sending_without_reply=None, protect_content=None,
-        message_thread_id=None):
+        entities=None, protect_content=None,
+        message_thread_id=None, reply_parameters=None):
     method_name = 'sendMessage'
     params = {'chat_id': str(chat_id), 'text': text}
     if disable_web_page_preview is not None:
         params['disable_web_page_preview'] = disable_web_page_preview
-    if reply_to_message_id:
-        params['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         params['reply_markup'] = await _convert_markup(reply_markup)
     if parse_mode:
@@ -298,8 +296,8 @@ async def send_message(
         params['timeout'] = timeout
     if entities:
         params['entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(entities))
-    if allow_sending_without_reply is not None:
-        params['allow_sending_without_reply'] = allow_sending_without_reply
+    if reply_parameters is not None:
+        params['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         params['protect_content'] = protect_content
     if message_thread_id:
@@ -406,8 +404,8 @@ async def forward_message(
 
 
 async def copy_message(token, chat_id, from_chat_id, message_id, caption=None, parse_mode=None, caption_entities=None,
-                 disable_notification=None, reply_to_message_id=None, allow_sending_without_reply=None,
-                 reply_markup=None, timeout=None, protect_content=None, message_thread_id=None):
+                 disable_notification=None,  
+                 reply_markup=None, timeout=None, protect_content=None, message_thread_id=None, reply_parameters=None):
     method_url = r'copyMessage'
     payload = {'chat_id': chat_id, 'from_chat_id': from_chat_id, 'message_id': message_id}
     if caption is not None:
@@ -418,12 +416,10 @@ async def copy_message(token, chat_id, from_chat_id, message_id, caption=None, p
         payload['caption_entities'] = await _convert_entites(caption_entities)
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup is not None:
         payload['reply_markup'] = await _convert_markup(reply_markup)
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if timeout:
         payload['timeout'] = timeout
     if protect_content is not None:
@@ -435,36 +431,34 @@ async def copy_message(token, chat_id, from_chat_id, message_id, caption=None, p
 
 async def send_dice(
         token, chat_id,
-        emoji=None, disable_notification=None, reply_to_message_id=None,
-        reply_markup=None, timeout=None, allow_sending_without_reply=None, protect_content=None,
-        message_thread_id=None):
+        emoji=None, disable_notification=None, 
+        reply_markup=None, timeout=None,  protect_content=None,
+        message_thread_id=None,reply_parameters=None):
     method_url = r'sendDice'
     payload = {'chat_id': chat_id}
     if emoji:
         payload['emoji'] = emoji
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if timeout:
         payload['timeout'] = timeout
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return await _process_request(token, method_url, params=payload)
 
 
 async def send_photo(
         token, chat_id, photo,
-        caption=None, reply_to_message_id=None, reply_markup=None,
+        caption=None,  reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
-        caption_entities=None, allow_sending_without_reply=None, protect_content=None,
-        message_thread_id=None, has_spoiler=None):
+        caption_entities=None,  protect_content=None,
+        message_thread_id=None, has_spoiler=None,reply_parameters=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None
@@ -476,8 +470,6 @@ async def send_photo(
         files = {'photo': photo}
     if caption:
         payload['caption'] = caption
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if parse_mode:
@@ -488,8 +480,8 @@ async def send_photo(
         payload['timeout'] = timeout
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
@@ -501,23 +493,21 @@ async def send_photo(
 
 async def send_media_group(
         token, chat_id, media,
-        disable_notification=None, reply_to_message_id=None,
-        timeout=None, allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
+        disable_notification=None, 
+        timeout=None,  protect_content=None, message_thread_id=None,reply_parameters=None):
     method_url = r'sendMediaGroup'
     media_json, files = await convert_input_media_array(media)
     payload = {'chat_id': chat_id, 'media': media_json}
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
     if timeout:
         payload['timeout'] = timeout
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     return await _process_request(
         token, method_url, params=payload,
         method='post' if files else 'get',
@@ -526,10 +516,10 @@ async def send_media_group(
 
 async def send_location(
         token, chat_id, latitude, longitude,
-        live_period=None, reply_to_message_id=None, 
+        live_period=None,  
         reply_markup=None, disable_notification=None, 
         timeout=None, horizontal_accuracy=None, heading=None,
-        proximity_alert_radius=None, allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
+        proximity_alert_radius=None,  protect_content=None, message_thread_id=None,reply_parameters=None):
     method_url = r'sendLocation'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude}
     if live_period:
@@ -540,10 +530,8 @@ async def send_location(
         payload['heading'] = heading
     if proximity_alert_radius:
         payload['proximity_alert_radius'] = proximity_alert_radius
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if disable_notification is not None:
@@ -603,9 +591,9 @@ async def stop_message_live_location(
 async def send_venue(
         token, chat_id, latitude, longitude, title, address,
         foursquare_id=None, foursquare_type=None, disable_notification=None,
-        reply_to_message_id=None, reply_markup=None, timeout=None,
-        allow_sending_without_reply=None, google_place_id=None,
-        google_place_type=None, protect_content=None, message_thread_id=None):
+         reply_markup=None, timeout=None,
+         google_place_id=None,
+        google_place_type=None, protect_content=None, message_thread_id=None,reply_parameters=None):
     method_url = r'sendVenue'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude, 'title': title, 'address': address}
     if foursquare_id:
@@ -614,14 +602,12 @@ async def send_venue(
         payload['foursquare_type'] = foursquare_type
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if timeout:
         payload['timeout'] = timeout
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if google_place_id:
         payload['google_place_id'] = google_place_id
     if google_place_type:
@@ -635,8 +621,8 @@ async def send_venue(
 
 async def send_contact(
         token, chat_id, phone_number, first_name, last_name=None, vcard=None,
-        disable_notification=None, reply_to_message_id=None, reply_markup=None, timeout=None,
-        allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
+        disable_notification=None,  reply_markup=None, timeout=None,
+         protect_content=None, message_thread_id=None,reply_parameters=None):
     method_url = r'sendContact'
     payload = {'chat_id': chat_id, 'phone_number': phone_number, 'first_name': first_name}
     if last_name:
@@ -645,14 +631,12 @@ async def send_contact(
         payload['vcard'] = vcard
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if timeout:
         payload['timeout'] = timeout
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
@@ -670,10 +654,10 @@ async def send_chat_action(token, chat_id, action, timeout=None, message_thread_
     return await _process_request(token, method_url, params=payload)
 
 
-async def send_video(token, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
+async def send_video(token, chat_id, data, duration=None, caption=None,  reply_markup=None,
                      parse_mode=None, supports_streaming=None, disable_notification=None, timeout=None,
-                     thumbnail=None, width=None, height=None, caption_entities=None, allow_sending_without_reply=None,
-                     protect_content=None, message_thread_id=None, has_spoiler=None):
+                     thumbnail=None, width=None, height=None, caption_entities=None, 
+                     protect_content=None, message_thread_id=None, has_spoiler=None,reply_parameters=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -685,8 +669,8 @@ async def send_video(token, chat_id, data, duration=None, caption=None, reply_to
         payload['duration'] = duration
     if caption:
         payload['caption'] = caption
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if parse_mode:
@@ -711,8 +695,6 @@ async def send_video(token, chat_id, data, duration=None, caption=None, reply_to
         payload['height'] = height
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
@@ -723,10 +705,10 @@ async def send_video(token, chat_id, data, duration=None, caption=None, reply_to
 
 
 async def send_animation(
-        token, chat_id, data, duration=None, caption=None, reply_to_message_id=None, reply_markup=None,
+        token, chat_id, data, duration=None, caption=None,  reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None, thumbnail=None, caption_entities=None,
-        allow_sending_without_reply=None, width=None, height=None, protect_content=None, message_thread_id=None,
-        has_spoiler=None):
+         width=None, height=None, protect_content=None, message_thread_id=None,
+        has_spoiler=None,reply_parameters=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}
     files = None
@@ -738,8 +720,8 @@ async def send_animation(
         payload['duration'] = duration
     if caption:
         payload['caption'] = caption
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if parse_mode:
@@ -758,8 +740,6 @@ async def send_animation(
             payload['thumbnail'] = thumbnail
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if width:
         payload['width'] = width
     if height:
@@ -773,9 +753,9 @@ async def send_animation(
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
-async def send_voice(token, chat_id, voice, caption=None, duration=None, reply_to_message_id=None, reply_markup=None,
+async def send_voice(token, chat_id, voice, caption=None, duration=None,  reply_markup=None,
                parse_mode=None, disable_notification=None, timeout=None, caption_entities=None,
-               allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
+                protect_content=None, message_thread_id=None,reply_parameters=None):
     method_url = r'sendVoice'
     payload = {'chat_id': chat_id}
     files = None
@@ -787,8 +767,8 @@ async def send_voice(token, chat_id, voice, caption=None, duration=None, reply_t
         payload['caption'] = caption
     if duration:
         payload['duration'] = duration
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if parse_mode:
@@ -799,8 +779,6 @@ async def send_voice(token, chat_id, voice, caption=None, duration=None, reply_t
         payload['timeout'] = timeout
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
@@ -808,9 +786,9 @@ async def send_voice(token, chat_id, voice, caption=None, duration=None, reply_t
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
-async def send_video_note(token, chat_id, data, duration=None, length=None, reply_to_message_id=None, reply_markup=None,
-                          disable_notification=None, timeout=None, thumbnail=None, allow_sending_without_reply=None, protect_content=None,
-                          message_thread_id=None):
+async def send_video_note(token, chat_id, data, duration=None, length=None,  reply_markup=None,
+                          disable_notification=None, timeout=None, thumbnail=None,  protect_content=None,
+                          message_thread_id=None,reply_parameters=None):
     method_url = r'sendVideoNote'
     payload = {'chat_id': chat_id}
     files = None
@@ -824,8 +802,8 @@ async def send_video_note(token, chat_id, data, duration=None, length=None, repl
         payload['length'] = length
     else:
         payload['length'] = 639  # seems like it is MAX length size
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if disable_notification is not None:
@@ -840,8 +818,6 @@ async def send_video_note(token, chat_id, data, duration=None, length=None, repl
                 files = {'thumbnail': thumbnail}
         else:
             payload['thumbnail'] = thumbnail
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
@@ -849,9 +825,9 @@ async def send_video_note(token, chat_id, data, duration=None, length=None, repl
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
-async def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None, reply_to_message_id=None,
+async def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None, 
                      reply_markup=None, parse_mode=None, disable_notification=None, timeout=None, thumbnail=None,
-                     caption_entities=None, allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
+                     caption_entities=None,  protect_content=None, message_thread_id=None,reply_parameters=None):
     method_url = r'sendAudio'
     payload = {'chat_id': chat_id}
     files = None
@@ -867,8 +843,8 @@ async def send_audio(token, chat_id, audio, caption=None, duration=None, perform
         payload['performer'] = performer
     if title:
         payload['title'] = title
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if parse_mode:
@@ -887,8 +863,6 @@ async def send_audio(token, chat_id, audio, caption=None, duration=None, perform
             payload['thumbnail'] = thumbnail
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
@@ -896,10 +870,10 @@ async def send_audio(token, chat_id, audio, caption=None, duration=None, perform
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
-async def send_data(token, chat_id, data, data_type, reply_to_message_id=None, reply_markup=None, parse_mode=None,
+async def send_data(token, chat_id, data, data_type,  reply_markup=None, parse_mode=None,
                     disable_notification=None, timeout=None, caption=None, thumbnail=None, caption_entities=None,
-                    allow_sending_without_reply=None, disable_content_type_detection=None, visible_file_name=None, protect_content=None,
-                    message_thread_id=None, emoji=None):
+                     disable_content_type_detection=None, visible_file_name=None, protect_content=None,
+                    message_thread_id=None, emoji=None,reply_parameters=None):
     method_url = await get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None
@@ -910,8 +884,8 @@ async def send_data(token, chat_id, data, data_type, reply_to_message_id=None, r
         files = {data_type: file_data}
     else:
         payload[data_type] = data
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if parse_mode and data_type == 'document':
@@ -932,8 +906,6 @@ async def send_data(token, chat_id, data, data_type, reply_to_message_id=None, r
             payload['thumbnail'] = thumbnail
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if method_url == 'sendDocument' and disable_content_type_detection is not None:
@@ -1386,20 +1358,18 @@ async def delete_message(token, chat_id, message_id, timeout=None):
 
 async def send_game(
         token, chat_id, game_short_name,
-        disable_notification=None, reply_to_message_id=None, reply_markup=None, timeout=None,
-        allow_sending_without_reply=None, protect_content=None, message_thread_id=None):
+        disable_notification=None,  reply_markup=None, timeout=None,
+         protect_content=None, message_thread_id=None,reply_parameters=None):
     method_url = r'sendGame'
     payload = {'chat_id': chat_id, 'game_short_name': game_short_name}
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if timeout:
         payload['timeout'] = timeout
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
@@ -1467,9 +1437,9 @@ async def send_invoice(
         start_parameter = None, photo_url=None, photo_size=None, photo_width=None, photo_height=None,
         need_name=None, need_phone_number=None, need_email=None, need_shipping_address=None,
         send_phone_number_to_provider = None, send_email_to_provider = None, is_flexible=None,
-        disable_notification=None, reply_to_message_id=None, reply_markup=None, provider_data=None,
-        timeout=None, allow_sending_without_reply=None, max_tip_amount=None, suggested_tip_amounts=None,
-        protect_content=None, message_thread_id=None):
+        disable_notification=None,  reply_markup=None, provider_data=None,
+        timeout=None,  max_tip_amount=None, suggested_tip_amounts=None,
+        protect_content=None, message_thread_id=None,reply_parameters=None):
     """
     Use this method to send invoices. On success, the sent Message is returned.
     :param token: Bot's token (you don't need to fill this)
@@ -1535,16 +1505,14 @@ async def send_invoice(
         payload['is_flexible'] = is_flexible
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id:
-        payload['reply_to_message_id'] = reply_to_message_id
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if provider_data:
         payload['provider_data'] = provider_data
     if timeout:
         payload['timeout'] = timeout
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
     if max_tip_amount is not None:
         payload['max_tip_amount'] = max_tip_amount
     if suggested_tip_amounts is not None:
@@ -1788,8 +1756,8 @@ async def send_poll(
         question, options,
         is_anonymous = None, type = None, allows_multiple_answers = None, correct_option_id = None,
         explanation = None, explanation_parse_mode=None, open_period = None, close_date = None, is_closed = None,
-        disable_notification=False, reply_to_message_id=None, allow_sending_without_reply=None,
-        reply_markup=None, timeout=None, explanation_entities=None, protect_content=None, message_thread_id=None):
+        disable_notification=False,  
+        reply_markup=None, timeout=None, explanation_entities=None, protect_content=None, message_thread_id=None,reply_parameters=None):
     method_url = r'sendPoll'
     payload = {
         'chat_id': str(chat_id),
@@ -1820,10 +1788,8 @@ async def send_poll(
 
     if disable_notification:
         payload['disable_notification'] = disable_notification
-    if reply_to_message_id is not None:
-        payload['reply_to_message_id'] = reply_to_message_id
-    if allow_sending_without_reply is not None:
-        payload['allow_sending_without_reply'] = allow_sending_without_reply
+    if reply_parameters is not None:
+        payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if reply_markup is not None:
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if timeout:

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -278,14 +278,14 @@ async def _check_result(method_name, result: aiohttp.ClientResponse):
 
 async def send_message(
         token, chat_id, text,
-        disable_web_page_preview=None, reply_markup=None,
+        reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
         entities=None, protect_content=None,
-        message_thread_id=None, reply_parameters=None):
+        message_thread_id=None, reply_parameters=None, link_preview_options=None):
     method_name = 'sendMessage'
     params = {'chat_id': str(chat_id), 'text': text}
-    if disable_web_page_preview is not None:
-        params['disable_web_page_preview'] = disable_web_page_preview
+    if link_preview_options is not None:
+        params['link_preview_options'] = json.dumps(link_preview_options.to_dict())
     if reply_markup:
         params['reply_markup'] = await _convert_markup(reply_markup)
     if parse_mode:
@@ -1278,7 +1278,7 @@ async def unpin_all_chat_messages(token, chat_id):
 # Updating messages
 
 async def edit_message_text(token, text, chat_id=None, message_id=None, inline_message_id=None, parse_mode=None,
-                      entities = None, disable_web_page_preview=None, reply_markup=None):
+                      entities = None, reply_markup=None, link_preview_options=None):
     method_url = r'editMessageText'
     payload = {'text': text}
     if chat_id:
@@ -1291,10 +1291,10 @@ async def edit_message_text(token, text, chat_id=None, message_id=None, inline_m
         payload['parse_mode'] = parse_mode
     if entities:
         payload['entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(entities))
-    if disable_web_page_preview is not None:
-        payload['disable_web_page_preview'] = disable_web_page_preview
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
+    if link_preview_options is not None:
+        payload['link_preview_options'] = link_preview_options.to_json()
     return await _process_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1871,6 +1871,53 @@ async def unhide_general_forum_topic(token, chat_id):
     payload = {'chat_id': chat_id}
     return await _process_request(token, method_url, params=payload)
 
+async def delete_messages(token, chat_id, message_ids):
+    method_url = 'deleteMessages'
+    payload = {
+        'chat_id': chat_id,
+        'message_ids': message_ids
+    }
+    return await _process_request(token, method_url, params=payload)
+
+async def forward_messages(token, chat_id, from_chat_id, message_ids, disable_notification=None,
+                            message_thread_id=None, protect_content=None):
+    method_url = 'forwardMessages'
+    payload = {
+        'chat_id': chat_id,
+        'from_chat_id': from_chat_id,
+        'message_ids': message_ids,
+    }
+    if disable_notification is not None:
+        payload['disable_notification'] = disable_notification
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
+    if protect_content is not None:
+        payload['protect_content'] = protect_content
+    
+    result = await _process_request(token, method_url, params=payload)
+    return result
+
+async def copy_messages(token, chat_id, from_chat_id, message_ids, disable_notification=None,
+                        message_thread_id=None, protect_content=None, remove_caption=None):
+    method_url = 'copyMessages'
+    payload = {
+        'chat_id': chat_id,
+        'from_chat_id': from_chat_id,
+        'message_ids': message_ids,
+    }
+    if disable_notification is not None:
+        payload['disable_notification'] = disable_notification
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
+    if protect_content is not None:
+        payload['protect_content'] = protect_content
+    if remove_caption is not None:
+        payload['remove_caption'] = remove_caption
+    
+    result = await _process_request(token, method_url, params=payload)
+    return result
+
+
 async def _convert_list_json_serializable(results):
     ret = ''
     for r in results:
@@ -1999,3 +2046,5 @@ class RequestTimeout(Exception):
     This class represents a request timeout.
     """
     pass
+
+

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -318,6 +318,15 @@ async def get_user_profile_photos(token, user_id, offset=None, limit=None):
         payload['limit'] = limit
     return await _process_request(token, method_url, params=payload)
 
+async def set_message_reaction(token, chat_id, message_id, reaction=None, is_big=None):
+    method_url = r'setMessageReaction'
+    payload = {'chat_id': chat_id, 'message_id': message_id}
+    if reaction:
+        payload['reaction'] = reaction
+    if is_big is not None:
+        payload['is_big'] = is_big
+    return await _process_request(token, method_url, params=payload)
+
 
 async def get_chat(token, chat_id):
     method_url = r'getChat'

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -320,7 +320,7 @@ async def set_message_reaction(token, chat_id, message_id, reaction=None, is_big
     method_url = r'setMessageReaction'
     payload = {'chat_id': chat_id, 'message_id': message_id}
     if reaction:
-        payload['reaction'] = reaction
+        payload['reaction'] = json.dumps([r.to_dict() for r in reaction])
     if is_big is not None:
         payload['is_big'] = is_big
     return await _process_request(token, method_url, params=payload)

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -954,8 +954,8 @@ class Message(JsonDeserializable):
         the payment. More about payments »
     :type successful_payment: :class:`telebot.types.SuccessfulPayment`
 
-    :param user_shared: Optional. Service message: a user was shared with the bot
-    :type user_shared: :class:`telebot.types.UserShared`
+    :param users_shared: Optional. Service message: a user was shared with the bot
+    :type users_shared: :class:`telebot.types.UserShared`
 
     :param chat_shared: Optional. Service message: a chat was shared with the bot
     :type chat_shared: :class:`telebot.types.ChatShared`
@@ -1209,9 +1209,9 @@ class Message(JsonDeserializable):
         if 'write_access_allowed' in obj:
             opts['write_access_allowed'] = WriteAccessAllowed.de_json(obj['write_access_allowed'])
             content_type = 'write_access_allowed'
-        if 'user_shared' in obj:
-            opts['user_shared'] = UserShared.de_json(obj['user_shared'])
-            content_type = 'user_shared'
+        if 'users_shared' in obj:
+            opts['users_shared'] = UserShared.de_json(obj['users_shared'])
+            content_type = 'users_shared' # COMPATIBILITY BROKEN!
         if 'chat_shared' in obj:
             opts['chat_shared'] = ChatShared.de_json(obj['chat_shared'])
             content_type = 'chat_shared'
@@ -1324,7 +1324,8 @@ class Message(JsonDeserializable):
         self.general_forum_topic_hidden: Optional[GeneralForumTopicHidden] = None
         self.general_forum_topic_unhidden: Optional[GeneralForumTopicUnhidden] = None
         self.write_access_allowed: Optional[WriteAccessAllowed] = None
-        self.user_shared: Optional[UserShared] = None
+        self.users_shared: Optional[UserShared] = None
+        self.user_shared: Optional[UserShared] = self.users_shared
         self.chat_shared: Optional[ChatShared] = None
         self.story: Optional[Story] = None
         self.external_reply: Optional[ExternalReplyInfo] = None
@@ -8742,3 +8743,35 @@ class ReplyParameters(JsonDeserializable, Dictionaryable, JsonSerializable):
     def to_json(self) -> str:
         return json.dumps(self.to_dict())
     
+class UsersShared(JsonDeserializable):
+    """
+    This object contains information about the users whose identifiers were shared with the bot
+    using a KeyboardButtonRequestUsers button.
+
+    Telegram documentation: https://core.telegram.org/bots/api#usersshared
+
+    :param request_id: Identifier of the request
+    :type request_id: :obj:`int`
+
+    :param user_ids: Identifiers of the shared users. These numbers may have more than 32 significant bits
+                     and some programming languages may have difficulty/silent defects in interpreting them.
+                     But they have at most 52 significant bits, so 64-bit integers or double-precision float
+                     types are safe for storing these identifiers. The bot may not have access to the users and
+                     could be unable to use these identifiers unless the users are already known to the bot by
+                     some other means.
+    :type user_ids: :obj:`list` of :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`UsersShared`
+    """
+
+    def __init__(self, request_id, user_ids):
+        self.request_id = request_id
+        self.user_ids = user_ids
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -551,6 +551,10 @@ class Chat(JsonDeserializable):
         Returned only in getChat.
     :type active_usernames: :obj:`list` of :obj:`str`
 
+    :param available_reactions: Optional. List of available chat reactions; for private chats, supergroups and channels.
+        Returned only in getChat.
+    :type available_reactions: :obj:`list` of :class:`telebot.types.ReactionType`
+
     :param emoji_status_custom_emoji_id: Optional. Custom emoji identifier of emoji status of the other party in a private chat.
         Returned only in getChat.
     :type emoji_status_custom_emoji_id: :obj:`str`
@@ -644,6 +648,8 @@ class Chat(JsonDeserializable):
             obj['permissions'] = ChatPermissions.de_json(obj['permissions'])
         if 'location' in obj:
             obj['location'] = ChatLocation.de_json(obj['location'])
+        if 'available_reactions' in obj:
+            obj['available_reactions'] = [ReactionType(reaction) for reaction in obj['available_reactions']]
         return cls(**obj)
 
     def __init__(self, id, type, title=None, username=None, first_name=None,
@@ -654,7 +660,8 @@ class Chat(JsonDeserializable):
                  can_set_sticker_set=None, linked_chat_id=None, location=None, 
                  join_to_send_messages=None, join_by_request=None, has_restricted_voice_and_video_messages=None, 
                  is_forum=None, active_usernames=None, emoji_status_custom_emoji_id=None,
-                 has_hidden_members=None, has_aggressive_anti_spam_enabled=None, emoji_status_expiration_date=None, **kwargs):
+                 has_hidden_members=None, has_aggressive_anti_spam_enabled=None, emoji_status_expiration_date=None, 
+                 available_reactions=None,**kwargs):
         self.id: int = id
         self.type: str = type
         self.title: str = title
@@ -684,6 +691,7 @@ class Chat(JsonDeserializable):
         self.has_hidden_members: bool = has_hidden_members
         self.has_aggressive_anti_spam_enabled: bool = has_aggressive_anti_spam_enabled
         self.emoji_status_expiration_date: int = emoji_status_expiration_date
+        self.available_reactions: List[ReactionType] = available_reactions
 
 
 class MessageID(JsonDeserializable):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -7835,3 +7835,90 @@ class Story(JsonDeserializable):
     def __init__(self) -> None:
         pass
 
+# base class
+class ReactionType(JsonDeserializable, Dictionaryable, JsonSerializable):
+    """
+    This object represents a reaction type.
+
+    Telegram documentation: https://core.telegram.org/bots/api#reactiontype
+
+    :param type: Type of the reaction
+    :type type: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`ReactionType`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+
+    def __init__(self, type: str) -> None:
+        self.type: str = type
+
+    def to_dict(self) -> dict:
+        json_dict = {
+            'type': self.type
+        }
+
+        return json_dict
+    
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+    
+
+class ReactionTypeEmoji(ReactionType):
+    """
+    This object represents an emoji reaction type.
+
+    Telegram documentation: https://core.telegram.org/bots/api#reactiontypeemoji
+
+    :param type: Type of the reaction, must be emoji
+    :type type: :obj:`str`
+
+    :param emoji: Reaction emoji. List is available on the API doc.
+    :type emoji: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`ReactionTypeEmoji`
+    """
+
+    def __init__(self, emoji: str) -> None:
+        super().__init__('emoji')
+        self.emoji: str = emoji
+
+    def to_dict(self) -> dict:
+        json_dict = super().to_dict()
+        json_dict['emoji'] = self.emoji
+
+        return json_dict
+    
+
+class ReactionTypeCustomEmoji(ReactionType):
+    """
+    This object represents a custom emoji reaction type.
+
+    Telegram documentation: https://core.telegram.org/bots/api#reactiontypecustomemoji
+
+    :param type: Type of the reaction, must be custom_emoji
+    :type type: :obj:`str`
+
+    :param custom_emoji: Identifier of the custom emoji
+    :type custom_emoji: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`ReactionTypeCustomEmoji`
+    """
+
+    def __init__(self, custom_emoji: str) -> None:
+        super().__init__('custom_emoji')
+        self.custom_emoji: str = custom_emoji
+
+    def to_dict(self) -> dict:
+        json_dict = super().to_dict()
+        json_dict['custom_emoji'] = self.custom_emoji
+
+        return json_dict

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -7986,7 +7986,13 @@ class ReactionType(JsonDeserializable, Dictionaryable, JsonSerializable):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
-        return cls(**obj)
+        # remove type 
+        if obj['type'] == 'emoji':
+            del obj['type']
+            return ReactionTypeEmoji(**obj)
+        elif obj['type'] == 'custom_emoji':
+            del obj['type']
+            return ReactionTypeCustomEmoji(**obj)
 
     def __init__(self, type: str) -> None:
         self.type: str = type
@@ -8028,6 +8034,8 @@ class ReactionTypeEmoji(ReactionType):
 
         return json_dict
     
+    
+    
 
 class ReactionTypeCustomEmoji(ReactionType):
     """
@@ -8054,6 +8062,8 @@ class ReactionTypeCustomEmoji(ReactionType):
         json_dict['custom_emoji'] = self.custom_emoji
 
         return json_dict
+    
+    
     
 
 class MessageReactionUpdated(JsonDeserializable):
@@ -8092,6 +8102,16 @@ class MessageReactionUpdated(JsonDeserializable):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
+
+        if 'user' in obj:
+            obj['user'] = User.de_json(obj['user'])
+        if 'actor_chat' in obj:
+            obj['actor_chat'] = Chat.de_json(obj['actor_chat'])
+        obj['old_reaction'] = [ReactionType.de_json(reaction) for reaction in obj['old_reaction']]
+        obj['new_reaction'] = [ReactionType.de_json(reaction) for reaction in obj['new_reaction']]
+        if 'chat' in obj:
+            obj['chat'] = Chat.de_json(obj['chat'])
+
         return cls(**obj)
 
     def __init__(self, chat: Chat, message_id: int, date: int, old_reaction: List[ReactionType], new_reaction: List[ReactionType],

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -9028,3 +9028,29 @@ class ChatBoost(JsonDeserializable):
 
         return cls(**obj)
 
+class UserChatBoosts(JsonDeserializable):
+    """
+    This object represents a list of boosts added to a chat by a user.
+
+    Telegram documentation: https://core.telegram.org/bots/api#userchatboosts
+
+    :param boosts: The list of boosts added to the chat by the user
+    :type boosts: :obj:`list` of :class:`ChatBoost`
+
+    :return: Instance of the class
+    :rtype: :class:`UserChatBoosts`
+    """
+
+    def __init__(self, boosts):
+        self.boosts: ChatBoost = boosts
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        
+        obj = cls.check_json(json_string)
+        obj['boosts'] = [ChatBoost.de_json(boost) for boost in obj.get('boosts', [])]
+
+        return cls(**obj)
+    

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -833,6 +833,9 @@ class Message(JsonDeserializable):
     :param forward_date: Optional. For forwarded messages, date the original message was sent in Unix time
     :type forward_date: :obj:`int`
 
+    :forward_origin: Optional. For forwarded messages, information about the original message; 
+    :type forward_origin: :class:`telebot.types.MessageOrigin`
+
     :param is_topic_message: Optional. True, if the message is sent to a forum topic
     :type is_topic_message: :obj:`bool`
 
@@ -1289,8 +1292,8 @@ class Message(JsonDeserializable):
         if 'giveaway_completed' in obj:
             opts['giveaway_completed'] = GiveawayCompleted.de_json(obj['giveaway_completed'])
             content_type = 'giveaway_completed'
-
-
+        if 'message_origin' in obj:
+            opts['message_origin'] = MessageOrigin.de_json(obj['message_origin'])
 
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
@@ -1398,6 +1401,7 @@ class Message(JsonDeserializable):
         self.giveaway: Optional[Giveaway] = None
         self.giveaway_winners: Optional[GiveawayWinners] = None
         self.giveaway_completed: Optional[GiveawayCompleted] = None
+        self.forward_origin: Optional[MessageOrigin] = None
 
         
         for key in options:

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -131,6 +131,10 @@ class Update(JsonDeserializable):
         and must explicitly specify "message_reaction" in the list of allowed_updates to receive these updates. The update isn't received for reactions set by bots.
     :type message_reaction: :class:`telebot.types.MessageReactionUpdated`
 
+    :param message_reaction_count: Optional. Reactions to a message with anonymous reactions were changed. The bot must be an administrator in the chat and must explicitly specify
+        "message_reaction_count" in the list of allowed_updates to receive these updates.
+    :type message_reaction_count: :class:`telebot.types.MessageReactionCountUpdated`
+
     :param inline_query: Optional. New incoming inline query
     :type inline_query: :class:`telebot.types.InlineQuery`
 
@@ -193,13 +197,14 @@ class Update(JsonDeserializable):
         chat_member = ChatMemberUpdated.de_json(obj.get('chat_member'))
         chat_join_request = ChatJoinRequest.de_json(obj.get('chat_join_request'))
         message_reaction = MessageReactionUpdated.de_json(obj.get('message_reaction'))
+        message_reaction_count = MessageReactionCountUpdated.de_json(obj.get('message_reaction_count'))
         return cls(update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                    chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                   my_chat_member, chat_member, chat_join_request, message_reaction)
+                   my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count)
 
     def __init__(self, update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                  chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                 my_chat_member, chat_member, chat_join_request, message_reaction):
+                 my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count):
         self.update_id = update_id
         self.message = message
         self.edited_message = edited_message
@@ -216,6 +221,7 @@ class Update(JsonDeserializable):
         self.chat_member = chat_member
         self.chat_join_request = chat_join_request
         self.message_reaction = message_reaction
+        self.message_reaction_count = message_reaction_count
 
 
 class ChatMemberUpdated(JsonDeserializable):
@@ -7977,3 +7983,69 @@ class MessageReactionUpdated(JsonDeserializable):
         self.date: int = date
         self.old_reaction: List[ReactionType] = old_reaction
         self.new_reaction: List[ReactionType] = new_reaction
+
+
+
+class MessageReactionCountUpdated(JsonDeserializable):
+    """
+    This object represents a service message about a change in the list of the current user's reactions to a message.
+
+    Telegram documentation: https://core.telegram.org/bots/api#messagereactioncountupdated
+
+    :param chat: The chat containing the message
+    :type chat: :class:`telebot.types.Chat`
+
+    :param message_id: Unique message identifier inside the chat
+    :type message_id: :obj:`int`
+
+    :param date: Date of the change in Unix time
+    :type date: :obj:`int`
+
+    :param reactions: List of reactions that are present on the message
+    :type reactions: :obj:`list` of :class:`ReactionCount`
+
+    :return: Instance of the class
+    :rtype: :class:`MessageReactionCountUpdated`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+
+    def __init__(self, chat: Chat, message_id: int, date: int, reactions: List[ReactionCount]) -> None:
+        self.chat: Chat = chat
+        self.message_id: int = message_id
+        self.date: int = date
+        self.reactions: List[ReactionCount] = reactions
+        
+
+class ReactionCount(JsonDeserializable):
+    """
+    This object represents a reaction added to a message along with the number of times it was added.
+
+    Telegram documentation: https://core.telegram.org/bots/api#reactioncount
+
+    :param type: Type of the reaction
+    :type type: :class:`ReactionType`
+
+    :param total_count: Number of times the reaction was added
+    :type total_count: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`ReactionCount`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+    
+    def __init__(self, type: ReactionType, total_count: int) -> None:
+        self.type: ReactionType = type
+        self.total_count: int = total_count
+

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1003,6 +1003,18 @@ class Message(JsonDeserializable):
     :param general_forum_topic_unhidden: Optional. Service message: the 'General' forum topic unhidden
     :type general_forum_topic_unhidden: :class:`telebot.types.GeneralForumTopicUnhidden`
 
+    :param giveaway_created: Optional. Service message: a giveaway has been created
+    :type giveaway_created: :class:`telebot.types.GiveawayCreated`
+
+    :param giveaway: Optional. The message is a scheduled giveaway message
+    :type giveaway: :class:`telebot.types.Giveaway`
+
+    :param giveaway_winners: Optional. Service message: giveaway winners(public winners)
+    :type giveaway_winners: :class:`telebot.types.GiveawayWinners`
+
+    :param giveaway_completed: Optional. Service message: giveaway completed, without public winners
+    :type giveaway_completed: :class:`telebot.types.GiveawayCompleted`
+
     :param video_chat_scheduled: Optional. Service message: video chat scheduled
     :type video_chat_scheduled: :class:`telebot.types.VideoChatScheduled`
 
@@ -1238,6 +1250,20 @@ class Message(JsonDeserializable):
         if 'link_preview_options' in obj:
             opts['link_preview_options'] = LinkPreviewOptions.de_json(obj['link_preview_options'])
 
+        if 'giveaway_created' in obj:
+            opts['giveaway_created'] = GiveawayCreated.de_json(obj['giveaway_created'])
+            content_type = 'giveaway_created'
+        if 'giveaway' in obj:
+            opts['giveaway'] = Giveaway.de_json(obj['giveaway'])
+            content_type = 'giveaway'
+        if 'giveaway_winners' in obj:
+            opts['giveaway_winners'] = GiveawayWinners.de_json(obj['giveaway_winners'])
+            content_type = 'giveaway_winners'
+        if 'giveaway_completed' in obj:
+            opts['giveaway_completed'] = GiveawayCompleted.de_json(obj['giveaway_completed'])
+            content_type = 'giveaway_completed'
+
+
 
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
@@ -1341,6 +1367,11 @@ class Message(JsonDeserializable):
         self.external_reply: Optional[ExternalReplyInfo] = None
         self.quote: Optional[TextQuote] = None
         self.LinkPreviewOptions: Optional[LinkPreviewOptions] = None
+        self.giveaway_created: Optional[GiveawayCreated] = None
+        self.giveaway: Optional[Giveaway] = None
+        self.giveaway_winners: Optional[GiveawayWinners] = None
+        self.giveaway_completed: Optional[GiveawayCompleted] = None
+
         
         for key in options:
             setattr(self, key, options[key])
@@ -8634,7 +8665,45 @@ class GiveawayWinners(JsonDeserializable):
         self.was_refunded: Optional[bool] = was_refunded
         self.prize_description: Optional[str] = prize_description
         
+class GiveawayCompleted(JsonDeserializable):
+    """
+    This object represents a service message about the completion of a giveaway without public winners.
 
+    Telegram documentation: https://core.telegram.org/bots/api#giveawaycompleted
+
+    :param winner_count: Number of winners in the giveaway
+    :type winner_count: :obj:`int`
+
+    :param unclaimed_prize_count: Optional. Number of undistributed prizes
+    :type unclaimed_prize_count: :obj:`int`
+
+    :param giveaway_message: Optional. Message with the giveaway that was completed, if it wasn't deleted
+    :type giveaway_message: :class:`Message`
+
+    :return: Instance of the class
+    :rtype: :class:`GiveawayCompleted`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+
+        obj['giveaway_message'] = Message.de_json(obj.get('giveaway_message'))
+
+        return cls(**obj)
+    
+    def __init__(self, winner_count: int, unclaimed_prize_count: Optional[int] = None,
+                    giveaway_message: Optional[Message] = None) -> None:
+        self.winner_count: int = winner_count
+        self.unclaimed_prize_count: Optional[int] = unclaimed_prize_count
+        self.giveaway_message: Optional[Message] = giveaway_message
+
+class GiveawayCreated(JsonDeserializable):
+    """
+    This object represents a service message about the creation of a scheduled giveaway. Currently holds no information.
+    """
         
 class TextQuote(JsonDeserializable):
     """

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -8622,3 +8622,83 @@ class TextQuote(JsonDeserializable):
         self.entities: Optional[List[MessageEntity]] = entities
         self.position: Optional[int] = position
         self.is_manual: Optional[bool] = is_manual
+
+class ReplyParameters(JsonDeserializable, Dictionaryable, JsonSerializable):
+    """
+    Describes reply parameters for the message that is being sent.
+
+    Telegram documentation: https://core.telegram.org/bots/api#replyparameters
+
+    :param message_id: Identifier of the message that will be replied to in the current chat, or in the chat chat_id if it is specified
+    :type message_id: :obj:`int`
+
+    :param chat_id: Optional. If the message to be replied to is from a different chat, unique identifier for the chat or username of the channel (in the format @channelusername)
+    :type chat_id: :obj:`int` or :obj:`str`
+
+    :param allow_sending_without_reply: Optional. Pass True if the message should be sent even if the specified message to be replied to is not found; can be used only for replies in the same chat and forum topic.
+    :type allow_sending_without_reply: :obj:`bool`
+
+    :param quote: Optional. Quoted part of the message to be replied to; 0-1024 characters after entities parsing. The quote must be an exact substring of the message to be replied to, including bold, italic, underline, strikethrough, spoiler, and custom_emoji entities. The message will fail to send if the quote isn't found in the original message.
+    :type quote: :obj:`str`
+
+    :param quote_parse_mode: Optional. Mode for parsing entities in the quote. See formatting options for more details.
+    :type quote_parse_mode: :obj:`str`
+
+    :param quote_entities: Optional. A JSON-serialized list of special entities that appear in the quote. It can be specified instead of quote_parse_mode.
+    :type quote_entities: :obj:`list` of :class:`MessageEntity`
+
+    :param quote_position: Optional. Position of the quote in the original message in UTF-16 code units
+    :type quote_position: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`ReplyParameters`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+
+        obj['quote_entities'] = [MessageEntity.de_json(entity) for entity in obj.get('quote_entities', [])]
+
+        return cls(**obj)
+    
+
+    def __init__(self, message_id: int, chat_id: Optional[Union[int, str]] = None,
+                 allow_sending_without_reply: Optional[bool] = None, quote: Optional[str] = None,
+                 quote_parse_mode: Optional[str] = None, quote_entities: Optional[List[MessageEntity]] = None,
+                 quote_position: Optional[int] = None) -> None:
+        self.message_id: int = message_id
+        self.chat_id: Optional[Union[int, str]] = chat_id
+        self.allow_sending_without_reply: Optional[bool] = allow_sending_without_reply
+        self.quote: Optional[str] = quote
+        self.quote_parse_mode: Optional[str] = quote_parse_mode
+        self.quote_entities: Optional[List[MessageEntity]] = quote_entities
+        self.quote_position: Optional[int] = quote_position
+
+
+    def to_dict(self) -> dict:
+        json_dict = {
+            'message_id': self.message_id
+        }
+
+        if self.chat_id is not None:
+            json_dict['chat_id'] = self.chat_id
+        if self.allow_sending_without_reply is not None:
+            json_dict['allow_sending_without_reply'] = self.allow_sending_without_reply
+        if self.quote is not None:
+            json_dict['quote'] = self.quote
+        if self.quote_parse_mode is not None:
+            json_dict['quote_parse_mode'] = self.quote_parse_mode
+        if self.quote_entities is not None:
+            json_dict['quote_entities'] = [entity.to_dict() for entity in self.quote_entities]
+        if self.quote_position is not None:
+            json_dict['quote_position'] = self.quote_position
+
+        return json_dict
+    
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+    
+    

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -2337,13 +2337,12 @@ class KeyboardButtonPollType(Dictionaryable):
         return {'type': self.type}
     
  
-
-class KeyboardButtonRequestUser(Dictionaryable):
+class KeyboardButtonRequestUsers(Dictionaryable):
     """
     This object defines the criteria used to request a suitable user.
     The identifier of the selected user will be shared with the bot when the corresponding button is pressed.
 
-    Telegram documentation: https://core.telegram.org/bots/api#keyboardbuttonrequestuser
+    Telegram documentation: https://core.telegram.org/bots/api#keyboardbuttonrequestusers
 
     :param request_id: Signed 32-bit identifier of the request, which will be received back in the UserShared object.
         Must be unique within the message
@@ -2357,15 +2356,19 @@ class KeyboardButtonRequestUser(Dictionaryable):
         If not specified, no additional restrictions are applied.
     :type user_is_premium: :obj:`bool`
 
+    :param max_quantity: Optional. The maximum number of users to be selected; 1-10. Defaults to 1.
+    :type max_quantity: :obj:`int`
+
     :return: Instance of the class
-    :rtype: :class:`telebot.types.KeyboardButtonRequestUser`
+    :rtype: :class:`telebot.types.KeyboardButtonRequestUsers`
 
     """
 
-    def __init__(self, request_id: int, user_is_bot: Optional[bool]=None, user_is_premium: Optional[bool]=None) -> None:
+    def __init__(self, request_id: int, user_is_bot: Optional[bool]=None, user_is_premium: Optional[bool]=None, max_quantity: Optional[int]=None) -> None:
         self.request_id: int = request_id
         self.user_is_bot: Optional[bool] = user_is_bot
         self.user_is_premium: Optional[bool] = user_is_premium
+        self.max_quantity: Optional[int] = max_quantity
 
     def to_dict(self) -> dict:
         data = {'request_id': self.request_id}
@@ -2373,8 +2376,11 @@ class KeyboardButtonRequestUser(Dictionaryable):
             data['user_is_bot'] = self.user_is_bot
         if self.user_is_premium is not None:
             data['user_is_premium'] = self.user_is_premium
+        if self.max_quantity is not None:
+            data['max_quantity'] = self.max_quantity
         return data
 
+KeyboardButtonRequestUser = KeyboardButtonRequestUsers
 
 class KeyboardButtonRequestChat(Dictionaryable):
     """
@@ -2476,7 +2482,7 @@ class KeyboardButton(Dictionaryable, JsonSerializable):
 
     :param request_user: Optional. If specified, pressing the button will open a list of suitable users. Tapping on any user
         will send their identifier to the bot in a “user_shared” service message. Available in private chats only.
-    :type request_user: :class:`telebot.types.KeyboardButtonRequestUser`
+    :type request_user: :class:`telebot.types.KeyboardButtonRequestUsers`
 
     :param request_chat: Optional. If specified, pressing the button will open a list of suitable chats. Tapping on a chat will
         send its identifier to the bot in a “chat_shared” service message. Available in private chats only.
@@ -2487,15 +2493,18 @@ class KeyboardButton(Dictionaryable, JsonSerializable):
     """
     def __init__(self, text: str, request_contact: Optional[bool]=None, 
             request_location: Optional[bool]=None, request_poll: Optional[KeyboardButtonPollType]=None,
-            web_app: Optional[WebAppInfo]=None, request_user: Optional[KeyboardButtonRequestUser]=None,
-            request_chat: Optional[KeyboardButtonRequestChat]=None):
+            web_app: Optional[WebAppInfo]=None, request_user: Optional[KeyboardButtonRequestUsers]=None,
+            request_chat: Optional[KeyboardButtonRequestChat]=None, request_users: Optional[KeyboardButtonRequestUsers]=None):
         self.text: str = text
         self.request_contact: bool = request_contact
         self.request_location: bool = request_location
         self.request_poll: KeyboardButtonPollType = request_poll
         self.web_app: WebAppInfo = web_app
-        self.request_user: KeyboardButtonRequestUser = request_user
+        self.request_user: KeyboardButtonRequestUsers = request_user
         self.request_chat: KeyboardButtonRequestChat = request_chat
+        self.request_users: KeyboardButtonRequestUsers = request_users
+        if request_user is not None:
+            self.request_users = request_user
 
 
     def to_json(self):
@@ -7565,7 +7574,7 @@ class WriteAccessAllowed(JsonDeserializable):
 class UserShared(JsonDeserializable):
     """
     This object contains information about the user whose identifier was shared with the bot using a
-    `telebot.types.KeyboardButtonRequestUser` button.
+    `telebot.types.KeyboardButtonRequestUsers` button.
 
     Telegram documentation: https://core.telegram.org/bots/api#usershared
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -807,6 +807,12 @@ class Message(JsonDeserializable):
         will not contain further reply_to_message fields even if it itself is a reply.
     :type reply_to_message: :class:`telebot.types.Message`
 
+    :param external_reply: Optional. Information about the message that is being replied to, which may come from another chat or forum topic
+    :type external_reply: :class:`telebot.types.ExternalReplyInfo`
+
+    :param quote: Optional. For replies that quote part of the original message, the quoted part of the message
+    :type quote: :class:`telebot.types.TextQuote`
+
     :param via_bot: Optional. Bot through which the message was sent
     :type via_bot: :class:`telebot.types.User`
 
@@ -1208,6 +1214,13 @@ class Message(JsonDeserializable):
         if 'story' in obj:
             opts['story'] = Story.de_json(obj['story'])
             content_type = 'story'
+        if 'external_reply' in obj:
+            opts['external_reply'] = ExternalReplyInfo.de_json(obj['external_reply'])
+            content_type = 'text' # @Badiboy not sure about content_types in here, please check
+        if 'quote' in obj:
+            opts['quote'] = TextQuote.de_json(obj['quote'])
+            content_type = 'text' # Here too, check the content types   
+
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
     @classmethod
@@ -1306,6 +1319,9 @@ class Message(JsonDeserializable):
         self.user_shared: Optional[UserShared] = None
         self.chat_shared: Optional[ChatShared] = None
         self.story: Optional[Story] = None
+        self.external_reply: Optional[ExternalReplyInfo] = None
+        self.quote: Optional[TextQuote] = None
+        
         for key in options:
             setattr(self, key, options[key])
         self.json = json_string
@@ -8568,3 +8584,41 @@ class GiveawayWinners(JsonDeserializable):
         
 
         
+class TextQuote(JsonDeserializable):
+    """
+    This object contains information about the quoted part of a message that is replied to by the given message.
+
+    Telegram documentation: https://core.telegram.org/bots/api#textquote
+
+    :param text: Text of the quoted part of a message that is replied to by the given message
+    :type text: :obj:`str`
+
+    :param entities: Optional. Special entities that appear in the quote. Currently, only bold, italic, underline, strikethrough, spoiler, and custom_emoji entities are kept in quotes.
+    :type entities: :obj:`list` of :class:`MessageEntity`
+
+    :param position: Approximate quote position in the original message in UTF-16 code units as specified by the sender
+    :type position: :obj:`int`
+
+    :param is_manual: Optional. True, if the quote was chosen manually by the message sender. Otherwise, the quote was added automatically by the server.
+    :type is_manual: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`TextQuote`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+
+        obj['entities'] = [MessageEntity.de_json(entity) for entity in obj.get('entities', [])]
+
+        return cls(**obj)
+
+    def __init__(self, text: str, entities: Optional[List[MessageEntity]] = None,
+                 position: Optional[int] = None, is_manual: Optional[bool] = None) -> None:
+        self.text: str = text
+        self.entities: Optional[List[MessageEntity]] = entities
+        self.position: Optional[int] = position
+        self.is_manual: Optional[bool] = is_manual

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -173,6 +173,12 @@ class Update(JsonDeserializable):
         can_invite_users administrator right in the chat to receive these updates.
     :type chat_join_request: :class:`telebot.types.ChatJoinRequest`
 
+    :param chat_boost: Optional. A chat boost was added or changed. The bot must be an administrator in the chat to receive these updates.
+    :type chat_boost: :class:`telebot.types.ChatBoost`
+
+    :param removed_chat_boost: Optional. A chat boost was removed. The bot must be an administrator in the chat to receive these updates.
+    :type removed_chat_boost: :class:`telebot.types.RemovedChatBoost`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.Update`
 
@@ -198,13 +204,15 @@ class Update(JsonDeserializable):
         chat_join_request = ChatJoinRequest.de_json(obj.get('chat_join_request'))
         message_reaction = MessageReactionUpdated.de_json(obj.get('message_reaction'))
         message_reaction_count = MessageReactionCountUpdated.de_json(obj.get('message_reaction_count'))
+        removed_chat_boost = ChatBoostRemoved.de_json(obj.get('removed_chat_boost'))
+        chat_boost = ChatBoost.de_json(obj.get('chat_boost'))
         return cls(update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                    chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                   my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count)
+                   my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, removed_chat_boost, chat_boost)
 
     def __init__(self, update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                  chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                 my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count):
+                 my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, removed_chat_boost, chat_boost):
         self.update_id = update_id
         self.message = message
         self.edited_message = edited_message
@@ -222,6 +230,8 @@ class Update(JsonDeserializable):
         self.chat_join_request = chat_join_request
         self.message_reaction = message_reaction
         self.message_reaction_count = message_reaction_count
+        self.removed_chat_boost = removed_chat_boost
+        self.chat_boost = chat_boost
 
 
 class ChatMemberUpdated(JsonDeserializable):
@@ -8775,3 +8785,246 @@ class UsersShared(JsonDeserializable):
             return None
         obj = cls.check_json(json_string)
         return cls(**obj)
+    
+
+class ChatBoostUpdated(JsonDeserializable):
+    """
+    This object represents a boost added to a chat or changed.
+
+    Telegram documentation: https://core.telegram.org/bots/api#chatboostupdated
+
+    :param chat: Chat which was boosted
+    :type chat: :class:`Chat`
+
+    :param boost: Infomation about the chat boost
+    :type boost: :class:`ChatBoost`
+
+    :return: Instance of the class
+    :rtype: :class:`ChatBoostUpdated`
+    """
+
+    def __init__(self, chat, boost):
+        self.chat = chat
+        self.boost = boost
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+        
+        obj['chat'] = Chat.de_json(obj.get('chat'))
+        obj['boost'] = ChatBoost.de_json(obj.get('boost'))
+
+        return cls(**obj)
+    
+# ChatBoostRemoved
+# This object represents a boost removed from a chat.
+
+# Field	Type	Description
+# chat	Chat	Chat which was boosted
+# boost_id	String	Unique identifier of the boost
+# remove_date	Integer	Point in time (Unix timestamp) when the boost was removed
+# source	ChatBoostSource	Source of the removed boost
+    
+class ChatBoostRemoved(JsonDeserializable):
+    """
+    This object represents a boost removed from a chat.
+
+    Telegram documentation: https://core.telegram.org/bots/api#chatboostremoved
+
+    :param chat: Chat which was boosted
+    :type chat: :class:`Chat`
+
+    :param boost_id: Unique identifier of the boost
+    :type boost_id: :obj:`str`
+
+    :param remove_date: Point in time (Unix timestamp) when the boost was removed
+    :type remove_date: :obj:`int`
+
+    :param source: Source of the removed boost
+    :type source: :class:`ChatBoostSource`
+
+    :return: Instance of the class
+    :rtype: :class:`ChatBoostRemoved`
+    """
+
+    def __init__(self, chat, boost_id, remove_date, source):
+        self.chat = chat
+        self.boost_id = boost_id
+        self.remove_date = remove_date
+        self.source = source
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+
+        obj['chat'] = Chat.de_json(obj.get('chat'))
+        obj['source'] = ChatBoostSource.de_json(obj.get('source'))
+        
+        return cls(**obj)
+    
+class ChatBoostSource(JsonDeserializable):
+    """
+    This object describes the source of a chat boost.
+
+    Telegram documentation: https://core.telegram.org/bots/api#chatboostsource
+
+    :param source: Source of the boost
+    :type source: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`ChatBoostSource`
+    """
+
+    def __init__(self, source):
+        self.source = source
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        return cls(**cls.check_json(json_string))
+    
+
+class ChatBoostSourcePremium(ChatBoostSource):
+    """
+    The boost was obtained by subscribing to Telegram Premium or by gifting a Telegram Premium subscription to another user.
+
+    Telegram documentation: https://core.telegram.org/bots/api#chatboostsourcepremium
+
+    :param source: Source of the boost, always “premium”
+    :type source: :obj:`str`
+
+    :param user: User that boosted the chat
+    :type user: :class:`User`
+
+    :return: Instance of the class
+    :rtype: :class:`ChatBoostSourcePremium`
+    """
+
+    def __init__(self, user):
+        super().__init__('premium')
+        self.user = user
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+        user = User.de_json(json.dumps(obj['user']))
+        return cls(user)
+    
+class ChatBoostSourceGiftCode(ChatBoostSource):
+    """
+    The boost was obtained by the creation of Telegram Premium gift codes to boost a chat.
+
+    Telegram documentation: https://core.telegram.org/bots/api#chatboostsourcegiftcode
+
+    :param source: Source of the boost, always “gift_code”
+    :type source: :obj:`str`
+
+    :param user: User for which the gift code was created
+    :type user: :class:`User`
+
+    :return: Instance of the class
+    :rtype: :class:`ChatBoostSourceGiftCode`
+    """
+
+    def __init__(self, user):
+        super().__init__('gift_code')
+        self.user = user
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+        user = User.de_json(json.dumps(obj['user']))
+        return cls(user)
+    
+class ChatBoostSourceGiveaway(ChatBoostSource):
+    """
+    The boost was obtained by the creation of a Telegram Premium giveaway.
+
+    Telegram documentation: https://core.telegram.org/bots/api#chatboostsourcegiveaway
+
+    :param source: Source of the boost, always “giveaway”
+    :type source: :obj:`str`
+
+    :param giveaway_message_id: Identifier of a message in the chat with the giveaway; the message could have been deleted already. May be 0 if the message isn't sent yet.
+    :type giveaway_message_id: :obj:`int`
+
+    :param user: User that won the prize in the giveaway if any
+    :type user: :class:`User`
+
+    :param is_unclaimed: True, if the giveaway was completed, but there was no user to win the prize
+    :type is_unclaimed: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`ChatBoostSourceGiveaway`
+    """
+
+    def __init__(self, giveaway_message_id, user=None, is_unclaimed=None):
+        super().__init__('giveaway')
+        self.giveaway_message_id = giveaway_message_id
+        self.user = user
+        self.is_unclaimed = is_unclaimed
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+        user = User.de_json(json.dumps(obj['user'])) if 'user' in obj else None
+        return cls(obj['giveaway_message_id'], user, obj.get('is_unclaimed'))
+
+#ChatBoost
+# This object contains information about a chat boost.
+
+# Field	Type	Description
+# boost_id	String	Unique identifier of the boost
+# add_date	Integer	Point in time (Unix timestamp) when the chat was boosted
+# expiration_date	Integer	Point in time (Unix timestamp) when the boost will automatically expire, unless the booster's Telegram Premium subscription is prolonged
+# source	ChatBoostSource	Source of the added boost
+    
+class ChatBoost(JsonDeserializable):
+    """
+    This object contains information about a chat boost.
+
+    Telegram documentation: https://core.telegram.org/bots/api#chatboost
+
+    :param boost_id: Unique identifier of the boost
+    :type boost_id: :obj:`str`
+
+    :param add_date: Point in time (Unix timestamp) when the chat was boosted
+    :type add_date: :obj:`int`
+
+    :param expiration_date: Point in time (Unix timestamp) when the boost will automatically expire, unless the booster's Telegram Premium subscription is prolonged
+    :type expiration_date: :obj:`int`
+
+    :param source: Source of the added boost
+    :type source: :class:`ChatBoostSource`
+
+    :return: Instance of the class
+    :rtype: :class:`ChatBoost`
+    """
+
+    def __init__(self, boost_id, add_date, expiration_date, source):
+        self.boost_id = boost_id
+        self.add_date = add_date
+        self.expiration_date = expiration_date
+        self.source: ChatBoostSource = source
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+
+        obj['source'] = ChatBoostSource.de_json(json.dumps(obj['source']))
+
+        return cls(**obj)
+

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1148,7 +1148,7 @@ class Message(JsonDeserializable):
         if 'caption' in obj:
             opts['caption'] = obj['caption']
         if 'contact' in obj:
-            opts['contact'] = Contact.de_json(json.dumps(obj['contact']))
+            opts['contact'] = Contact.de_json(obj['contact'])
             content_type = 'contact'
         if 'location' in obj:
             opts['location'] = Location.de_json(obj['location'])
@@ -7932,7 +7932,6 @@ class InlineQueryResultsButton(JsonSerializable, Dictionaryable):
         self.web_app: Optional[WebAppInfo] = web_app
         self.start_parameter: Optional[str] = start_parameter
 
-
     def to_dict(self) -> dict:
         json_dict = {
             'text': self.text
@@ -7964,6 +7963,7 @@ class Story(JsonDeserializable):
 
     def __init__(self) -> None:
         pass
+
 
 # base class
 class ReactionType(JsonDeserializable, Dictionaryable, JsonSerializable):
@@ -7999,7 +7999,6 @@ class ReactionType(JsonDeserializable, Dictionaryable, JsonSerializable):
         json_dict = {
             'type': self.type
         }
-
         return json_dict
     
     def to_json(self) -> str:
@@ -8029,11 +8028,8 @@ class ReactionTypeEmoji(ReactionType):
     def to_dict(self) -> dict:
         json_dict = super().to_dict()
         json_dict['emoji'] = self.emoji
+        return json_dict    
 
-        return json_dict
-    
-    
-    
 
 class ReactionTypeCustomEmoji(ReactionType):
     """
@@ -8058,11 +8054,8 @@ class ReactionTypeCustomEmoji(ReactionType):
     def to_dict(self) -> dict:
         json_dict = super().to_dict()
         json_dict['custom_emoji'] = self.custom_emoji
-
         return json_dict
-    
-    
-    
+
 
 class MessageReactionUpdated(JsonDeserializable):
     """
@@ -8101,15 +8094,13 @@ class MessageReactionUpdated(JsonDeserializable):
             return None
         obj = cls.check_json(json_string)
 
+        obj['chat'] = Chat.de_json(obj['chat'])
         if 'user' in obj:
             obj['user'] = User.de_json(obj['user'])
         if 'actor_chat' in obj:
             obj['actor_chat'] = Chat.de_json(obj['actor_chat'])
         obj['old_reaction'] = [ReactionType.de_json(reaction) for reaction in obj['old_reaction']]
         obj['new_reaction'] = [ReactionType.de_json(reaction) for reaction in obj['new_reaction']]
-        if 'chat' in obj:
-            obj['chat'] = Chat.de_json(obj['chat'])
-
         return cls(**obj)
 
     def __init__(self, chat: Chat, message_id: int, date: int, old_reaction: List[ReactionType], new_reaction: List[ReactionType],
@@ -8151,10 +8142,8 @@ class MessageReactionCountUpdated(JsonDeserializable):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
-
-        obj['reactions'] = [ReactionCount.de_json(reaction) for reaction in obj['reactions']]
         obj['chat'] = Chat.de_json(obj['chat'])
-
+        obj['reactions'] = [ReactionCount.de_json(reaction) for reaction in obj['reactions']]
         return cls(**obj)
 
     def __init__(self, chat: Chat, message_id: int, date: int, reactions: List[ReactionCount]) -> None:
@@ -8185,15 +8174,12 @@ class ReactionCount(JsonDeserializable):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
-
         obj['type'] = ReactionType.de_json(obj['type'])
-        
         return cls(**obj)
     
     def __init__(self, type: ReactionType, total_count: int) -> None:
         self.type: ReactionType = type
         self.total_count: int = total_count
-
 
 
 class ExternalReplyInfo(JsonDeserializable):
@@ -8280,23 +8266,14 @@ class ExternalReplyInfo(JsonDeserializable):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
+        origin = MessageOrigin.de_json(obj['origin'])
+        if 'chat' in obj:
+            chat = Chat.de_json(obj['chat'])
+        if 'link_preview_options' in obj:
+            link_preview_options = LinkPreviewOptions.de_json(obj['link_preview_options'])
 
-        origin = obj.get('origin')
-        if origin is not None:
-            origin = MessageOrigin.de_json(origin)
+        #todo: update data processing to common way
         
-        chat = obj.get('chat')
-        if chat is not None:
-            chat = Chat.de_json(chat)
-
-        message_id = obj.get('message_id')
-        if message_id is not None:
-            message_id = int(message_id)
-
-        link_preview_options = obj.get('link_preview_options')
-        if link_preview_options is not None:
-            link_preview_options = LinkPreviewOptions.de_json(link_preview_options)
-
         animation = obj.get('animation')
         if animation is not None:
             animation = Animation.de_json(animation)
@@ -8414,6 +8391,7 @@ class ExternalReplyInfo(JsonDeserializable):
         self.poll: Optional[Poll] = poll
         self.venue: Optional[Venue] = venue
 
+
 class MessageOrigin(JsonDeserializable):
     """
     This object describes the origin of a message.
@@ -8450,16 +8428,16 @@ class MessageOrigin(JsonDeserializable):
 
         message_type = obj.get('type')
         if message_type == 'user':
-            sender_user = User.de_json(obj.get('sender_user'))
-            return MessageOriginUser(date=obj.get('date'), sender_user=sender_user)
+            sender_user = User.de_json(obj['sender_user'])
+            return MessageOriginUser(date=obj['date'], sender_user=sender_user)
         elif message_type == 'hidden_user':
-            return MessageOriginHiddenUser(date=obj.get('date'), sender_user_name=obj.get('sender_user_name'))
+            return MessageOriginHiddenUser(date=obj['date'], sender_user_name=obj['sender_user_name'])
         elif message_type == 'chat':
-            sender_chat = Chat.de_json(obj.get('sender_chat'))
-            return MessageOriginChat(date=obj.get('date'), sender_chat=sender_chat, author_signature=obj.get('author_signature'))
+            sender_chat = Chat.de_json(obj['sender_chat'])
+            return MessageOriginChat(date=obj['date'], sender_chat=sender_chat, author_signature=obj.get('author_signature'))
         elif message_type == 'channel':
-            chat = Chat.de_json(obj.get('chat'))
-            return MessageOriginChannel(date=obj.get('date'), chat=chat, message_id=obj.get('message_id'), author_signature=obj.get('author_signature'))
+            chat = Chat.de_json(obj['chat'])
+            return MessageOriginChannel(date=obj['date'], chat=chat, message_id=obj['message_id'], author_signature=obj.get('author_signature'))
 
     def __init__(self, type: str, date: int) -> None:
         self.type: str = type
@@ -8474,9 +8452,9 @@ class MessageOriginUser(MessageOrigin):
     :type sender_user: :class:`User`
     """
 
-    def __init__(self, date: int, sender_user: Optional[User] = None) -> None:
+    def __init__(self, date: int, sender_user: User) -> None:
         super().__init__('user', date)
-        self.sender_user: Optional[User] = sender_user
+        self.sender_user: User = sender_user
 
 
 class MessageOriginHiddenUser(MessageOrigin):
@@ -8487,9 +8465,9 @@ class MessageOriginHiddenUser(MessageOrigin):
     :type sender_user_name: :obj:`str`
     """
 
-    def __init__(self, date: int, sender_user_name: Optional[str] = None) -> None:
+    def __init__(self, date: int, sender_user_name: str) -> None:
         super().__init__('hidden_user', date)
-        self.sender_user_name: Optional[str] = sender_user_name
+        self.sender_user_name: str = sender_user_name
 
 
 class MessageOriginChat(MessageOrigin):
@@ -8503,9 +8481,9 @@ class MessageOriginChat(MessageOrigin):
     :type author_signature: :obj:`str`
     """
 
-    def __init__(self, date: int, sender_chat: Optional[Chat] = None, author_signature: Optional[str] = None) -> None:
+    def __init__(self, date: int, sender_chat: Chat, author_signature: Optional[str] = None) -> None:
         super().__init__('chat', date)
-        self.sender_chat: Optional[Chat] = sender_chat
+        self.sender_chat: Chat = sender_chat
         self.author_signature: Optional[str] = author_signature
 
 
@@ -8523,10 +8501,10 @@ class MessageOriginChannel(MessageOrigin):
     :type author_signature: :obj:`str`
     """
 
-    def __init__(self, date: int, chat: Optional[Chat] = None, message_id: Optional[int] = None, author_signature: Optional[str] = None) -> None:
+    def __init__(self, date: int, chat: Chat, message_id: int, author_signature: Optional[str] = None) -> None:
         super().__init__('channel', date)
-        self.chat: Optional[Chat] = chat
-        self.message_id: Optional[int] = message_id
+        self.chat: Chat = chat
+        self.message_id: int = message_id
         self.author_signature: Optional[str] = author_signature
 
 
@@ -8560,7 +8538,7 @@ class LinkPreviewOptions(JsonDeserializable, Dictionaryable, JsonSerializable):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
-
+        #todo: adopt to common way
         return cls(is_disabled=obj.get('is_disabled'), url=obj.get('url'), prefer_small_media=obj.get('prefer_small_media'),
                         prefer_large_media=obj.get('prefer_large_media'), show_above_text=obj.get('show_above_text'))
     
@@ -8632,10 +8610,8 @@ class Giveaway(JsonDeserializable):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
-
-        chats = [Chat.de_json(chat) for chat in obj.get('chats', [])]
-
-        return cls(**obj, chats=chats)
+        self.chats = [Chat.de_json(chat) for chat in obj['chats']]
+        return cls(**obj)
 
     def __init__(self, chats: List[Chat], winners_selection_date: int, winner_count: int,
                  only_new_members: Optional[bool] = None, has_public_winners: Optional[bool] = None,
@@ -8647,8 +8623,9 @@ class Giveaway(JsonDeserializable):
         self.only_new_members: Optional[bool] = only_new_members
         self.has_public_winners: Optional[bool] = has_public_winners
         self.prize_description: Optional[str] = prize_description
-        self.country_codes: Optional[List[str]] = country_codes or []
+        self.country_codes: Optional[List[str]] = country_codes
         self.premium_subscription_month_count: Optional[int] = premium_subscription_month_count
+                     
 
 class GiveawayWinners(JsonDeserializable):
     """
@@ -8698,10 +8675,8 @@ class GiveawayWinners(JsonDeserializable):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
-
-        obj['chat'] = Chat.de_json(obj.get('chat'))
-        obj['winners'] = [User.de_json(user) for user in obj.get('winners', [])]
-
+        obj['chat'] = Chat.de_json(obj['chat'])
+        obj['winners'] = [User.de_json(user) for user in obj['winners']]
         return cls(**obj)
     
     def __init__(self, chat: Chat, giveaway_message_id: int, winners_selection_date: int, winner_count: int,
@@ -8720,6 +8695,7 @@ class GiveawayWinners(JsonDeserializable):
         self.only_new_members: Optional[bool] = only_new_members
         self.was_refunded: Optional[bool] = was_refunded
         self.prize_description: Optional[str] = prize_description
+                     
         
 class GiveawayCompleted(JsonDeserializable):
     """
@@ -8745,9 +8721,8 @@ class GiveawayCompleted(JsonDeserializable):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
-
-        obj['giveaway_message'] = Message.de_json(obj.get('giveaway_message'))
-
+        if 'giveaway_message' in obj:
+            obj['giveaway_message'] = Message.de_json(obj['giveaway_message'])
         return cls(**obj)
     
     def __init__(self, winner_count: int, unclaimed_prize_count: Optional[int] = None,
@@ -8755,11 +8730,13 @@ class GiveawayCompleted(JsonDeserializable):
         self.winner_count: int = winner_count
         self.unclaimed_prize_count: Optional[int] = unclaimed_prize_count
         self.giveaway_message: Optional[Message] = giveaway_message
+                        
 
 class GiveawayCreated(JsonDeserializable):
     """
     This object represents a service message about the creation of a scheduled giveaway. Currently holds no information.
     """
+    
         
 class TextQuote(JsonDeserializable):
     """
@@ -8788,9 +8765,7 @@ class TextQuote(JsonDeserializable):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
-
         obj['entities'] = [MessageEntity.de_json(entity) for entity in obj.get('entities', [])]
-
         return cls(**obj)
 
     def __init__(self, text: str, entities: Optional[List[MessageEntity]] = None,
@@ -8799,6 +8774,7 @@ class TextQuote(JsonDeserializable):
         self.entities: Optional[List[MessageEntity]] = entities
         self.position: Optional[int] = position
         self.is_manual: Optional[bool] = is_manual
+
 
 class ReplyParameters(JsonDeserializable, Dictionaryable, JsonSerializable):
     """
@@ -8836,11 +8812,8 @@ class ReplyParameters(JsonDeserializable, Dictionaryable, JsonSerializable):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
-
         obj['quote_entities'] = [MessageEntity.de_json(entity) for entity in obj.get('quote_entities', [])]
-
-        return cls(**obj)
-    
+        return cls(**obj)    
 
     def __init__(self, message_id: int, chat_id: Optional[Union[int, str]] = None,
                  allow_sending_without_reply: Optional[bool] = None, quote: Optional[str] = None,
@@ -8854,12 +8827,10 @@ class ReplyParameters(JsonDeserializable, Dictionaryable, JsonSerializable):
         self.quote_entities: Optional[List[MessageEntity]] = quote_entities
         self.quote_position: Optional[int] = quote_position
 
-
     def to_dict(self) -> dict:
         json_dict = {
             'message_id': self.message_id
         }
-
         if self.chat_id is not None:
             json_dict['chat_id'] = self.chat_id
         if self.allow_sending_without_reply is not None:
@@ -8872,11 +8843,11 @@ class ReplyParameters(JsonDeserializable, Dictionaryable, JsonSerializable):
             json_dict['quote_entities'] = [entity.to_dict() for entity in self.quote_entities]
         if self.quote_position is not None:
             json_dict['quote_position'] = self.quote_position
-
         return json_dict
     
     def to_json(self) -> str:
         return json.dumps(self.to_dict())
+        
     
 class UsersShared(JsonDeserializable):
     """
@@ -8900,16 +8871,16 @@ class UsersShared(JsonDeserializable):
     :rtype: :class:`UsersShared`
     """
 
-    def __init__(self, request_id, user_ids):
-        self.request_id = request_id
-        self.user_ids = user_ids
-
     @classmethod
     def de_json(cls, json_string):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
         return cls(**obj)
+
+    def __init__(self, request_id, user_ids):
+        self.request_id = request_id
+        self.user_ids = user_ids
     
 
 class ChatBoostUpdated(JsonDeserializable):
@@ -8928,29 +8899,19 @@ class ChatBoostUpdated(JsonDeserializable):
     :rtype: :class:`ChatBoostUpdated`
     """
 
-    def __init__(self, chat, boost):
-        self.chat = chat
-        self.boost = boost
-
     @classmethod
     def de_json(cls, json_string):
         if json_string is None:
             return None
-        obj = cls.check_json(json_string)
-        
-        obj['chat'] = Chat.de_json(obj.get('chat'))
-        obj['boost'] = ChatBoost.de_json(obj.get('boost'))
-
+        obj = cls.check_json(json_string)        
+        obj['chat'] = Chat.de_json(obj['chat'])
+        obj['boost'] = ChatBoost.de_json(obj['boost'])
         return cls(**obj)
-    
-# ChatBoostRemoved
-# This object represents a boost removed from a chat.
 
-# Field	Type	Description
-# chat	Chat	Chat which was boosted
-# boost_id	String	Unique identifier of the boost
-# remove_date	Integer	Point in time (Unix timestamp) when the boost was removed
-# source	ChatBoostSource	Source of the removed boost
+    def __init__(self, chat, boost):
+        self.chat = chat
+        self.boost = boost
+        
     
 class ChatBoostRemoved(JsonDeserializable):
     """
@@ -8974,22 +8935,21 @@ class ChatBoostRemoved(JsonDeserializable):
     :rtype: :class:`ChatBoostRemoved`
     """
 
-    def __init__(self, chat, boost_id, remove_date, source):
-        self.chat = chat
-        self.boost_id = boost_id
-        self.remove_date = remove_date
-        self.source = source
-
     @classmethod
     def de_json(cls, json_string):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
-
-        obj['chat'] = Chat.de_json(obj.get('chat'))
-        obj['source'] = ChatBoostSource.de_json(obj.get('source'))
-        
+        obj['chat'] = Chat.de_json(obj['chat'])
+        obj['source'] = ChatBoostSource.de_json(obj['source'])        
         return cls(**obj)
+
+    def __init__(self, chat, boost_id, remove_date, source):
+        self.chat = chat
+        self.boost_id = boost_id
+        self.remove_date = remove_date
+        self.source = source
+        
     
 class ChatBoostSource(JsonDeserializable):
     """
@@ -9004,14 +8964,14 @@ class ChatBoostSource(JsonDeserializable):
     :rtype: :class:`ChatBoostSource`
     """
 
-    def __init__(self, source):
-        self.source = source
-
     @classmethod
     def de_json(cls, json_string):
         if json_string is None:
             return None
         return cls(**cls.check_json(json_string))
+
+    def __init__(self, source):
+        self.source = source
     
 
 class ChatBoostSourcePremium(ChatBoostSource):
@@ -9030,17 +8990,18 @@ class ChatBoostSourcePremium(ChatBoostSource):
     :rtype: :class:`ChatBoostSourcePremium`
     """
 
-    def __init__(self, user):
-        super().__init__('premium')
-        self.user = user
-
     @classmethod
     def de_json(cls, json_string):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
-        user = User.de_json(json.dumps(obj['user']))
+        user = User.de_json(obj['user'])
         return cls(user)
+
+    def __init__(self, user):
+        super().__init__('premium')
+        self.user = user
+        
     
 class ChatBoostSourceGiftCode(ChatBoostSource):
     """
@@ -9058,17 +9019,18 @@ class ChatBoostSourceGiftCode(ChatBoostSource):
     :rtype: :class:`ChatBoostSourceGiftCode`
     """
 
-    def __init__(self, user):
-        super().__init__('gift_code')
-        self.user = user
-
     @classmethod
     def de_json(cls, json_string):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
-        user = User.de_json(json.dumps(obj['user']))
+        user = User.de_json(obj['user'])
         return cls(user)
+
+    def __init__(self, user):
+        super().__init__('gift_code')
+        self.user = user
+        
     
 class ChatBoostSourceGiveaway(ChatBoostSource):
     """
@@ -9092,29 +9054,21 @@ class ChatBoostSourceGiveaway(ChatBoostSource):
     :rtype: :class:`ChatBoostSourceGiveaway`
     """
 
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+        user = User.de_json(obj['user']) if 'user' in obj else None
+        return cls(obj['giveaway_message_id'], user, obj.get('is_unclaimed'))
+
     def __init__(self, giveaway_message_id, user=None, is_unclaimed=None):
         super().__init__('giveaway')
         self.giveaway_message_id = giveaway_message_id
         self.user = user
         self.is_unclaimed = is_unclaimed
 
-    @classmethod
-    def de_json(cls, json_string):
-        if json_string is None:
-            return None
-        obj = cls.check_json(json_string)
-        user = User.de_json(json.dumps(obj['user'])) if 'user' in obj else None
-        return cls(obj['giveaway_message_id'], user, obj.get('is_unclaimed'))
 
-#ChatBoost
-# This object contains information about a chat boost.
-
-# Field	Type	Description
-# boost_id	String	Unique identifier of the boost
-# add_date	Integer	Point in time (Unix timestamp) when the chat was boosted
-# expiration_date	Integer	Point in time (Unix timestamp) when the boost will automatically expire, unless the booster's Telegram Premium subscription is prolonged
-# source	ChatBoostSource	Source of the added boost
-    
 class ChatBoost(JsonDeserializable):
     """
     This object contains information about a chat boost.
@@ -9137,21 +9091,20 @@ class ChatBoost(JsonDeserializable):
     :rtype: :class:`ChatBoost`
     """
 
-    def __init__(self, boost_id, add_date, expiration_date, source):
-        self.boost_id = boost_id
-        self.add_date = add_date
-        self.expiration_date = expiration_date
-        self.source: ChatBoostSource = source
-
     @classmethod
     def de_json(cls, json_string):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
-
-        obj['source'] = ChatBoostSource.de_json(json.dumps(obj['source']))
-
+        obj['source'] = ChatBoostSource.de_json(obj['source'])
         return cls(**obj)
+
+    def __init__(self, boost_id, add_date, expiration_date, source):
+        self.boost_id = boost_id
+        self.add_date = add_date
+        self.expiration_date = expiration_date
+        self.source: ChatBoostSource = source
+        
 
 class UserChatBoosts(JsonDeserializable):
     """
@@ -9166,18 +9119,16 @@ class UserChatBoosts(JsonDeserializable):
     :rtype: :class:`UserChatBoosts`
     """
 
-    def __init__(self, boosts):
-        self.boosts: ChatBoost = boosts
-
     @classmethod
     def de_json(cls, json_string):
         if json_string is None:
             return None
-        
         obj = cls.check_json(json_string)
-        obj['boosts'] = [ChatBoost.de_json(boost) for boost in obj.get('boosts', [])]
-
+        obj['boosts'] = [ChatBoost.de_json(boost) for boost in obj['boosts']]
         return cls(**obj)
+
+    def __init__(self, boosts):
+        self.boosts: ChatBoost = boosts
     
 
 class InaccessibleMessage(JsonDeserializable):
@@ -9199,18 +9150,15 @@ class InaccessibleMessage(JsonDeserializable):
     :rtype: :class:`InaccessibleMessage`
     """
 
-    def __init__(self, chat, message_id, date):
-        self.chat = chat
-        self.message_id = message_id
-        self.date = date
-
     @classmethod
     def de_json(cls, json_string):
         if json_string is None:
             return None
-        
         obj = cls.check_json(json_string)
-        obj['chat'] = Chat.de_json(obj.get('chat'))
-
+        obj['chat'] = Chat.de_json(obj['chat'])
         return cls(**obj)
-    
+
+    def __init__(self, chat, message_id, date):
+        self.chat = chat
+        self.message_id = message_id
+        self.date = date

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -836,6 +836,10 @@ class Message(JsonDeserializable):
         appear in the text
     :type entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
+    :param link_preview_options: Optional. Options used for link preview generation for the message,
+        if it is a text message and link preview options were changed
+    :type link_preview_options: :class:`telebot.types.LinkPreviewOptions`
+
     :param animation: Optional. Message is an animation, information about the animation. For backward 
         compatibility, when this field is set, the document field will also be set
     :type animation: :class:`telebot.types.Animation`
@@ -1221,6 +1225,10 @@ class Message(JsonDeserializable):
             opts['quote'] = TextQuote.de_json(obj['quote'])
             content_type = 'text' # Here too, check the content types   
 
+        if 'link_preview_options' in obj:
+            opts['link_preview_options'] = LinkPreviewOptions.de_json(obj['link_preview_options'])
+
+
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
     @classmethod
@@ -1321,6 +1329,7 @@ class Message(JsonDeserializable):
         self.story: Optional[Story] = None
         self.external_reply: Optional[ExternalReplyInfo] = None
         self.quote: Optional[TextQuote] = None
+        self.LinkPreviewOptions: Optional[LinkPreviewOptions] = None
         
         for key in options:
             setattr(self, key, options[key])

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -8409,7 +8409,7 @@ class MessageOriginChannel(MessageOrigin):
         self.author_signature: Optional[str] = author_signature
 
 
-class LinkPreviewOptions(JsonDeserializable):
+class LinkPreviewOptions(JsonDeserializable, Dictionaryable, JsonSerializable):
     """
     Describes the options used for link preview generation.
 
@@ -8452,6 +8452,24 @@ class LinkPreviewOptions(JsonDeserializable):
         self.prefer_small_media: Optional[bool] = prefer_small_media
         self.prefer_large_media: Optional[bool] = prefer_large_media
         self.show_above_text: Optional[bool] = show_above_text
+
+    def to_dict(self) -> dict:
+        json_dict = {}
+
+        if self.is_disabled is not None:
+            json_dict['is_disabled'] = self.is_disabled
+        if self.url is not None:
+            json_dict['url'] = self.url
+        if self.prefer_small_media is not None:
+            json_dict['prefer_small_media'] = self.prefer_small_media
+        if self.prefer_large_media is not None:
+            json_dict['prefer_large_media'] = self.prefer_large_media
+        if self.show_above_text is not None:
+            json_dict['show_above_text'] = self.show_above_text
+
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
 
 
 class Giveaway(JsonDeserializable):
@@ -8700,5 +8718,4 @@ class ReplyParameters(JsonDeserializable, Dictionaryable, JsonSerializable):
     
     def to_json(self) -> str:
         return json.dumps(self.to_dict())
-    
     

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -9154,3 +9154,38 @@ class UserChatBoosts(JsonDeserializable):
 
         return cls(**obj)
     
+
+class InaccessibleMessage(JsonDeserializable):
+    """
+    This object describes a message that was deleted or is otherwise inaccessible to the bot.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inaccessiblemessage
+
+    :param chat: Chat the message belonged to
+    :type chat: :class:`Chat`
+
+    :param message_id: Unique message identifier inside the chat
+    :type message_id: :obj:`int`
+
+    :param date: Always 0. The field can be used to differentiate regular and inaccessible messages.
+    :type date: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`InaccessibleMessage`
+    """
+
+    def __init__(self, chat, message_id, date):
+        self.chat = chat
+        self.message_id = message_id
+        self.date = date
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        
+        obj = cls.check_json(json_string)
+        obj['chat'] = Chat.de_json(obj.get('chat'))
+
+        return cls(**obj)
+    

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1272,14 +1272,10 @@ class Message(JsonDeserializable):
             content_type = 'story'
         if 'external_reply' in obj:
             opts['external_reply'] = ExternalReplyInfo.de_json(obj['external_reply'])
-            content_type = 'text' # @Badiboy not sure about content_types in here, please check
         if 'quote' in obj:
             opts['quote'] = TextQuote.de_json(obj['quote'])
-            content_type = 'text' # Here too, check the content types   
-
         if 'link_preview_options' in obj:
             opts['link_preview_options'] = LinkPreviewOptions.de_json(obj['link_preview_options'])
-
         if 'giveaway_created' in obj:
             opts['giveaway_created'] = GiveawayCreated.de_json(obj['giveaway_created'])
             content_type = 'giveaway_created'
@@ -1396,7 +1392,7 @@ class Message(JsonDeserializable):
         self.story: Optional[Story] = None
         self.external_reply: Optional[ExternalReplyInfo] = None
         self.quote: Optional[TextQuote] = None
-        self.LinkPreviewOptions: Optional[LinkPreviewOptions] = None
+        self.link_preview_options: Optional[LinkPreviewOptions] = None
         self.giveaway_created: Optional[GiveawayCreated] = None
         self.giveaway: Optional[Giveaway] = None
         self.giveaway_winners: Optional[GiveawayWinners] = None
@@ -3713,7 +3709,7 @@ class InputTextMessageContent(Dictionaryable):
         parse_mode
     :type entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
-    :param disable_web_page_preview: Optional. Disables link previews for links in the sent message
+    :param disable_web_page_preview: Optional, deprecated. Disables link previews for links in the sent message
     :type disable_web_page_preview: :obj:`bool`
 
     :return: Instance of the class
@@ -3724,11 +3720,13 @@ class InputTextMessageContent(Dictionaryable):
         self.parse_mode: str = parse_mode
         self.entities: List[MessageEntity] = entities
         link_preview_options: LinkPreviewOptions = link_preview_options
-        if disable_web_page_preview is not None and link_preview_options is None:
-            # deprecated
-            self.link_preview_options: LinkPreviewOptions = LinkPreviewOptions(disable_web_page_preview)
+        if disable_web_page_preview is not None:
+            logger.warning("The parameter 'disable_web_page_preview' is deprecated. Use 'link_preview_options' instead.")
             
-
+            if link_preview_options:
+                logger.warning("Both 'link_preview_options' and 'disable_web_page_preview' parameters are set: conflicting, 'disable_web_page_preview' is deprecated")
+            else:
+                self.link_preview_options: LinkPreviewOptions = LinkPreviewOptions(disable_web_page_preview)
 
     def to_dict(self):
         json_dict = {'message_text': self.message_text}

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -195,7 +195,7 @@ class Update(JsonDeserializable):
         message_reaction = MessageReactionUpdated.de_json(obj.get('message_reaction'))
         return cls(update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                    chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                   my_chat_member, chat_member, chat_join_request)
+                   my_chat_member, chat_member, chat_join_request, message_reaction)
 
     def __init__(self, update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                  chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -3628,11 +3628,16 @@ class InputTextMessageContent(Dictionaryable):
     :return: Instance of the class
     :rtype: :class:`telebot.types.InputTextMessageContent`
     """
-    def __init__(self, message_text, parse_mode=None, entities=None, disable_web_page_preview=None):
+    def __init__(self, message_text, parse_mode=None, entities=None, disable_web_page_preview=None, link_preview_options=None):
         self.message_text: str = message_text
         self.parse_mode: str = parse_mode
         self.entities: List[MessageEntity] = entities
-        self.disable_web_page_preview: bool = disable_web_page_preview
+        link_preview_options: LinkPreviewOptions = link_preview_options
+        if disable_web_page_preview is not None and link_preview_options is None:
+            # deprecated
+            self.link_preview_options: LinkPreviewOptions = LinkPreviewOptions(disable_web_page_preview)
+            
+
 
     def to_dict(self):
         json_dict = {'message_text': self.message_text}
@@ -3640,8 +3645,8 @@ class InputTextMessageContent(Dictionaryable):
             json_dict['parse_mode'] = self.parse_mode
         if self.entities:
             json_dict['entities'] = MessageEntity.to_list_of_dicts(self.entities)
-        if self.disable_web_page_preview is not None:
-            json_dict['disable_web_page_preview'] = self.disable_web_page_preview
+        if self.link_preview_options:
+            json_dict['link_preview_options'] = self.link_preview_options.to_dict()
         return json_dict
 
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -8153,6 +8153,10 @@ class MessageReactionCountUpdated(JsonDeserializable):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
+
+        obj['reactions'] = [ReactionCount.de_json(reaction) for reaction in obj['reactions']]
+        obj['chat'] = Chat.de_json(obj['chat'])
+
         return cls(**obj)
 
     def __init__(self, chat: Chat, message_id: int, date: int, reactions: List[ReactionCount]) -> None:
@@ -8183,6 +8187,9 @@ class ReactionCount(JsonDeserializable):
         if json_string is None:
             return None
         obj = cls.check_json(json_string)
+
+        obj['type'] = ReactionType.de_json(obj['type'])
+        
         return cls(**obj)
     
     def __init__(self, type: ReactionType, total_count: int) -> None:

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -8057,3 +8057,514 @@ class ReactionCount(JsonDeserializable):
         self.type: ReactionType = type
         self.total_count: int = total_count
 
+
+
+class ExternalReplyInfo(JsonDeserializable):
+    """
+    This object contains information about a message that is being replied to,
+    which may come from another chat or forum topic.
+
+    Telegram documentation: https://core.telegram.org/bots/api#externalreplyinfo
+
+    :param origin: Origin of the message replied to by the given message
+    :type origin: :class:`MessageOrigin`
+
+    :param chat: Optional. Chat the original message belongs to. Available only if the chat is a supergroup or a channel.
+    :type chat: :class:`Chat`
+
+    :param message_id: Optional. Unique message identifier inside the original chat. Available only if the original chat is a supergroup or a channel.
+    :type message_id: :obj:`int`
+
+    :param link_preview_options: Optional. Options used for link preview generation for the original message, if it is a text message
+    :type link_preview_options: :class:`LinkPreviewOptions`
+
+    :param animation: Optional. Message is an animation, information about the animation
+    :type animation: :class:`Animation`
+
+    :param audio: Optional. Message is an audio file, information about the file
+    :type audio: :class:`Audio`
+
+    :param document: Optional. Message is a general file, information about the file
+    :type document: :class:`Document`
+
+    :param photo: Optional. Message is a photo, available sizes of the photo
+    :type photo: :obj:`list` of :class:`PhotoSize`
+
+    :param sticker: Optional. Message is a sticker, information about the sticker
+    :type sticker: :class:`Sticker`
+
+    :param story: Optional. Message is a forwarded story
+    :type story: :class:`Story`
+
+    :param video: Optional. Message is a video, information about the video
+    :type video: :class:`Video`
+
+    :param video_note: Optional. Message is a video note, information about the video message
+    :type video_note: :class:`VideoNote`
+
+    :param voice: Optional. Message is a voice message, information about the file
+    :type voice: :class:`Voice`
+
+    :param has_media_spoiler: Optional. True, if the message media is covered by a spoiler animation
+    :type has_media_spoiler: :obj:`bool`
+
+    :param contact: Optional. Message is a shared contact, information about the contact
+    :type contact: :class:`Contact`
+
+    :param dice: Optional. Message is a dice with random value
+    :type dice: :class:`Dice`
+
+    :param game: Optional. Message is a game, information about the game. More about games »
+    :type game: :class:`Game`
+
+    :param giveaway: Optional. Message is a scheduled giveaway, information about the giveaway
+    :type giveaway: :class:`Giveaway`
+
+    :param giveaway_winners: Optional. A giveaway with public winners was completed
+    :type giveaway_winners: :class:`GiveawayWinners`
+
+    :param invoice: Optional. Message is an invoice for a payment, information about the invoice. More about payments »
+    :type invoice: :class:`Invoice`
+
+    :param location: Optional. Message is a shared location, information about the location
+    :type location: :class:`Location`
+
+    :param poll: Optional. Message is a native poll, information about the poll
+    :type poll: :class:`Poll`
+
+    :param venue: Optional. Message is a venue, information about the venue
+    :type venue: :class:`Venue`
+
+    :return: Instance of the class
+    :rtype: :class:`ExternalReplyInfo`
+    """
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+
+        origin = obj.get('origin')
+        if origin is not None:
+            origin = MessageOrigin.de_json(origin)
+        
+        chat = obj.get('chat')
+        if chat is not None:
+            chat = Chat.de_json(chat)
+
+        message_id = obj.get('message_id')
+        if message_id is not None:
+            message_id = int(message_id)
+
+        link_preview_options = obj.get('link_preview_options')
+        if link_preview_options is not None:
+            link_preview_options = LinkPreviewOptions.de_json(link_preview_options)
+
+        animation = obj.get('animation')
+        if animation is not None:
+            animation = Animation.de_json(animation)
+
+        audio = obj.get('audio')
+        if audio is not None:
+            audio = Audio.de_json(audio)
+
+        document = obj.get('document')
+        if document is not None:
+            document = Document.de_json(document)
+
+        photo = obj.get('photo')
+        if photo is not None:
+            photo = [PhotoSize.de_json(photo[i]) for i in range(len(photo))]
+
+        sticker = obj.get('sticker')
+        if sticker is not None:
+            sticker = Sticker.de_json(sticker)
+
+        story = obj.get('story')
+        if story is not None:
+            story = Story.de_json(story)
+
+        video = obj.get('video')
+        if video is not None:
+            video = Video.de_json(video)
+
+        video_note = obj.get('video_note')
+        if video_note is not None:
+            video_note = VideoNote.de_json(video_note)
+
+        voice = obj.get('voice')
+        if voice is not None:
+            voice = Voice.de_json(voice)
+
+        has_media_spoiler = obj.get('has_media_spoiler')
+        if has_media_spoiler is not None:
+            has_media_spoiler = bool(has_media_spoiler)
+
+        contact = obj.get('contact')
+        if contact is not None:
+            contact = Contact.de_json(contact)
+
+        dice = obj.get('dice')
+        if dice is not None:
+            dice = Dice.de_json(dice)
+
+        game = obj.get('game')
+        if game is not None:
+            game = Game.de_json(game)
+
+        giveaway = obj.get('giveaway')
+        if giveaway is not None:
+            giveaway = Giveaway.de_json(giveaway)
+
+        giveaway_winners = obj.get('giveaway_winners')
+        if giveaway_winners is not None:
+            giveaway_winners = GiveawayWinners.de_json(giveaway_winners)
+
+        invoice = obj.get('invoice')
+        if invoice is not None:
+            invoice = Invoice.de_json(invoice)
+
+        location = obj.get('location')
+        if location is not None:
+            location = Location.de_json(location)
+
+        poll = obj.get('poll')
+        if poll is not None:
+            poll = Poll.de_json(poll)
+
+        venue = obj.get('venue')
+        if venue is not None:
+            venue = Venue.de_json(venue)
+
+        return cls(origin=origin, chat=chat, message_id=message_id, link_preview_options=link_preview_options,
+                     animation=animation, audio=audio, document=document, photo=photo, sticker=sticker, story=story,
+                        video=video, video_note=video_note, voice=voice, has_media_spoiler=has_media_spoiler,
+                            contact=contact, dice=dice, game=game, giveaway=giveaway, giveaway_winners=giveaway_winners,
+                                invoice=invoice, location=location, poll=poll, venue=venue)
+    
+    def __init__(self, origin: MessageOrigin, chat: Optional[Chat]=None, message_id: Optional[int]=None,
+                    link_preview_options: Optional[LinkPreviewOptions]=None, animation: Optional[Animation]=None,
+                        audio: Optional[Audio]=None, document: Optional[Document]=None, photo: Optional[List[PhotoSize]]=None,
+                            sticker: Optional[Sticker]=None, story: Optional[Story]=None, video: Optional[Video]=None,
+                                video_note: Optional[VideoNote]=None, voice: Optional[Voice]=None,
+                                    has_media_spoiler: Optional[bool]=None, contact: Optional[Contact]=None,
+                                        dice: Optional[Dice]=None, game: Optional[Game]=None, giveaway: Optional[Giveaway]=None,
+                                            giveaway_winners: Optional[GiveawayWinners]=None, invoice: Optional[Invoice]=None,
+                                                location: Optional[Location]=None, poll: Optional[Poll]=None,
+                                                    venue: Optional[Venue]=None) -> None:
+        self.origin: MessageOrigin = origin
+
+        self.chat: Optional[Chat] = chat
+        self.message_id: Optional[int] = message_id
+        self.link_preview_options: Optional[LinkPreviewOptions] = link_preview_options
+        self.animation: Optional[Animation] = animation
+        self.audio: Optional[Audio] = audio
+        self.document: Optional[Document] = document
+        self.photo: Optional[List[PhotoSize]] = photo
+        self.sticker: Optional[Sticker] = sticker
+        self.story: Optional[Story] = story
+        self.video: Optional[Video] = video
+        self.video_note: Optional[VideoNote] = video_note
+        self.voice: Optional[Voice] = voice
+        self.has_media_spoiler: Optional[bool] = has_media_spoiler
+        self.contact: Optional[Contact] = contact
+        self.dice: Optional[Dice] = dice
+        self.game: Optional[Game] = game
+        self.giveaway: Optional[Giveaway] = giveaway
+        self.giveaway_winners: Optional[GiveawayWinners] = giveaway_winners
+        self.invoice: Optional[Invoice] = invoice
+        self.location: Optional[Location] = location
+        self.poll: Optional[Poll] = poll
+        self.venue: Optional[Venue] = venue
+
+class MessageOrigin(JsonDeserializable):
+    """
+    This object describes the origin of a message.
+
+    Telegram documentation: https://core.telegram.org/bots/api#messageorigin
+
+    :param type: Type of the message origin
+    :type type: :obj:`str`
+
+    :param date: Date the message was sent originally in Unix time
+    :type date: :obj:`int`
+
+    :param sender_user: User that sent the message originally (for MessageOriginUser)
+    :type sender_user: :class:`User`
+
+    :param sender_user_name: Name of the user that sent the message originally (for MessageOriginHiddenUser)
+    :type sender_user_name: :obj:`str`
+
+    :param sender_chat: Chat that sent the message originally (for MessageOriginChat)
+    :type sender_chat: :class:`Chat`
+
+    :param author_signature: Optional. Author signature for certain cases
+    :type author_signature: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`MessageOrigin`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+
+        message_type = obj.get('type')
+        if message_type == 'user':
+            sender_user = User.de_json(obj.get('sender_user'))
+            return MessageOriginUser(date=obj.get('date'), sender_user=sender_user)
+        elif message_type == 'hidden_user':
+            return MessageOriginHiddenUser(date=obj.get('date'), sender_user_name=obj.get('sender_user_name'))
+        elif message_type == 'chat':
+            sender_chat = Chat.de_json(obj.get('sender_chat'))
+            return MessageOriginChat(date=obj.get('date'), sender_chat=sender_chat, author_signature=obj.get('author_signature'))
+        elif message_type == 'channel':
+            chat = Chat.de_json(obj.get('chat'))
+            return MessageOriginChannel(date=obj.get('date'), chat=chat, message_id=obj.get('message_id'), author_signature=obj.get('author_signature'))
+
+    def __init__(self, type: str, date: int) -> None:
+        self.type: str = type
+        self.date: int = date
+
+
+class MessageOriginUser(MessageOrigin):
+    """
+    The message was originally sent by a known user.
+
+    :param sender_user: User that sent the message originally
+    :type sender_user: :class:`User`
+    """
+
+    def __init__(self, date: int, sender_user: Optional[User] = None) -> None:
+        super().__init__('user', date)
+        self.sender_user: Optional[User] = sender_user
+
+
+class MessageOriginHiddenUser(MessageOrigin):
+    """
+    The message was originally sent by an unknown user.
+
+    :param sender_user_name: Name of the user that sent the message originally
+    :type sender_user_name: :obj:`str`
+    """
+
+    def __init__(self, date: int, sender_user_name: Optional[str] = None) -> None:
+        super().__init__('hidden_user', date)
+        self.sender_user_name: Optional[str] = sender_user_name
+
+
+class MessageOriginChat(MessageOrigin):
+    """
+    The message was originally sent on behalf of a chat to a group chat.
+
+    :param sender_chat: Chat that sent the message originally
+    :type sender_chat: :class:`Chat`
+
+    :param author_signature: Optional. For messages originally sent by an anonymous chat administrator, original message author signature
+    :type author_signature: :obj:`str`
+    """
+
+    def __init__(self, date: int, sender_chat: Optional[Chat] = None, author_signature: Optional[str] = None) -> None:
+        super().__init__('chat', date)
+        self.sender_chat: Optional[Chat] = sender_chat
+        self.author_signature: Optional[str] = author_signature
+
+
+class MessageOriginChannel(MessageOrigin):
+    """
+    The message was originally sent to a channel chat.
+
+    :param chat: Channel chat to which the message was originally sent
+    :type chat: :class:`Chat`
+
+    :param message_id: Unique message identifier inside the chat
+    :type message_id: :obj:`int`
+
+    :param author_signature: Optional. Signature of the original post author
+    :type author_signature: :obj:`str`
+    """
+
+    def __init__(self, date: int, chat: Optional[Chat] = None, message_id: Optional[int] = None, author_signature: Optional[str] = None) -> None:
+        super().__init__('channel', date)
+        self.chat: Optional[Chat] = chat
+        self.message_id: Optional[int] = message_id
+        self.author_signature: Optional[str] = author_signature
+
+
+class LinkPreviewOptions(JsonDeserializable):
+    """
+    Describes the options used for link preview generation.
+
+    Telegram documentation: https://core.telegram.org/bots/api#linkpreviewoptions
+
+    :param is_disabled: Optional. True, if the link preview is disabled
+    :type is_disabled: :obj:`bool`
+
+    :param url: Optional. URL to use for the link preview. If empty, then the first URL found in the message text will be used
+    :type url: :obj:`str`
+
+    :param prefer_small_media: Optional. True, if the media in the link preview is supposed to be shrunk; ignored if the URL isn't explicitly specified or media size change isn't supported for the preview
+    :type prefer_small_media: :obj:`bool`
+
+    :param prefer_large_media: Optional. True, if the media in the link preview is supposed to be enlarged; ignored if the URL isn't explicitly specified or media size change isn't supported for the preview
+    :type prefer_large_media: :obj:`bool`
+
+    :param show_above_text: Optional. True, if the link preview must be shown above the message text; otherwise, the link preview will be shown below the message text
+    :type show_above_text: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`LinkPreviewOptions`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+
+        return cls(is_disabled=obj.get('is_disabled'), url=obj.get('url'), prefer_small_media=obj.get('prefer_small_media'),
+                        prefer_large_media=obj.get('prefer_large_media'), show_above_text=obj.get('show_above_text'))
+    
+
+    def __init__(self, is_disabled: Optional[bool] = None, url: Optional[str] = None,
+                 prefer_small_media: Optional[bool] = None, prefer_large_media: Optional[bool] = None,
+                 show_above_text: Optional[bool] = None) -> None:
+        self.is_disabled: Optional[bool] = is_disabled
+        self.url: Optional[str] = url
+        self.prefer_small_media: Optional[bool] = prefer_small_media
+        self.prefer_large_media: Optional[bool] = prefer_large_media
+        self.show_above_text: Optional[bool] = show_above_text
+
+
+class Giveaway(JsonDeserializable):
+    """
+    This object represents a message about a scheduled giveaway.
+
+    Telegram documentation: https://core.telegram.org/bots/api#giveaway
+
+    :param chats: The list of chats which the user must join to participate in the giveaway
+    :type chats: :obj:`list` of :class:`Chat`
+
+    :param winners_selection_date: Point in time (Unix timestamp) when winners of the giveaway will be selected
+    :type winners_selection_date: :obj:`int`
+
+    :param winner_count: The number of users which are supposed to be selected as winners of the giveaway
+    :type winner_count: :obj:`int`
+
+    :param only_new_members: Optional. True, if only users who join the chats after the giveaway started should be eligible to win
+    :type only_new_members: :obj:`bool`
+
+    :param has_public_winners: Optional. True, if the list of giveaway winners will be visible to everyone
+    :type has_public_winners: :obj:`bool`
+
+    :param prize_description: Optional. Description of additional giveaway prize
+    :type prize_description: :obj:`str`
+
+    :param country_codes: Optional. A list of two-letter ISO 3166-1 alpha-2 country codes indicating the countries from which eligible users for the giveaway must come. If empty, then all users can participate in the giveaway.
+    :type country_codes: :obj:`list` of :obj:`str`
+
+    :param premium_subscription_month_count: Optional. The number of months the Telegram Premium subscription won from the giveaway will be active for
+    :type premium_subscription_month_count: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`Giveaway`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+
+        chats = [Chat.de_json(chat) for chat in obj.get('chats', [])]
+
+        return cls(**obj, chats=chats)
+
+    def __init__(self, chats: List[Chat], winners_selection_date: int, winner_count: int,
+                 only_new_members: Optional[bool] = None, has_public_winners: Optional[bool] = None,
+                 prize_description: Optional[str] = None, country_codes: Optional[List[str]] = None,
+                 premium_subscription_month_count: Optional[int] = None) -> None:
+        self.chats: List[Chat] = chats
+        self.winners_selection_date: int = winners_selection_date
+        self.winner_count: int = winner_count
+        self.only_new_members: Optional[bool] = only_new_members
+        self.has_public_winners: Optional[bool] = has_public_winners
+        self.prize_description: Optional[str] = prize_description
+        self.country_codes: Optional[List[str]] = country_codes or []
+        self.premium_subscription_month_count: Optional[int] = premium_subscription_month_count
+
+class GiveawayWinners(JsonDeserializable):
+    """
+    This object represents a message about the completion of a giveaway with public winners.
+
+    Telegram documentation: https://core.telegram.org/bots/api#giveawaywinners
+
+    :param chat: The chat that created the giveaway
+    :type chat: :class:`Chat`
+
+    :param giveaway_message_id: Identifier of the messsage with the giveaway in the chat
+    :type giveaway_message_id: :obj:`int`
+
+    :param winners_selection_date: Point in time (Unix timestamp) when winners of the giveaway were selected
+    :type winners_selection_date: :obj:`int`
+
+    :param winner_count: Total number of winners in the giveaway
+    :type winner_count: :obj:`int`
+
+    :param winners: List of up to 100 winners of the giveaway
+    :type winners: :obj:`list` of :class:`User`
+
+    :param additional_chat_count: Optional. The number of other chats the user had to join in order to be eligible for the giveaway
+    :type additional_chat_count: :obj:`int`
+
+    :param premium_subscription_month_count: Optional. The number of months the Telegram Premium subscription won from the giveaway will be active for
+    :type premium_subscription_month_count: :obj:`int`
+
+    :param unclaimed_prize_count: Optional. Number of undistributed prizes
+    :type unclaimed_prize_count: :obj:`int`
+
+    :param only_new_members: Optional. True, if only users who had joined the chats after the giveaway started were eligible to win
+    :type only_new_members: :obj:`bool`
+
+    :param was_refunded: Optional. True, if the giveaway was canceled because the payment for it was refunded
+    :type was_refunded: :obj:`bool`
+
+    :param prize_description: Optional. Description of additional giveaway prize
+    :type prize_description: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`GiveawayWinners`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+
+        obj['chat'] = Chat.de_json(obj.get('chat'))
+        obj['winners'] = [User.de_json(user) for user in obj.get('winners', [])]
+
+        return cls(**obj)
+    
+    def __init__(self, chat: Chat, giveaway_message_id: int, winners_selection_date: int, winner_count: int,
+                 winners: List[User], additional_chat_count: Optional[int] = None,
+                 premium_subscription_month_count: Optional[int] = None, unclaimed_prize_count: Optional[int] = None,
+                 only_new_members: Optional[bool] = None, was_refunded: Optional[bool] = None,
+                 prize_description: Optional[str] = None) -> None:
+        self.chat: Chat = chat
+        self.giveaway_message_id: int = giveaway_message_id
+        self.winners_selection_date: int = winners_selection_date
+        self.winner_count: int = winner_count
+        self.winners: List[User] = winners
+        self.additional_chat_count: Optional[int] = additional_chat_count
+        self.premium_subscription_month_count: Optional[int] = premium_subscription_month_count
+        self.unclaimed_prize_count: Optional[int] = unclaimed_prize_count
+        self.only_new_members: Optional[bool] = only_new_members
+        self.was_refunded: Optional[bool] = was_refunded
+        self.prize_description: Optional[str] = prize_description
+        
+
+        

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -565,6 +565,22 @@ class Chat(JsonDeserializable):
         Returned only in getChat.
     :type available_reactions: :obj:`list` of :class:`telebot.types.ReactionType`
 
+    :param accent_color_id: Optional. Optional. Identifier of the accent color for the chat name and backgrounds of the chat photo,
+        reply header, and link preview. See accent colors for more details. Returned only in getChat. Always returned in getChat.
+    :type accent_color_id: :obj:`int`
+
+    :param background_custom_emoji_id: Optional. Custom emoji identifier of emoji chosen by the chat for the reply header
+        and link preview background. Returned only in getChat.
+    :type background_custom_emoji_id: :obj:`str`
+
+    :param profile_accent_color_id: Optional. Identifier of the accent color for the chat's profile background.
+        See profile accent colors for more details. Returned only in getChat.
+    :type profile_accent_color_id: :obj:`int`
+
+    :param profile_background_custom_emoji_id: Optional. Custom emoji identifier of the emoji chosen by the chat for its profile background.
+        Returned only in getChat.
+    :type profile_background_custom_emoji_id: :obj:`str`
+
     :param emoji_status_custom_emoji_id: Optional. Custom emoji identifier of emoji status of the other party in a private chat.
         Returned only in getChat.
     :type emoji_status_custom_emoji_id: :obj:`str`
@@ -626,6 +642,10 @@ class Chat(JsonDeserializable):
         chats. Returned only in getChat.
     :type has_protected_content: :obj:`bool`
 
+    :param has_visible_history: Optional. True, if new chat members will have access to old messages;
+        available only to chat administrators. Returned only in getChat.
+    :type has_visible_history: :obj:`bool`
+
     :param sticker_set_name: Optional. For supergroups, name of group sticker set. Returned only in getChat.
     :type sticker_set_name: :obj:`str`
 
@@ -671,7 +691,8 @@ class Chat(JsonDeserializable):
                  join_to_send_messages=None, join_by_request=None, has_restricted_voice_and_video_messages=None, 
                  is_forum=None, active_usernames=None, emoji_status_custom_emoji_id=None,
                  has_hidden_members=None, has_aggressive_anti_spam_enabled=None, emoji_status_expiration_date=None, 
-                 available_reactions=None,**kwargs):
+                 available_reactions=None, accent_color_id=None, background_custom_emoji_id=None, profile_accent_color_id=None,
+                 profile_background_custom_emoji_id=None, has_visible_history=None,**kwargs):
         self.id: int = id
         self.type: str = type
         self.title: str = title
@@ -702,6 +723,12 @@ class Chat(JsonDeserializable):
         self.has_aggressive_anti_spam_enabled: bool = has_aggressive_anti_spam_enabled
         self.emoji_status_expiration_date: int = emoji_status_expiration_date
         self.available_reactions: List[ReactionType] = available_reactions
+        self.accent_color_id: int = accent_color_id
+        self.background_custom_emoji_id: str = background_custom_emoji_id
+        self.profile_accent_color_id: int = profile_accent_color_id
+        self.profile_background_custom_emoji_id: str = profile_background_custom_emoji_id
+        self.has_visible_history: bool = has_visible_history
+
 
 
 class MessageID(JsonDeserializable):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -127,6 +127,10 @@ class Update(JsonDeserializable):
     :param edited_channel_post: Optional. New version of a channel post that is known to the bot and was edited
     :type edited_channel_post: :class:`telebot.types.Message`
 
+    :param message_reaction: Optional. A reaction to a message was changed by a user. The bot must be an administrator in the chat
+        and must explicitly specify "message_reaction" in the list of allowed_updates to receive these updates. The update isn't received for reactions set by bots.
+    :type message_reaction: :class:`telebot.types.MessageReactionUpdated`
+
     :param inline_query: Optional. New incoming inline query
     :type inline_query: :class:`telebot.types.InlineQuery`
 
@@ -188,13 +192,14 @@ class Update(JsonDeserializable):
         my_chat_member = ChatMemberUpdated.de_json(obj.get('my_chat_member'))
         chat_member = ChatMemberUpdated.de_json(obj.get('chat_member'))
         chat_join_request = ChatJoinRequest.de_json(obj.get('chat_join_request'))
+        message_reaction = MessageReactionUpdated.de_json(obj.get('message_reaction'))
         return cls(update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                    chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
                    my_chat_member, chat_member, chat_join_request)
 
     def __init__(self, update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                  chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                 my_chat_member, chat_member, chat_join_request):
+                 my_chat_member, chat_member, chat_join_request, message_reaction):
         self.update_id = update_id
         self.message = message
         self.edited_message = edited_message
@@ -210,6 +215,7 @@ class Update(JsonDeserializable):
         self.my_chat_member = my_chat_member
         self.chat_member = chat_member
         self.chat_join_request = chat_join_request
+        self.message_reaction = message_reaction
 
 
 class ChatMemberUpdated(JsonDeserializable):
@@ -7922,3 +7928,52 @@ class ReactionTypeCustomEmoji(ReactionType):
         json_dict['custom_emoji'] = self.custom_emoji
 
         return json_dict
+    
+
+class MessageReactionUpdated(JsonDeserializable):
+    """
+    This object represents a service message about a change in the list of the current user's reactions to a message.
+
+    Telegram documentation: https://core.telegram.org/bots/api#messagereactionupdated
+
+    :param chat: The chat containing the message the user reacted to
+    :type chat: :class:`telebot.types.Chat`
+
+    :param message_id: Unique identifier of the message inside the chat
+    :type message_id: :obj:`int`
+
+    :param user: Optional. The user that changed the reaction, if the user isn't anonymous
+    :type user: :class:`telebot.types.User`
+
+    :param actor_chat: Optional. The chat on behalf of which the reaction was changed, if the user is anonymous
+    :type actor_chat: :class:`telebot.types.Chat`
+
+    :param date: Date of the change in Unix time
+    :type date: :obj:`int`
+
+    :param old_reaction: Previous list of reaction types that were set by the user
+    :type old_reaction: :obj:`list` of :class:`ReactionType`
+
+    :param new_reaction: New list of reaction types that have been set by the user
+    :type new_reaction: :obj:`list` of :class:`ReactionType`
+
+    :return: Instance of the class
+    :rtype: :class:`MessageReactionUpdated`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None:
+            return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+
+    def __init__(self, chat: Chat, message_id: int, date: int, old_reaction: List[ReactionType], new_reaction: List[ReactionType],
+                 user: Optional[User]=None, actor_chat: Optional[Chat]=None) -> None:
+        self.chat: Chat = chat
+        self.message_id: int = message_id
+        self.user: Optional[User] = user
+        self.actor_chat: Optional[Chat] = actor_chat
+        self.date: int = date
+        self.old_reaction: List[ReactionType] = old_reaction
+        self.new_reaction: List[ReactionType] = new_reaction

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -45,7 +45,7 @@ content_type_service = [
 update_types = [
     "message", "edited_message", "channel_post", "edited_channel_post", "inline_query", "chosen_inline_result",
     "callback_query", "shipping_query", "pre_checkout_query", "poll", "poll_answer", "my_chat_member", "chat_member",
-    "chat_join_request", "message_reaction"
+    "chat_join_request", "message_reaction", "message_reaction_count"
 ]
 
 

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -45,7 +45,7 @@ content_type_service = [
 update_types = [
     "message", "edited_message", "channel_post", "edited_channel_post", "inline_query", "chosen_inline_result",
     "callback_query", "shipping_query", "pre_checkout_query", "poll", "poll_answer", "my_chat_member", "chat_member",
-    "chat_join_request",
+    "chat_join_request", "message_reaction"
 ]
 
 

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -45,7 +45,7 @@ content_type_service = [
 update_types = [
     "message", "edited_message", "channel_post", "edited_channel_post", "inline_query", "chosen_inline_result",
     "callback_query", "shipping_query", "pre_checkout_query", "poll", "poll_answer", "my_chat_member", "chat_member",
-    "chat_join_request", "message_reaction", "message_reaction_count"
+    "chat_join_request", "message_reaction", "message_reaction_count", "chat_boost", "removed_chat_boost",
 ]
 
 

--- a/tests/test_handler_backends.py
+++ b/tests/test_handler_backends.py
@@ -65,9 +65,10 @@ def update_type(message):
     my_chat_member = None
     chat_member = None
     chat_join_request = None
+    message_reaction = None
     return types.Update(1001234038283, message, edited_message, channel_post, edited_channel_post, inline_query,
                         chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                        my_chat_member, chat_member, chat_join_request)
+                        my_chat_member, chat_member, chat_join_request, message_reaction)
 
 
 @pytest.fixture()
@@ -85,9 +86,10 @@ def reply_to_message_update_type(reply_to_message):
     my_chat_member = None
     chat_member = None
     chat_join_request = None
+    message_reaction = None
     return types.Update(1001234038284, reply_to_message, edited_message, channel_post, edited_channel_post,
                         inline_query, chosen_inline_result, callback_query, shipping_query, pre_checkout_query, 
-                        poll, poll_answer, my_chat_member, chat_member, chat_join_request)
+                        poll, poll_answer, my_chat_member, chat_member, chat_join_request, message_reaction)
 
 
 def next_handler(message):

--- a/tests/test_handler_backends.py
+++ b/tests/test_handler_backends.py
@@ -66,9 +66,10 @@ def update_type(message):
     chat_member = None
     chat_join_request = None
     message_reaction = None
+    message_reaction_count = None
     return types.Update(1001234038283, message, edited_message, channel_post, edited_channel_post, inline_query,
                         chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                        my_chat_member, chat_member, chat_join_request, message_reaction)
+                        my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count)
 
 
 @pytest.fixture()
@@ -87,9 +88,10 @@ def reply_to_message_update_type(reply_to_message):
     chat_member = None
     chat_join_request = None
     message_reaction = None
+    message_reaction_count = None
     return types.Update(1001234038284, reply_to_message, edited_message, channel_post, edited_channel_post,
                         inline_query, chosen_inline_result, callback_query, shipping_query, pre_checkout_query, 
-                        poll, poll_answer, my_chat_member, chat_member, chat_join_request, message_reaction)
+                        poll, poll_answer, my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count)
 
 
 def next_handler(message):

--- a/tests/test_handler_backends.py
+++ b/tests/test_handler_backends.py
@@ -67,9 +67,11 @@ def update_type(message):
     chat_join_request = None
     message_reaction = None
     message_reaction_count = None
+    chat_boost = None
+    chat_boost_removed = None
     return types.Update(1001234038283, message, edited_message, channel_post, edited_channel_post, inline_query,
                         chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                        my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count)
+                        my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, chat_boost, chat_boost_removed)
 
 
 @pytest.fixture()
@@ -89,9 +91,11 @@ def reply_to_message_update_type(reply_to_message):
     chat_join_request = None
     message_reaction = None
     message_reaction_count = None
+    chat_boost = None
+    chat_boost_removed = None
     return types.Update(1001234038284, reply_to_message, edited_message, channel_post, edited_channel_post,
                         inline_query, chosen_inline_result, callback_query, shipping_query, pre_checkout_query, 
-                        poll, poll_answer, my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count)
+                        poll, poll_answer, my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, chat_boost, chat_boost_removed)
 
 
 def next_handler(message):

--- a/tests/test_telebot.py
+++ b/tests/test_telebot.py
@@ -544,9 +544,11 @@ let number = loop {
         chat_join_request = None
         message_reaction = None
         message_reaction_count = None
+        chat_boost = None
+        chat_boost_removed = None
         return types.Update(-1001234038283, message, edited_message, channel_post, edited_channel_post, inline_query,
                             chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                            my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count)
+                            my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, chat_boost, chat_boost_removed)
 
     def test_is_string_unicode(self):
         s1 = u'string'

--- a/tests/test_telebot.py
+++ b/tests/test_telebot.py
@@ -543,9 +543,10 @@ let number = loop {
         chat_member = None
         chat_join_request = None
         message_reaction = None
+        message_reaction_count = None
         return types.Update(-1001234038283, message, edited_message, channel_post, edited_channel_post, inline_query,
                             chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                            my_chat_member, chat_member, chat_join_request, message_reaction)
+                            my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count)
 
     def test_is_string_unicode(self):
         s1 = u'string'

--- a/tests/test_telebot.py
+++ b/tests/test_telebot.py
@@ -542,9 +542,10 @@ let number = loop {
         my_chat_member = None
         chat_member = None
         chat_join_request = None
+        message_reaction = None
         return types.Update(-1001234038283, message, edited_message, channel_post, edited_channel_post, inline_query,
                             chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                            my_chat_member, chat_member, chat_join_request)
+                            my_chat_member, chat_member, chat_join_request, message_reaction)
 
     def test_is_string_unicode(self):
         s1 = u'string'


### PR DESCRIPTION
December 29, 2023
Bot API 7.0

### Reactions

- [x] Added the classes [ReactionTypeEmoji](https://core.telegram.org/bots/api#reactiontypeemoji) and [ReactionTypeCustomEmoji](https://core.telegram.org/bots/api#reactiontypecustomemoji) representing different types of reaction.
- [x] Added updates about a reaction change on a message with non-anonymous reactions, represented by the class [MessageReactionUpdated](https://core.telegram.org/bots/api#messagereactionupdated) and the field message_reaction in the class [Update](https://core.telegram.org/bots/api#update). The bot must explicitly allow the update to receive it.
- [x] Added updates about reaction changes on a message with anonymous reactions, represented by the class [MessageReactionCountUpdated](https://core.telegram.org/bots/api#messagereactioncountupdated) and the field message_reaction_count in the class [Update](https://core.telegram.org/bots/api#update). The bot must explicitly allow the update to receive it.
- [x] Added the method [setMessageReaction](https://core.telegram.org/bots/api#setmessagereaction) that allows bots to react to messages.
- [x] Added the field available_reactions to the class [Chat](https://core.telegram.org/bots/api#chat).
### Replies 2.0

- [x] Added the ability to reply to messages in other chats or forum topics.
- [x] Added the class [ExternalReplyInfo](https://core.telegram.org/bots/api#externalreplyinfo) and the field external_reply of type [ExternalReplyInfo](https://core.telegram.org/bots/api#externalreplyinfo) to the class [Message](https://core.telegram.org/bots/api#message), containing information about a message that is replied to by the current message, but can be from another chat or forum topic.
- [x] Added the ability to quote a part of the replied message.
- [x] Added the class [TextQuote](https://core.telegram.org/bots/api#textquote) and the field quote of type [TextQuote](https://core.telegram.org/bots/api#textquote) to the class Message, which contains the part of the replied message text or caption that is quoted in the current message.
- [x] Added the class [ReplyParameters](https://core.telegram.org/bots/api#replyparameters) and replaced parameters reply_to_message_id and allow_sending_without_reply in the methods [copyMessage](https://core.telegram.org/bots/api#copymessage), [sendMessage](https://core.telegram.org/bots/api#sendmessage), [sendPhoto](https://core.telegram.org/bots/api#sendphoto), [sendVideo](https://core.telegram.org/bots/api#sendvideo), [sendAnimation](https://core.telegram.org/bots/api#sendanimation), [sendAudio](https://core.telegram.org/bots/api#sendaudio), [sendDocument](https://core.telegram.org/bots/api#senddocument), [sendSticker](https://core.telegram.org/bots/api#sendsticker), [sendVideoNote](https://core.telegram.org/bots/api#sendvideonote), [sendVoice](https://core.telegram.org/bots/api#sendvoice), [sendLocation](https://core.telegram.org/bots/api#sendlocation), [sendVenue](https://core.telegram.org/bots/api#sendvenue), [sendContact](https://core.telegram.org/bots/api#sendcontact), [sendPoll](https://core.telegram.org/bots/api#sendpoll), [sendDice](https://core.telegram.org/bots/api#senddice), [sendInvoice](https://core.telegram.org/bots/api#sendinvoice), [sendGame](https://core.telegram.org/bots/api#sendgame), and [sendMediaGroup](https://core.telegram.org/bots/api#sendmediagroup) with the field reply_parameters of type [ReplyParameters](https://core.telegram.org/bots/api#replyparameters).
### Link Preview Customization

- [x] Allowed to explicitly specify the URL that will be used for link preview generation in outgoing text messages.
- [x] Allowed to position link previews above the message text.
- [x] Allowed to choose media size in link previews.
- [x] Added the class [LinkPreviewOptions](https://core.telegram.org/bots/api#linkpreviewoptions) and replaced the parameter disable_web_page_preview with link_preview_options in the methods [sendMessage](https://core.telegram.org/bots/api#sendmessage) and [editMessageText](https://core.telegram.org/bots/api#editmessagetext).
- [x] Replaced the field disable_web_page_preview with link_preview_options in the class [InputTextMessageContent](https://core.telegram.org/bots/api#inputtextmessagecontent).
- [x] Added the field link_preview_options to the class [Message](https://core.telegram.org/bots/api#message) with information about the link preview options used to send the message.
### Block Quotation

- [x] Added support for “blockquote” entities in received messages.
- [x] Added support for “blockquote” entity parsing in “MarkdownV2” and “HTML” parse modes.
- [x] Allowed to explicitly specify “blockquote” entities in formatted texts.
### Multiple Message Actions

- [x] Added the method [deleteMessages](https://core.telegram.org/bots/api#deletemessages) to allow the deletion of multiple messages in a single request.
- [x] Added the method [forwardMessages](https://core.telegram.org/bots/api#forwardmessages) for forwarding of multiple messages in a single request.
- [x] Added the method [copyMessages](https://core.telegram.org/bots/api#copymessages) for copying of multiple messages in a single request.
### Request for multiple users

- [x] Renamed the class KeyboardButtonRequestUser to [KeyboardButtonRequestUsers](https://core.telegram.org/bots/api#keyboardbuttonrequestusers) and added the field max_quantity to it.
- [x] Renamed the field request_user in the class [KeyboardButton](https://core.telegram.org/bots/api#keyboardbutton) to request_users. The old name will still work for backward compatibility.
- [x] Added the class [UsersShared](https://core.telegram.org/bots/api#usersshared).
- [x] Replaced the field user_shared in the class [Message](https://core.telegram.org/bots/api#message) with the field users_shared.
### Chat Boost

- [x] Added updates about chat boost changes, represented by the classes [ChatBoostUpdated](https://core.telegram.org/bots/api#chatboostupdated) and [ChatBoostRemoved](https://core.telegram.org/bots/api#chatboostremoved) and the fields chat_boost and removed_chat_boost in the class [Update](https://core.telegram.org/bots/api#update). The bot must be an administrator in the chat to receive these updates.
- [x] Added the classes [ChatBoostSourcePremium](https://core.telegram.org/bots/api#chatboostsourcepremium), [ChatBoostSourceGiftCode](https://core.telegram.org/bots/api#chatboostsourcegiftcode) and [ChatBoostSourceGiveaway](https://core.telegram.org/bots/api#chatboostsourcegiveaway), representing different sources of a chat boost.
- [x] Added the method [getUserChatBoosts](https://core.telegram.org/bots/api#getuserchatboosts) for obtaining the list of all active boosts a user has contributed to a chat.
### Giveaway

- [x] Added the class [Giveaway](https://core.telegram.org/bots/api#giveaway) and the field giveaway to the class [Message](https://core.telegram.org/bots/api#message) for messages about scheduled giveaways.
- [x] Added the class [GiveawayCreated](https://core.telegram.org/bots/api#giveawaycreated) and the field giveaway_created to the class [Message](https://core.telegram.org/bots/api#message) for service messages about the creation of a scheduled giveaway.
- [x] Added the class [GiveawayWinners](https://core.telegram.org/bots/api#giveawaywinners) and the field giveaway_winners to the class [Message](https://core.telegram.org/bots/api#message) for messages about the completion of a giveaway with public winners.
- [x] Added the class [GiveawayCompleted](https://core.telegram.org/bots/api#giveawaycompleted) and the field giveaway_completed to the class [Message](https://core.telegram.org/bots/api#message) for service messages about the completion of a giveaway without public winners.

### Other Changes

- [x] Added support for the fields emoji_status_custom_emoji_id and emoji_status_expiration_date in the class [Chat](https://core.telegram.org/bots/api#chat) for non-private chats.
- [x] Added the fields accent_color_id, background_custom_emoji_id, profile_accent_color_id, and profile_background_custom_emoji_id to the class [Chat](https://core.telegram.org/bots/api#chat).
- [x] Added the field has_visible_history to the class [Chat](https://core.telegram.org/bots/api#chat).
- [x] Added the class [MessageOrigin](https://core.telegram.org/bots/api#messageorigin) and replaced the fields forward_from, forward_from_chat, forward_from_message_id, forward_signature, forward_sender_name, and forward_date with the field forward_origin of type [MessageOrigin](https://core.telegram.org/bots/api#messageorigin) in the class [Message](https://core.telegram.org/bots/api#message).
- [ ] Improved documentation for the field message of the class [callbackQuery](https://core.telegram.org/bots/api#callbackquery) and the field pinned_message of the class [Message](https://core.telegram.org/bots/api#message) by adding the classes [MaybeInaccessibleMessage](https://core.telegram.org/bots/api#maybeinaccessiblemessage) and [InaccessibleMessage](https://core.telegram.org/bots/api#inaccessiblemessage).