### PR TITLE
Allow to pass no message_id to bot.reply_to

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5263,6 +5263,9 @@ class TeleBot:
                 allow_sending_without_reply=kwargs.pop("allow_sending_without_reply", None) if kwargs else None
             )
 
+        if not reply_parameters.message_id:
+            reply_parameters.message_id = message.message_id
+
         return self.send_message(message.chat.id, text, reply_parameters=reply_parameters, **kwargs)
 
 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6246,6 +6246,9 @@ class AsyncTeleBot:
                 allow_sending_without_reply=kwargs.pop("allow_sending_without_reply", None) if kwargs else None
             )
 
+        if not reply_parameters.message_id:
+            reply_parameters.message_id = message.message_id
+
         return await self.send_message(message.chat.id, text, reply_parameters=reply_parameters, **kwargs)
 
     async def answer_inline_query(


### PR DESCRIPTION
## Description
Allow to pass no message_id to bot.reply_to

## Reason
If you want to pass allow_sending_without_reply to bot.reply_to you need to do:
```
reply_parameters = types.ReplyParameters(message.message_id, allow_sending_without_reply=True)
bot.reply_to(query.message, "Some text", reply_parameters=reply_parameters)
```
Where need to pass message.message_id make bot.reply_to a bit useless.

This proposal allows to use it like this:
```
reply_parameters = types.ReplyParameters(None, allow_sending_without_reply=True)
bot.reply_to(query.message, "Some text", reply_parameters=reply_parameters)
```
