### PR TITLE
Retry engine 2 backoff fixes

### DIFF
--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -147,6 +147,9 @@ def _make_request(token, method_name, method='get', params=None, files=None):
         # noinspection PyUnresolvedReferences
         retry_strategy = requests.packages.urllib3.util.retry.Retry(
             total=MAX_RETRIES,
+            allowed_methods=None,
+            backoff_factor=RETRY_TIMEOUT,
+            backoff_max=RETRY_TIMEOUT
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         for prefix in ('http://', 'https://'):


### PR DESCRIPTION
## Description
Retry engine 2 behaved differently than retry engine 1.

In particular, POST requests were not retried, because they were not included in the `allowed_methods` parameter of the urllib3 Retry strategy.

Furthermore, requests were retried without delay, ignoring the `RETRY_TIMEOUT` setting, because also the `backoff_` parameters were not implemented in the the urllib3 Retry strategy.

This PR aims to fix these problems, implementing the `allowed_methods`, `backoff_factor` and `backoff_max` parameters in the urllib3 Retry strategy.

It is important to note that `urllib3.util.Retry` does not allow you to directly set a fixed backoff delay, so I set `backoff_factor=RETRY_TIMEOUT` and `backoff_max=RETRY_TIMEOUT`. In this way, already on the second request, the backoff delay exceeds the `backoff_max` and remains so.

For more information, see the [urllib3.util.Retry](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html) documentation.

## Describe your tests
How did you test your change?

Python version: 3.8.10

OS: Ubuntu 20.04 LTS

## Checklist:
- [X] I added/edited example on new feature/change (if exists)
- [X] My changes won't break backward compatibility
- [X] I made changes both for sync and async
