### PR TITLE
Fix TextFilter error: if no message text and no caption -> return False

### DIFF
--- a/telebot/custom_filters.py
+++ b/telebot/custom_filters.py
@@ -149,6 +149,8 @@ class TextFilter:
             text = obj.question
         elif isinstance(obj, types.Message):
             text = obj.text or obj.caption
+            if text is None:
+                return False
         elif isinstance(obj, types.CallbackQuery):
             text = obj.data
         elif isinstance(obj, types.InlineQuery):


### PR DESCRIPTION
## Description
Fix TextFilter error when no message text and no message caption (for example when processing photo).

## Describe your tests
How did you test your change?

Python version: Independent (3.11)

OS: Independent (macOS)


## Example:
```python
from telebot.custom_filters import TextFilter

@bot.message_handler(
    content_types=["photo"],
    text=TextFilter(contains=["cat"], ignore_case=True),
)
def handle_cat_photo(message: types.Message):
    bot.send_message(
        message.chat.id,
        "Nice cat!",
    )
```

Previously: Python exception:
```
...
  File "/home/suren/tg-custom-filters/.venv/lib/python3.11/site-packages/telebot/custom_filters.py", line 162, in check
    text = text.lower()
           ^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'lower'
```

Now: if photo has no caption, filter returns False