### PR TITLE
fix(hint): add_sticker_to_set -> sticker

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5746,8 +5746,8 @@ class TeleBot:
         :param mask_position: A JSON-serialized object for position where the mask should be placed on faces
         :type mask_position: :class:`telebot.types.MaskPosition`
 
-        :param sticker: A JSON-serialized list of 1-50 initial stickers to be added to the sticker set
-        :type sticker: :obj:`list` of :class:`telebot.types.InputSticker`
+        :param sticker: A JSON-serialized object for stickers to be added to the sticker set
+        :type sticker: :class:`telebot.types.InputSticker`
 
         :return: On success, True is returned.
         :rtype: :obj:`bool`

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5710,7 +5710,7 @@ class TeleBot:
             tgs_sticker: Optional[Union[Any, str]]=None,  
             webm_sticker: Optional[Union[Any, str]]=None,
             mask_position: Optional[types.MaskPosition]=None,
-            sticker: Optional[List[types.InputSticker]]=None) -> bool:
+            sticker: Optional[types.InputSticker]=None) -> bool:
         """
         Use this method to add a new sticker to a set created by the bot.
         The format of the added sticker must match the format of the other stickers in the set.

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6725,8 +6725,8 @@ class AsyncTeleBot:
         :param mask_position: A JSON-serialized object for position where the mask should be placed on faces
         :type mask_position: :class:`telebot.types.MaskPosition`
 
-        :param sticker: A JSON-serialized list of 1-50 initial stickers to be added to the sticker set
-        :type sticker: :obj:`list` of :class:`telebot.types.InputSticker`
+        :param sticker: A JSON-serialized object for stickers to be added to the sticker set
+        :type sticker: :class:`telebot.types.InputSticker`
 
         :return: On success, True is returned.
         :rtype: :obj:`bool`

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6689,7 +6689,7 @@ class AsyncTeleBot:
             tgs_sticker: Optional[Union[Any, str]]=None,  
             webm_sticker: Optional[Union[Any, str]]=None,
             mask_position: Optional[types.MaskPosition]=None,
-            sticker: Optional[List[types.InputSticker]]=None) -> bool:
+            sticker: Optional[types.InputSticker]=None) -> bool:
         """
         Use this method to add a new sticker to a set created by the bot.
         The format of the added sticker must match the format of the other stickers in the set.


### PR DESCRIPTION
## Description
Method hint does not match the actual operation

## Describe your tests
Only the hint is fixed, the implementation remains unchanged

Python version: ALL

OS: ALL

## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async
