### PR TITLE
Fix preview link options if link_preview_options not provided

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -4452,6 +4452,11 @@ class TeleBot:
         if link_preview_options and (link_preview_options.is_disabled is None):
             link_preview_options.is_disabled = self.disable_web_page_preview
 
+        # Fix preview link options if link_preview_options not provided. Get param from class
+        if not link_preview_options and self.disable_web_page_preview:
+            # create a LinkPreviewOptions object
+            link_preview_options = types.LinkPreviewOptions(is_disabled=self.disable_web_page_preview)
+
         result = apihelper.edit_message_text(
             self.token, text, chat_id=chat_id, message_id=message_id, inline_message_id=inline_message_id,
             parse_mode=parse_mode, entities=entities, reply_markup=reply_markup, link_preview_options=link_preview_options)

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1664,6 +1664,11 @@ class TeleBot:
         if link_preview_options and (link_preview_options.is_disabled is None):
             link_preview_options.is_disabled = self.disable_web_page_preview
 
+        # Fix preview link options if link_preview_options not provided. Get param from class
+        if not link_preview_options and self.disable_web_page_preview:
+            # create a LinkPreviewOptions object
+            link_preview_options = types.LinkPreviewOptions(is_disabled=self.disable_web_page_preview)
+
         return types.Message.de_json(
             apihelper.send_message(
                 self.token, chat_id, text,

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -2739,6 +2739,11 @@ class AsyncTeleBot:
         if link_preview_options and (link_preview_options.is_disabled is None):
             link_preview_options.is_disabled = self.disable_web_page_preview
 
+        # Fix preview link options if link_preview_options not provided. Get param from class
+        if not link_preview_options and self.disable_web_page_preview:
+            # create a LinkPreviewOptions object
+            link_preview_options = types.LinkPreviewOptions(is_disabled=self.disable_web_page_preview)
+
         return types.Message.de_json(
             await asyncio_helper.send_message(
                 self.token, chat_id, text,
@@ -5467,6 +5472,11 @@ class AsyncTeleBot:
 
         if link_preview_options and (link_preview_options.is_disabled is None):
             link_preview_options.is_disabled = self.disable_web_page_preview
+
+        # Fix preview link options if link_preview_options not provided. Get param from class
+        if not link_preview_options and self.disable_web_page_preview:
+            # create a LinkPreviewOptions object
+            link_preview_options = types.LinkPreviewOptions(is_disabled=self.disable_web_page_preview)
 
         result = await asyncio_helper.edit_message_text(self.token, text, chat_id, message_id, inline_message_id, parse_mode,
                                              entities, reply_markup, link_preview_options)


### PR DESCRIPTION
Fix preview link options if link_preview_options not provided. Get param from class

## Description
Include changes, new features and etc:

## Describe your tests
Tested in my bot project

Python version: 3.10

OS: Windows

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async
