### PR TITLE
Fix deprecated parameters

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -3472,7 +3472,7 @@ class TeleBot:
                less than 30 seconds from the current time they are considered to be banned forever
         :type until_date: :obj:`int` or :obj:`datetime`
 
-        :param revoke_messages: Bool: Pass True to delete all messages from the chat for the user that is being removed.
+        :param revoke_messages: Pass True to delete all messages from the chat for the user that is being removed.
             If False, the user will be able to see messages in the group that were sent before the user was removed. 
             Always True for supergroups and channels.
         :type revoke_messages: :obj:`bool`
@@ -3545,7 +3545,7 @@ class TeleBot:
         :param until_date: Date when restrictions will be lifted for the user, unix time.
             If user is restricted for more than 366 days or less than 30 seconds from the current time,
             they are considered to be restricted forever
-        :type until_date: :obj:`int` or :obj:`datetime`
+        :type until_date: :obj:`int` or :obj:`datetime`, optional
 
         :param can_send_messages: deprecated
         :type can_send_messages: :obj:`bool`
@@ -3571,10 +3571,11 @@ class TeleBot:
         :param can_pin_messages: deprecated
         :type can_pin_messages: :obj:`bool`
 
-        :param use_independent_chat_permissions: Optional	Pass True if chat permissions are set independently.
+        :param use_independent_chat_permissions: Pass True if chat permissions are set independently.
             Otherwise, the can_send_other_messages and can_add_web_page_previews permissions will imply the can_send_messages,
             can_send_audios, can_send_documents, can_send_photos, can_send_videos, can_send_video_notes, and can_send_voice_notes
             permissions; the can_send_polls permission will imply the can_send_messages permission.
+        :type use_independent_chat_permissions: :obj:`bool`, optional
 
         :param permissions: ChatPermissions object defining permissions.
         :type permissions: :class:`telebot.types.ChatPermissions`
@@ -5251,14 +5252,16 @@ class TeleBot:
         """
         if kwargs:
             reply_parameters = kwargs.pop("reply_parameters", None)
+            if "allow_sending_without_reply" in kwargs:
+                logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
         else:
             reply_parameters = None
-        if not reply_parameters:
-            reply_parameters = types.ReplyParameters(message.message_id)
 
-        if "allow_sending_without_reply" in kwargs:
-            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-            reply_parameters.allow_sending_without_reply = kwargs.pop("allow_sending_without_reply")
+        if not reply_parameters:
+            reply_parameters = types.ReplyParameters(
+                message.message_id,
+                allow_sending_without_reply=kwargs.pop("allow_sending_without_reply", None) if kwargs else None
+            )
 
         return self.send_message(message.chat.id, text, reply_parameters=reply_parameters, **kwargs)
 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5249,8 +5249,8 @@ class TeleBot:
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
-        if "reply_parameters" in kwargs:
-            reply_parameters = kwargs["reply_parameters"]
+        if kwargs:
+            reply_parameters = kwargs.pop("reply_parameters", None)
         else:
             reply_parameters = None
         if not reply_parameters:

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -3547,48 +3547,43 @@ class TeleBot:
             they are considered to be restricted forever
         :type until_date: :obj:`int` or :obj:`datetime`
 
-        :param can_send_messages: Pass True, if the user can send text messages, contacts, locations and venues
+        :param can_send_messages: deprecated
         :type can_send_messages: :obj:`bool`
         
-        :param can_send_media_messages: Pass True, if the user can send audios, documents, photos, videos, video notes
-            and voice notes, implies can_send_messages
+        :param can_send_media_messages: deprecated
         :type can_send_media_messages: :obj:`bool`
         
-        :param can_send_polls: Pass True, if the user is allowed to send polls, implies can_send_messages
+        :param can_send_polls: deprecated
         :type can_send_polls: :obj:`bool`
 
-        :param can_send_other_messages: Pass True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages
+        :param can_send_other_messages: deprecated
         :type can_send_other_messages: :obj:`bool`
 
-        :param can_add_web_page_previews: Pass True, if the user may add web page previews to their messages,
-            implies can_send_media_messages
+        :param can_add_web_page_previews: deprecated
         :type can_add_web_page_previews: :obj:`bool`
 
-        :param can_change_info: Pass True, if the user is allowed to change the chat title, photo and other settings.
-            Ignored in public supergroups
+        :param can_change_info: deprecated
         :type can_change_info: :obj:`bool`
 
-        :param can_invite_users: Pass True, if the user is allowed to invite new users to the chat,
-            implies can_invite_users
+        :param can_invite_users: deprecated
         :type can_invite_users: :obj:`bool`
 
-        :param can_pin_messages: Pass True, if the user is allowed to pin messages. Ignored in public supergroups
+        :param can_pin_messages: deprecated
         :type can_pin_messages: :obj:`bool`
 
-        :param use_independent_chat_permissions: Pass True if chat permissions are set independently. Otherwise,
-            the can_send_other_messages and can_add_web_page_previews permissions will imply the can_send_messages,
-            can_send_audios, can_send_documents, can_send_photos, can_send_videos, can_send_video_notes, and
-            can_send_voice_notes permissions; the can_send_polls permission will imply the can_send_messages permission.
-        :type use_independent_chat_permissions: :obj:`bool`
+        :param use_independent_chat_permissions: Optional	Pass True if chat permissions are set independently.
+            Otherwise, the can_send_other_messages and can_add_web_page_previews permissions will imply the can_send_messages,
+            can_send_audios, can_send_documents, can_send_photos, can_send_videos, can_send_video_notes, and can_send_voice_notes
+            permissions; the can_send_polls permission will imply the can_send_messages permission.
 
-        :param permissions: Pass ChatPermissions object to set all permissions at once. Use this param instead of
-            passing all boolean parameters.
+        :param permissions: ChatPermissions object defining permissions.
         :type permissions: :class:`telebot.types.ChatPermissions`
 
         :return: True on success
         :rtype: :obj:`bool`
         """
         if permissions is None:
+            logger.warning('The parameters "can_..." are deprecated, use "permissions" instead.')
             permissions = types.ChatPermissions(
                 can_send_messages=can_send_messages,
                 can_send_media_messages=can_send_media_messages,
@@ -3599,7 +3594,6 @@ class TeleBot:
                 can_invite_users=can_invite_users,
                 can_pin_messages=can_pin_messages
             )
-            logger.warning('The parameters "can_..." are deprecated, use "permissions" instead.')
 
         return apihelper.restrict_chat_member(
             self.token, chat_id, user_id, permissions, until_date=until_date,
@@ -5242,8 +5236,8 @@ class TeleBot:
 
     def reply_to(self, message: types.Message, text: str, **kwargs) -> types.Message:
         """
-        Convenience function for `send_message(message.chat.id, text, reply_to_message_id=message.message_id, **kwargs)`
-        
+        Convenience function for `send_message(message.chat.id, text, reply_parameters=(message.message_id...), **kwargs)`
+
         :param message: Instance of :class:`telebot.types.Message`
         :type message: :obj:`types.Message`
 
@@ -5255,7 +5249,18 @@ class TeleBot:
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
-        return self.send_message(message.chat.id, text, reply_to_message_id=message.message_id, **kwargs)
+        if "reply_parameters" in kwargs:
+            reply_parameters = kwargs["reply_parameters"]
+        else:
+            reply_parameters = None
+        if not reply_parameters:
+            reply_parameters = types.ReplyParameters(message.message_id)
+
+        if "allow_sending_without_reply" in kwargs:
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
+            reply_parameters.allow_sending_without_reply = kwargs.pop("allow_sending_without_reply")
+
+        return self.send_message(message.chat.id, text, reply_parameters=reply_parameters, **kwargs)
 
 
     def answer_inline_query(

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1473,11 +1473,9 @@ def send_invoice(
     :param send_phone_number_to_provider: Pass True, if user's phone number should be sent to provider
     :param send_email_to_provider: Pass True, if user's email address should be sent to provider
     :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
-    :param reply_to_message_id: If the message is a reply, ID of the original message
     :param reply_markup: A JSON-serialized object for an inline keyboard. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button
     :param provider_data: A JSON-serialized data about the invoice, which will be shared with the payment provider. A detailed description of required fields should be provided by the payment provider.
     :param timeout:
-    :param allow_sending_without_reply:
     :param max_tip_amount: The maximum accepted amount for tips in the smallest units of the currency
     :param suggested_tip_amounts: A JSON-serialized array of suggested amounts of tips in the smallest units of the currency.
         At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed max_tip_amount.

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -4606,7 +4606,7 @@ class AsyncTeleBot:
         :param until_date: Date when restrictions will be lifted for the user, unix time.
             If user is restricted for more than 366 days or less than 30 seconds from the current time,
             they are considered to be restricted forever
-        :type until_date: :obj:`int` or :obj:`datetime`
+        :type until_date: :obj:`int` or :obj:`datetime`, optional
 
         :param can_send_messages: deprecated
         :type can_send_messages: :obj:`bool`
@@ -4632,10 +4632,11 @@ class AsyncTeleBot:
         :param can_pin_messages: deprecated
         :type can_pin_messages: :obj:`bool`
 
-        :param use_independent_chat_permissions: Optional	Pass True if chat permissions are set independently.
+        :param use_independent_chat_permissions: Pass True if chat permissions are set independently.
             Otherwise, the can_send_other_messages and can_add_web_page_previews permissions will imply the can_send_messages,
             can_send_audios, can_send_documents, can_send_photos, can_send_videos, can_send_video_notes, and can_send_voice_notes
             permissions; the can_send_polls permission will imply the can_send_messages permission.
+        :type use_independent_chat_permissions: :obj:`bool`, optional
 
         :param permissions: Pass ChatPermissions object to set all permissions at once. Use this parameter instead of
             passing all boolean parameters to avoid backward compatibility problems in future.
@@ -6234,14 +6235,16 @@ class AsyncTeleBot:
         """
         if kwargs:
             reply_parameters = kwargs.pop("reply_parameters", None)
+            if "allow_sending_without_reply" in kwargs:
+                logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
         else:
             reply_parameters = None
-        if not reply_parameters:
-            reply_parameters = types.ReplyParameters(message.message_id)
 
-        if "allow_sending_without_reply" in kwargs:
-            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-            reply_parameters.allow_sending_without_reply = kwargs.pop("allow_sending_without_reply")
+        if not reply_parameters:
+            reply_parameters = types.ReplyParameters(
+                message.message_id,
+                allow_sending_without_reply=kwargs.pop("allow_sending_without_reply", None) if kwargs else None
+            )
 
         return await self.send_message(message.chat.id, text, reply_parameters=reply_parameters, **kwargs)
 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6232,8 +6232,8 @@ class AsyncTeleBot:
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
-        if "reply_parameters" in kwargs:
-            reply_parameters = kwargs["reply_parameters"]
+        if kwargs:
+            reply_parameters = kwargs.pop("reply_parameters", None)
         else:
             reply_parameters = None
         if not reply_parameters:

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -4608,39 +4608,34 @@ class AsyncTeleBot:
             they are considered to be restricted forever
         :type until_date: :obj:`int` or :obj:`datetime`
 
-        :param can_send_messages: Pass True, if the user can send text messages, contacts, locations and venues
+        :param can_send_messages: deprecated
         :type can_send_messages: :obj:`bool`
         
-        :param can_send_media_messages: Pass True, if the user can send audios, documents, photos, videos, video notes
-            and voice notes, implies can_send_messages
+        :param can_send_media_messages: deprecated
         :type can_send_media_messages: :obj:`bool`
         
-        :param can_send_polls: Pass True, if the user is allowed to send polls, implies can_send_messages
+        :param can_send_polls: deprecated
         :type can_send_polls: :obj:`bool`
 
-        :param can_send_other_messages: Pass True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages
+        :param can_send_other_messages: deprecated
         :type can_send_other_messages: :obj:`bool`
 
-        :param can_add_web_page_previews: Pass True, if the user may add web page previews to their messages,
-            implies can_send_media_messages
+        :param can_add_web_page_previews: deprecated
         :type can_add_web_page_previews: :obj:`bool`
 
-        :param can_change_info: Pass True, if the user is allowed to change the chat title, photo and other settings.
-            Ignored in public supergroups
+        :param can_change_info: deprecated
         :type can_change_info: :obj:`bool`
 
-        :param can_invite_users: Pass True, if the user is allowed to invite new users to the chat,
-            implies can_invite_users
+        :param can_invite_users: deprecated
         :type can_invite_users: :obj:`bool`
 
-        :param can_pin_messages: Pass True, if the user is allowed to pin messages. Ignored in public supergroups
+        :param can_pin_messages: deprecated
         :type can_pin_messages: :obj:`bool`
 
-        :param use_independent_chat_permissions: Pass True if chat permissions are set independently. Otherwise,
-            the can_send_other_messages and can_add_web_page_previews permissions will imply the can_send_messages,
-            can_send_audios, can_send_documents, can_send_photos, can_send_videos, can_send_video_notes, and
-            can_send_voice_notes permissions; the can_send_polls permission will imply the can_send_messages permission.
-        :type use_independent_chat_permissions: :obj:`bool`
+        :param use_independent_chat_permissions: Optional	Pass True if chat permissions are set independently.
+            Otherwise, the can_send_other_messages and can_add_web_page_previews permissions will imply the can_send_messages,
+            can_send_audios, can_send_documents, can_send_photos, can_send_videos, can_send_video_notes, and can_send_voice_notes
+            permissions; the can_send_polls permission will imply the can_send_messages permission.
 
         :param permissions: Pass ChatPermissions object to set all permissions at once. Use this parameter instead of
             passing all boolean parameters to avoid backward compatibility problems in future.
@@ -6224,7 +6219,7 @@ class AsyncTeleBot:
 
     async def reply_to(self, message: types.Message, text: str, **kwargs) -> types.Message:
         """
-        Convenience function for `send_message(message.chat.id, text, reply_to_message_id=message.message_id, **kwargs)`
+        Convenience function for `send_message(message.chat.id, text, reply_parameters=(message.message_id...), **kwargs)`
         
         :param message: Instance of :class:`telebot.types.Message`
         :type message: :obj:`types.Message`
@@ -6237,7 +6232,18 @@ class AsyncTeleBot:
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
-        return await self.send_message(message.chat.id, text, reply_to_message_id=message.message_id, **kwargs)
+        if "reply_parameters" in kwargs:
+            reply_parameters = kwargs["reply_parameters"]
+        else:
+            reply_parameters = None
+        if not reply_parameters:
+            reply_parameters = types.ReplyParameters(message.message_id)
+
+        if "allow_sending_without_reply" in kwargs:
+            logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
+            reply_parameters.allow_sending_without_reply = kwargs.pop("allow_sending_without_reply")
+
+        return await self.send_message(message.chat.id, text, reply_parameters=reply_parameters, **kwargs)
 
     async def answer_inline_query(
             self, inline_query_id: str, 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1463,11 +1463,9 @@ async def send_invoice(
     :param send_phone_number_to_provider: Pass True, if user's phone number should be sent to provider
     :param send_email_to_provider: Pass True, if user's email address should be sent to provider
     :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
-    :param reply_to_message_id: If the message is a reply, ID of the original message
     :param reply_markup: A JSON-serialized object for an inline keyboard. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button
     :param provider_data: A JSON-serialized data about the invoice, which will be shared with the payment provider. A detailed description of required fields should be provided by the payment provider.
     :param timeout:
-    :param allow_sending_without_reply:
     :param max_tip_amount: The maximum accepted amount for tips in the smallest units of the currency
     :param suggested_tip_amounts: A JSON-serialized array of suggested amounts of tips in the smallest units of the currency.
         At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed max_tip_amount.

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -2226,9 +2226,9 @@ class ForceReply(JsonSerializable):
         1-64 characters
     :type input_field_placeholder: :obj:`str`
 
-    :param selective: Optional. Use this parameter if you want to force reply from specific users only. Targets: 1) users 
-        that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), 
-        sender of the original message.
+    :param selective: Optional. Use this parameter if you want to force reply from specific users only. Targets: 1) users
+        that are @mentioned in the text of the Message object; 2) if the bot's message is a reply to a message in the same
+        chat and forum topic, sender of the original message.
     :type selective: :obj:`bool`
 
     :return: Instance of the class
@@ -2343,10 +2343,11 @@ class ReplyKeyboardMarkup(JsonSerializable):
         active; 1-64 characters
     :type input_field_placeholder: :obj:`str`
 
-    :param selective: Optional. Use this parameter if you want to show the keyboard to specific users only. Targets: 1) 
-        users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has 
-        reply_to_message_id), sender of the original message.Example: A user requests to change the bot's language, bot 
-        replies to the request with a keyboard to select the new language. Other users in the group don't see the keyboard.
+    :param selective: Optional. Use this parameter if you want to show the keyboard to specific users only. Targets:
+        1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply to a message
+        in the same chat and forum topic, sender of the original message. Example: A user requests to change the bot's
+        language, bot replies to the request with a keyboard to select the new language. Other users in the group don't
+        see the keyboard.
     :type selective: :obj:`bool`
 
     :param is_persistent: Optional. Use this parameter if you want to show the keyboard to specific users only.
@@ -3424,7 +3425,7 @@ class ChatPermissions(JsonDeserializable, JsonSerializable, Dictionaryable):
     def de_json(cls, json_string):
         if json_string is None: return json_string
         obj = cls.check_json(json_string, dict_copy=False)
-        return cls(**obj)
+        return cls(**obj, de_json = True)
 
     def __init__(self, can_send_messages=None, can_send_media_messages=None,can_send_audios=None,
                     can_send_documents=None, can_send_photos=None,
@@ -3448,7 +3449,9 @@ class ChatPermissions(JsonDeserializable, JsonSerializable, Dictionaryable):
         self.can_send_video_notes: bool = can_send_video_notes
         self.can_send_voice_notes: bool = can_send_voice_notes
 
-        if can_send_media_messages is not None:
+        if kwargs.get("de_json", False) and can_send_media_messages is not None:
+            # Telegram passes can_send_media_messages in Chat.permissions. Temporary created parameter "de_json" allows avoid
+            # deprection warning and individual parameters overriding.
             logger.warning('The parameter "can_send_media_messages" is deprecated. Use individual parameters like "can_send_audios", "can_send_documents" etc.')
             self.can_send_audios = can_send_media_messages
             self.can_send_documents = can_send_media_messages


### PR DESCRIPTION
## Description
Fix deprecated parameters:
1. Fix descriptions
2. Fix bot.reply_to function
3. Fix ChatPermissions.de_json
