### PR TITLE
BOT API 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">A simple, but extensible Python implementation for the <a href="https://core.telegram.org/bots/api">Telegram Bot API</a>.</p>
 <p align="center">Both synchronous and asynchronous.</p>
 
-## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#february-16-2024">7.1</a>!
+## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#march-31-2024">7.2</a>!
 
 <h2><a href='https://pytba.readthedocs.io/en/latest/index.html'>Official documentation</a></h2>
 <h2><a href='https://pytba.readthedocs.io/ru/latest/index.html'>Official ru documentation</a></h2>

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5543,7 +5543,7 @@ class TeleBot:
         )
 
 
-    def set_sticker_set_thumbnail(self, name: str, user_id: int, thumbnail: Union[Any, str]=None):
+    def set_sticker_set_thumbnail(self, name: str, user_id: int, format: str, thumbnail: Union[Any, str]=None):
         """
         Use this method to set the thumbnail of a sticker set. 
         Animated thumbnails can be set for animated sticker sets only. Returns True on success.
@@ -5559,10 +5559,13 @@ class TeleBot:
         :param thumbnail: A .WEBP or .PNG image with the thumbnail, must be up to 128 kilobytes in size and have a width and height of exactly 100px, or a .TGS animation with a thumbnail up to 32 kilobytes in size (see https://core.telegram.org/stickers#animated-sticker-requirements for animated sticker technical requirements), or a WEBM video with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/stickers#video-sticker-requirements for video sticker technical requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More information on Sending Files ». Animated and video sticker set thumbnails can't be uploaded via HTTP URL. If omitted, then the thumbnail is dropped and the first sticker is used as the thumbnail.
         :type thumbnail: :obj:`filelike object`
 
+        :param format: Format of the thumbnail, must be one of “static” for a .WEBP or .PNG image, “animated” for a .TGS animation, or “video” for a WEBM video
+        :type format: :obj:`str`
+
         :return: On success, True is returned.
         :rtype: :obj:`bool`
         """
-        return apihelper.set_sticker_set_thumbnail(self.token, name, user_id, thumbnail)
+        return apihelper.set_sticker_set_thumbnail(self.token, name, user_id, thumbnail, format)
 
     
     @util.deprecated(deprecation_text="Use set_sticker_set_thumbnail instead")

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5543,12 +5543,12 @@ class TeleBot:
         )
 
 
-    def set_sticker_set_thumbnail(self, name: str, user_id: int, format: str, thumbnail: Union[Any, str]=None):
+    def set_sticker_set_thumbnail(self, name: str, user_id: int, thumbnail: Union[Any, str]=None, format: Optional[str]=None) -> bool:
         """
         Use this method to set the thumbnail of a sticker set. 
         Animated thumbnails can be set for animated sticker sets only. Returns True on success.
 
-        Telegram documentation: https://core.telegram.org/bots/api#setstickersetthumb
+        Telegram documentation: https://core.telegram.org/bots/api#setstickersetthumbnail
 
         :param name: Sticker set name
         :type name: :obj:`str`
@@ -5556,7 +5556,12 @@ class TeleBot:
         :param user_id: User identifier
         :type user_id: :obj:`int`
 
-        :param thumbnail: A .WEBP or .PNG image with the thumbnail, must be up to 128 kilobytes in size and have a width and height of exactly 100px, or a .TGS animation with a thumbnail up to 32 kilobytes in size (see https://core.telegram.org/stickers#animated-sticker-requirements for animated sticker technical requirements), or a WEBM video with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/stickers#video-sticker-requirements for video sticker technical requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More information on Sending Files ». Animated and video sticker set thumbnails can't be uploaded via HTTP URL. If omitted, then the thumbnail is dropped and the first sticker is used as the thumbnail.
+        :param thumbnail: A .WEBP or .PNG image with the thumbnail, must be up to 128 kilobytes in size and have a width and height of exactly 100px, or a .TGS animation
+            with a thumbnail up to 32 kilobytes in size (see https://core.telegram.org/stickers#animated-sticker-requirements for animated sticker technical requirements),
+            or a WEBM video with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/stickers#video-sticker-requirements for video sticker technical
+            requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from
+            the Internet, or upload a new one using multipart/form-data. More information on Sending Files ». Animated and video sticker set thumbnails can't be uploaded via
+            HTTP URL. If omitted, then the thumbnail is dropped and the first sticker is used as the thumbnail.
         :type thumbnail: :obj:`filelike object`
 
         :param format: Format of the thumbnail, must be one of “static” for a .WEBP or .PNG image, “animated” for a .TGS animation, or “video” for a WEBM video
@@ -5565,6 +5570,10 @@ class TeleBot:
         :return: On success, True is returned.
         :rtype: :obj:`bool`
         """
+        if format is None:
+            logger.warning("Format in set_sticker_set_thumbnail cannot be None. Setting format to 'static'.")
+            format = "static"
+
         return apihelper.set_sticker_set_thumbnail(self.token, name, user_id, thumbnail, format)
 
     

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1630,7 +1630,8 @@ class TeleBot:
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            link_preview_options : Optional[types.LinkPreviewOptions]=None) -> types.Message:
+            link_preview_options : Optional[types.LinkPreviewOptions]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send text messages.
 
@@ -1683,6 +1684,9 @@ class TeleBot:
         :param link_preview_options: Link preview options.
         :type link_preview_options: :class:`telebot.types.LinkPreviewOptions`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -1730,7 +1734,7 @@ class TeleBot:
                 self.token, chat_id, text,
                 reply_markup=reply_markup, parse_mode=parse_mode, disable_notification=disable_notification,
                 timeout=timeout, entities=entities, protect_content=protect_content, message_thread_id=message_thread_id,
-                reply_parameters=reply_parameters, link_preview_options=link_preview_options))
+                reply_parameters=reply_parameters, link_preview_options=link_preview_options, business_connection_id=business_connection_id))
 
 
     def forward_message(
@@ -2017,7 +2021,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send an animated emoji that will display a random value. On success, the sent Message is returned.
 
@@ -2056,6 +2061,9 @@ class TeleBot:
         :param reply_parameters: Additional parameters for replies to messages
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2084,7 +2092,7 @@ class TeleBot:
             apihelper.send_dice(
                 self.token, chat_id, emoji=emoji, disable_notification=disable_notification,
                 reply_markup=reply_markup, timeout=timeout, protect_content=protect_content,
-                message_thread_id=message_thread_id, reply_parameters=reply_parameters)
+                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id))
         )
 
 
@@ -2100,7 +2108,8 @@ class TeleBot:
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send photos. On success, the sent Message is returned.
 
@@ -2151,6 +2160,9 @@ class TeleBot:
 
         :param reply_parameters: Additional parameters for replies to messages
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
         
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -2182,7 +2194,7 @@ class TeleBot:
                 self.token, chat_id, photo, caption=caption, reply_markup=reply_markup,
                 parse_mode=parse_mode, disable_notification=disable_notification, timeout=timeout,
                 caption_entities=caption_entities, protect_content=protect_content,
-                message_thread_id=message_thread_id, has_spoiler=has_spoiler, reply_parameters=reply_parameters)
+                message_thread_id=message_thread_id, has_spoiler=has_spoiler, reply_parameters=reply_parameters, business_connection_id=business_connection_id))
         )
 
 
@@ -2201,7 +2213,8 @@ class TeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player.
         Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size,
@@ -2271,6 +2284,9 @@ class TeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2305,7 +2321,7 @@ class TeleBot:
                 self.token, chat_id, audio, caption=caption, duration=duration, performer=performer, title=title,
                 reply_markup=reply_markup, parse_mode=parse_mode, disable_notification=disable_notification,
                 timeout=timeout, thumbnail=thumbnail, caption_entities=caption_entities, protect_content=protect_content,
-                message_thread_id=message_thread_id, reply_parameters=reply_parameters)
+                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
         )
 
 
@@ -2321,7 +2337,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
         For this to work, your audio must be in an .OGG file encoded with OPUS (other formats may be sent as Audio or Document).
@@ -2374,6 +2391,9 @@ class TeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
@@ -2403,7 +2423,7 @@ class TeleBot:
                 self.token, chat_id, voice, caption=caption, duration=duration, reply_markup=reply_markup,
                 parse_mode=parse_mode, disable_notification=disable_notification, timeout=timeout,
                 caption_entities=caption_entities, protect_content=protect_content,
-                message_thread_id=message_thread_id, reply_parameters=reply_parameters)
+                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
         )
 
 
@@ -2423,7 +2443,8 @@ class TeleBot:
             data: Optional[Union[Any, str]]=None,
             protect_content: Optional[bool]=None, message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send general files.
 
@@ -2486,6 +2507,9 @@ class TeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2525,7 +2549,7 @@ class TeleBot:
                 reply_markup=reply_markup, parse_mode=parse_mode, disable_notification=disable_notification,
                 timeout=timeout, caption=caption, thumbnail=thumbnail, caption_entities=caption_entities,
                 disable_content_type_detection=disable_content_type_detection, visible_file_name=visible_file_name,
-                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters)
+                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
         )
 
 
@@ -2541,7 +2565,8 @@ class TeleBot:
             data: Union[Any, str]=None,
             message_thread_id: Optional[int]=None,
             emoji: Optional[str]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers.
         On success, the sent Message is returned.
@@ -2587,6 +2612,9 @@ class TeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2620,7 +2648,7 @@ class TeleBot:
                 self.token, chat_id, sticker, 'sticker',
                 reply_markup=reply_markup, disable_notification=disable_notification, timeout=timeout,
                 protect_content=protect_content, message_thread_id=message_thread_id, emoji=emoji,
-                reply_parameters=reply_parameters)
+                reply_parameters=reply_parameters, business_connection_id=business_connection_id)
         )
 
 
@@ -2644,7 +2672,8 @@ class TeleBot:
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
             thumb: Optional[Union[Any, str]]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
         
@@ -2715,6 +2744,9 @@ class TeleBot:
         :param reply_parameters: Reply parameters
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2755,7 +2787,7 @@ class TeleBot:
                 supports_streaming=supports_streaming, disable_notification=disable_notification, timeout=timeout,
                 thumbnail=thumbnail, height=height, width=width, caption_entities=caption_entities,
                 protect_content=protect_content, message_thread_id=message_thread_id, has_spoiler=has_spoiler,
-                reply_parameters=reply_parameters)
+                reply_parameters=reply_parameters, business_connection_id=business_connection_id)
         )
 
 
@@ -2777,7 +2809,8 @@ class TeleBot:
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
             thumb: Optional[Union[Any, str]]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
@@ -2847,6 +2880,9 @@ class TeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2882,7 +2918,7 @@ class TeleBot:
                 parse_mode=parse_mode, disable_notification=disable_notification, timeout=timeout,
                 thumbnail=thumbnail, caption_entities=caption_entities, protect_content=protect_content,
                 width=width, height=height, message_thread_id=message_thread_id, reply_parameters=reply_parameters,
-                has_spoiler=has_spoiler)
+                has_spoiler=has_spoiler, business_connection_id=business_connection_id)
             )
 
 
@@ -2899,7 +2935,8 @@ class TeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         As of v.4.0, Telegram clients support rounded square MPEG4 videos of up to 1 minute long.
         Use this method to send video messages. On success, the sent Message is returned.
@@ -2954,6 +2991,9 @@ class TeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2986,7 +3026,7 @@ class TeleBot:
             apihelper.send_video_note(
                 self.token, chat_id, data, duration=duration, length=length, reply_markup=reply_markup,
                 disable_notification=disable_notification, timeout=timeout, thumbnail=thumbnail,
-                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters)
+                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
         )
 
 
@@ -3001,7 +3041,8 @@ class TeleBot:
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> List[types.Message]:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> List[types.Message]:
         """
         Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files
         can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned.
@@ -3035,6 +3076,9 @@ class TeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, an array of Messages that were sent is returned.
         :rtype: List[types.Message]
         """
@@ -3061,7 +3105,8 @@ class TeleBot:
 
         result = apihelper.send_media_group(
             self.token, chat_id, media, disable_notification=disable_notification, timeout=timeout,
-            protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters)
+            protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters,
+            business_connection_id=business_connection_id)
         return [types.Message.de_json(msg) for msg in result]
 
 
@@ -3079,7 +3124,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility 
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send point on the map. On success, the sent Message is returned.
 
@@ -3132,6 +3178,9 @@ class TeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3161,7 +3210,7 @@ class TeleBot:
                 self.token, chat_id, latitude, longitude, live_period=live_period, reply_markup=reply_markup,
                 disable_notification=disable_notification, timeout=timeout, horizontal_accuracy=horizontal_accuracy,
                 heading=heading, proximity_alert_radius=proximity_alert_radius, protect_content=protect_content,
-                message_thread_id=message_thread_id, reply_parameters=reply_parameters)
+                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
             )
 
 
@@ -3277,7 +3326,8 @@ class TeleBot:
             google_place_type: Optional[str]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send information about a venue. On success, the sent Message is returned.
         
@@ -3337,6 +3387,9 @@ class TeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3366,7 +3419,7 @@ class TeleBot:
                 self.token, chat_id, latitude, longitude, title, address, foursquare_id=foursquare_id,
                 foursquare_type=foursquare_type, disable_notification=disable_notification, reply_markup=reply_markup,
                 timeout=timeout, google_place_id=google_place_id, google_place_type=google_place_type,
-                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters)
+                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
             )
 
 
@@ -3380,7 +3433,8 @@ class TeleBot:
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             protect_content: Optional[bool]=None, message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send phone contacts. On success, the sent Message is returned.
 
@@ -3427,6 +3481,9 @@ class TeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3455,7 +3512,7 @@ class TeleBot:
             apihelper.send_contact(
                 self.token, chat_id, phone_number, first_name, last_name=last_name, vcard=vcard,
                 disable_notification=disable_notification, reply_markup=reply_markup, timeout=timeout,
-                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters)
+                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
             )
 
 
@@ -4618,7 +4675,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Used to send the game.
 
@@ -4654,6 +4712,9 @@ class TeleBot:
         :param reply_parameters: Reply parameters
         :type reply_parameters: :obj:`ReplyParameters`
 
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -4685,7 +4746,7 @@ class TeleBot:
             apihelper.send_game(
                 self.token, chat_id, game_short_name, disable_notification=disable_notification,
                 reply_markup=reply_markup, timeout=timeout, protect_content=protect_content,
-                message_thread_id=message_thread_id, reply_parameters=reply_parameters)
+                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
         )
 
 
@@ -5059,7 +5120,8 @@ class TeleBot:
             explanation_entities: Optional[List[types.MessageEntity]]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send a native poll.
         On success, the sent Message is returned.
@@ -5133,6 +5195,9 @@ class TeleBot:
         :param reply_parameters: reply parameters.
         :type reply_parameters: :obj:`ReplyParameters`
 
+        :param business_connection_id: Identifier of the business connection to use for the poll
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -5174,7 +5239,7 @@ class TeleBot:
                 close_date=close_date, is_closed=is_closed, disable_notification=disable_notification,
                 reply_markup=reply_markup, timeout=timeout, explanation_entities=explanation_entities,
                 protect_content=protect_content, message_thread_id=message_thread_id,
-                reply_parameters=reply_parameters)
+                reply_parameters=reply_parameters, business_connection_id=business_connection_id)
             )
 
 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5705,6 +5705,31 @@ class TeleBot:
         """
         return apihelper.delete_sticker_set(self.token, name)
 
+
+    def replace_sticker_in_set(self, user_id: int, name: str, old_sticker: str, sticker: types.InputSticker) -> bool:
+        """
+        Use this method to replace an existing sticker in a sticker set with a new one. The method is equivalent to calling deleteStickerFromSet, then addStickerToSet,
+            then setStickerPositionInSet. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#replaceStickerInSet
+
+        :param user_id: User identifier of the sticker set owner
+        :type user_id: :obj:`int`
+
+        :param name: Sticker set name
+        :type name: :obj:`str`
+
+        :param old_sticker: File identifier of the replaced sticker
+        :type old_sticker: :obj:`str`
+
+        :param sticker: A JSON-serialized object with information about the added sticker. If exactly the same sticker had already been added to the set, then the set remains unchanged.
+        :type sticker: :class:`telebot.types.InputSticker`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.replace_sticker_in_set(self.token, user_id, name, old_sticker, sticker)
+    
     
     def set_sticker_emoji_list(self, sticker: str, emoji_list: List[str]) -> bool:
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -4280,6 +4280,25 @@ class TeleBot:
             apihelper.get_my_default_administrator_rights(self.token, for_channels=for_channels)
         )
 
+
+    def get_business_connection(self, business_connection_id: str) -> types.BusinessConnection:
+        """
+        Use this method to get information about the connection of the bot with a business account.
+        Returns a BusinessConnection object on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#getbusinessconnection
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :return: Returns a BusinessConnection object on success.
+        :rtype: :class:`telebot.types.BusinessConnection`
+        """
+
+        return types.BusinessConnection.de_json(
+            apihelper.get_business_connection(self.token, business_connection_id)
+        )
+    
         
     def set_my_commands(self, commands: List[types.BotCommand],
             scope: Optional[types.BotCommandScope]=None,
@@ -8155,7 +8174,7 @@ class TeleBot:
         handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
         self.add_deleted_business_messages_handler(handler_dict)
 
-        
+
 
 
 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -8060,7 +8060,7 @@ class TeleBot:
                                                     regexp=regexp,
                                                     func=func,
                                                     **kwargs)
-            self.add_message_handler(handler_dict)
+            self.add_business_message_handler(handler_dict)
             return handler
 
         return decorator
@@ -8151,7 +8151,7 @@ class TeleBot:
                                                     regexp=regexp,
                                                     func=func,
                                                     **kwargs)
-            self.add_edited_message_handler(handler_dict)
+            self.add_edited_business_message_handler(handler_dict)
             return handler
 
         return decorator
@@ -8167,7 +8167,7 @@ class TeleBot:
         :param handler_dict:
         :return:
         """
-        self.edited_message_handlers.append(handler_dict)
+        self.edited_business_message_handlers.append(handler_dict)
 
 
     def register_edited_business_message_handler(self, callback: Callable, content_types: Optional[List[str]]=None,

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -2093,7 +2093,7 @@ class TeleBot:
                 self.token, chat_id, emoji=emoji, disable_notification=disable_notification,
                 reply_markup=reply_markup, timeout=timeout, protect_content=protect_content,
                 message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id))
-        )
+
 
 
     def send_photo(
@@ -2195,7 +2195,7 @@ class TeleBot:
                 parse_mode=parse_mode, disable_notification=disable_notification, timeout=timeout,
                 caption_entities=caption_entities, protect_content=protect_content,
                 message_thread_id=message_thread_id, has_spoiler=has_spoiler, reply_parameters=reply_parameters, business_connection_id=business_connection_id))
-        )
+        
 
 
     def send_audio(
@@ -3517,7 +3517,8 @@ class TeleBot:
 
 
     def send_chat_action(
-            self, chat_id: Union[int, str], action: str, timeout: Optional[int]=None, message_thread_id: Optional[int]=None) -> bool:
+            self, chat_id: Union[int, str], action: str, timeout: Optional[int]=None, message_thread_id: Optional[int]=None,
+            business_connection_id: Optional[str]=None) -> bool:
         """
         Use this method when you need to tell the user that something is happening on the bot's side.
         The status is set for 5 seconds or less (when a message arrives from your bot, Telegram clients clear its typing status).
@@ -3543,11 +3544,14 @@ class TeleBot:
         :param message_thread_id: The thread identifier of a message from which the reply will be sent(supergroups only)
         :type message_thread_id: :obj:`int`
 
+        :param business_connection_id: Identifier of a business connection
+        :type business_connection_id: :obj:`str`
+
         :return: Returns True on success.
         :rtype: :obj:`bool`
         """
         return apihelper.send_chat_action(
-            self.token, chat_id, action, timeout=timeout, message_thread_id=message_thread_id)
+            self.token, chat_id, action, timeout=timeout, message_thread_id=message_thread_id, business_connection_id=business_connection_id)
 
     
     @util.deprecated(deprecation_text="Use ban_chat_member instead")

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -8208,7 +8208,7 @@ class TeleBot:
         def decorator(handler):
             handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
 
-            self.add_deleted_message_handler(handler_dict)
+            self.add_deleted_business_messages_handler(handler_dict)
             return handler
         
         return decorator
@@ -8220,7 +8220,7 @@ class TeleBot:
 
         :meta private:
         """
-        self.deleted_message_handlers.append(handler_dict)
+        self.deleted_business_messages_handlers.append(handler_dict)
 
     def register_deleted_business_messages_handler(self, callback: Callable, func: Optional[Callable]=None, pass_bot: Optional[bool]=False, **kwargs):
         """

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1247,6 +1247,10 @@ def set_my_commands(token, commands, scope=None, language_code=None):
         payload['language_code'] = language_code
     return _make_request(token, method_url, params=payload, method='post')
 
+def get_business_connection(token, business_connection_id):
+    method_url = 'getBusinessConnection'
+    payload = {'business_connection_id': business_connection_id}
+    return _make_request(token, method_url, params=payload , method='post')
 
 def delete_my_commands(token, scope=None, language_code=None):
     method_url = r'deleteMyCommands'

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -383,6 +383,11 @@ def set_sticker_set_thumbnail(token, name, user_id, thumbnail, format):
     return _make_request(token, method_url, params=payload, files=files or None)
 
 
+def replace_sticker_in_set(token, user_id, name, old_sticker, sticker):
+    method_url = r'replaceStickerInSet'
+    payload = {'user_id': user_id, 'name': name, 'old_sticker': old_sticker, 'sticker': sticker.to_json()}
+    return _make_request(token, method_url, params=payload)
+
 def set_chat_sticker_set(token, chat_id, sticker_set_name):
     method_url = r'setChatStickerSet'
     payload = {'chat_id': chat_id, 'sticker_set_name': sticker_set_name}

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -669,13 +669,15 @@ def send_contact(
     return _make_request(token, method_url, params=payload)
 
 
-def send_chat_action(token, chat_id, action, timeout=None, message_thread_id=None):
+def send_chat_action(token, chat_id, action, timeout=None, message_thread_id=None, business_connection_id=None):
     method_url = r'sendChatAction'
     payload = {'chat_id': chat_id, 'action': action}
     if timeout:
         payload['timeout'] = timeout
     if message_thread_id is not None:
         payload['message_thread_id'] = message_thread_id
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload)
 
 

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -371,9 +371,9 @@ def get_chat_member_count(token, chat_id):
     return _make_request(token, method_url, params=payload)
 
 
-def set_sticker_set_thumbnail(token, name, user_id, thumbnail):
+def set_sticker_set_thumbnail(token, name, user_id, thumbnail, format):
     method_url = r'setStickerSetThumbnail'
-    payload = {'name': name, 'user_id': user_id}
+    payload = {'name': name, 'user_id': user_id, 'format': format}
     files = {}
     if thumbnail:
         if not isinstance(thumbnail, str):

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -243,7 +243,8 @@ def send_message(
          reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
         entities=None, protect_content=None,
-        message_thread_id=None, reply_parameters=None, link_preview_options=None):
+        message_thread_id=None, reply_parameters=None, link_preview_options=None,
+        business_connection_id=None):
     method_url = r'sendMessage'
     payload = {'chat_id': str(chat_id), 'text': text}
     if link_preview_options is not None:
@@ -264,6 +265,8 @@ def send_message(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload, method='post')
 
 
@@ -441,7 +444,8 @@ def copy_message(token, chat_id, from_chat_id, message_id, caption=None, parse_m
 def send_dice(
         token, chat_id,
         emoji=None, disable_notification=None,
-        reply_markup=None, timeout=None, protect_content=None, message_thread_id=None, reply_parameters=None):
+        reply_markup=None, timeout=None, protect_content=None, message_thread_id=None, reply_parameters=None,
+        business_connection_id=None):
     method_url = r'sendDice'
     payload = {'chat_id': chat_id}
     if emoji:
@@ -458,6 +462,8 @@ def send_dice(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload)
 
 
@@ -466,7 +472,7 @@ def send_photo(
         caption=None, reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
         caption_entities=None, protect_content=None,
-        message_thread_id=None, has_spoiler=None, reply_parameters=None):
+        message_thread_id=None, has_spoiler=None, reply_parameters=None, business_connection_id=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None
@@ -496,13 +502,15 @@ def send_photo(
         payload['has_spoiler'] = has_spoiler
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_media_group(
         token, chat_id, media,
         disable_notification=None,
-        timeout=None, protect_content=None, message_thread_id=None, reply_parameters=None):
+        timeout=None, protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None):
     method_url = r'sendMediaGroup'
     media_json, files = convert_input_media_array(media)
     payload = {'chat_id': chat_id, 'media': media_json}
@@ -516,6 +524,8 @@ def send_media_group(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(
         token, method_url, params=payload,
         method='post' if files else 'get',
@@ -528,7 +538,7 @@ def send_location(
         reply_markup=None, disable_notification=None, 
         timeout=None, horizontal_accuracy=None, heading=None,
         proximity_alert_radius=None, protect_content=None,
-        message_thread_id=None, reply_parameters=None):
+        message_thread_id=None, reply_parameters=None, business_connection_id=None):
     method_url = r'sendLocation'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude}
     if live_period:
@@ -551,6 +561,8 @@ def send_location(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload)
 
 
@@ -601,7 +613,7 @@ def send_venue(
         token, chat_id, latitude, longitude, title, address,
         foursquare_id=None, foursquare_type=None, disable_notification=None,
         reply_markup=None, timeout=None, google_place_id=None,
-        google_place_type=None, protect_content=None, message_thread_id=None, reply_parameters=None):
+        google_place_type=None, protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None):
     method_url = r'sendVenue'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude, 'title': title, 'address': address}
     if foursquare_id:
@@ -624,13 +636,15 @@ def send_venue(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload)
 
 
 def send_contact(
         token, chat_id, phone_number, first_name, last_name=None, vcard=None,
         disable_notification=None, reply_markup=None, timeout=None,
-        protect_content=None, message_thread_id=None, reply_parameters=None):
+        protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None):
     method_url = r'sendContact'
     payload = {'chat_id': chat_id, 'phone_number': phone_number, 'first_name': first_name}
     if last_name:
@@ -649,6 +663,8 @@ def send_contact(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
 
     return _make_request(token, method_url, params=payload)
 
@@ -666,7 +682,7 @@ def send_chat_action(token, chat_id, action, timeout=None, message_thread_id=Non
 def send_video(token, chat_id, data, duration=None, caption=None, reply_markup=None,
                parse_mode=None, supports_streaming=None, disable_notification=None, timeout=None,
                thumbnail=None, width=None, height=None, caption_entities=None, protect_content=None,
-               message_thread_id=None, has_spoiler=None, reply_parameters=None):
+               message_thread_id=None, has_spoiler=None, reply_parameters=None, business_connection_id=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -710,6 +726,9 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_markup=N
         payload['has_spoiler'] = has_spoiler
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
+    
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -717,7 +736,7 @@ def send_animation(
         token, chat_id, data, duration=None, caption=None,  reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None, thumbnail=None, caption_entities=None,
         protect_content=None, width=None, height=None, message_thread_id=None, reply_parameters=None,
-        has_spoiler=None):
+        has_spoiler=None, business_connection_id=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}
     files = None
@@ -759,12 +778,14 @@ def send_animation(
         payload['has_spoiler'] = has_spoiler
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_voice(token, chat_id, voice, caption=None, duration=None, reply_markup=None,
                parse_mode=None, disable_notification=None, timeout=None, caption_entities=None,
-                 protect_content=None, message_thread_id=None, reply_parameters=None):
+                 protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None):
     method_url = r'sendVoice'
     payload = {'chat_id': chat_id}
     files = None
@@ -792,12 +813,14 @@ def send_voice(token, chat_id, voice, caption=None, duration=None, reply_markup=
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_video_note(token, chat_id, data, duration=None, length=None, reply_markup=None,
                     disable_notification=None, timeout=None, thumbnail=None, protect_content=None,
-                    message_thread_id=None, reply_parameters=None):
+                    message_thread_id=None, reply_parameters=None,business_connection_id=None):
     method_url = r'sendVideoNote'
     payload = {'chat_id': chat_id}
     files = None
@@ -831,12 +854,14 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_mark
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None,
                reply_markup=None, parse_mode=None, disable_notification=None, timeout=None, thumbnail=None,
-               caption_entities=None, protect_content=None, message_thread_id=None, reply_parameters=None):
+               caption_entities=None, protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None):
     method_url = r'sendAudio'
     payload = {'chat_id': chat_id}
     files = None
@@ -876,13 +901,15 @@ def send_audio(token, chat_id, audio, caption=None, duration=None, performer=Non
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_data(token, chat_id, data, data_type, reply_markup=None, parse_mode=None,
               disable_notification=None, timeout=None, caption=None, thumbnail=None, caption_entities=None,
               disable_content_type_detection=None, visible_file_name=None,
-              protect_content = None, message_thread_id=None, emoji=None, reply_parameters=None):
+              protect_content = None, message_thread_id=None, emoji=None, reply_parameters=None, business_connection_id=None):
     method_url = get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None
@@ -923,6 +950,8 @@ def send_data(token, chat_id, data, data_type, reply_markup=None, parse_mode=Non
         payload['emoji'] = emoji
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1376,7 +1405,7 @@ def delete_message(token, chat_id, message_id, timeout=None):
 def send_game(
         token, chat_id, game_short_name,
         disable_notification=None, reply_markup=None, timeout=None,
-       protect_content=None, message_thread_id=None, reply_parameters=None):
+       protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None):
     method_url = r'sendGame'
     payload = {'chat_id': chat_id, 'game_short_name': game_short_name}
     if disable_notification is not None:
@@ -1391,6 +1420,8 @@ def send_game(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload)
 
 
@@ -1779,7 +1810,8 @@ def send_poll(
         question, options,
         is_anonymous = None, type = None, allows_multiple_answers = None, correct_option_id = None, explanation = None,
         explanation_parse_mode=None, open_period = None, close_date = None, is_closed = None, disable_notification=False,
-        reply_markup=None, timeout=None, explanation_entities=None, protect_content=None, message_thread_id=None, reply_parameters=None):
+        reply_markup=None, timeout=None, explanation_entities=None, protect_content=None, message_thread_id=None, reply_parameters=None,
+        business_connection_id=None):
     method_url = r'sendPoll'
     payload = {
         'chat_id': str(chat_id),
@@ -1822,6 +1854,8 @@ def send_poll(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if business_connection_id is not None:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload)
 
 def create_forum_topic(token, chat_id, name, icon_color=None, icon_custom_emoji_id=None):

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -3035,7 +3035,8 @@ class AsyncTeleBot:
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            link_preview_options: Optional[types.LinkPreviewOptions]=None) -> types.Message:
+            link_preview_options: Optional[types.LinkPreviewOptions]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send text messages.
 
@@ -3087,6 +3088,9 @@ class AsyncTeleBot:
 
         :param link_preview_options: Options for previewing links.
         :type link_preview_options: :class:`telebot.types.LinkPreviewOptions`
+
+        :param business_connection_id: Unique identifier for the target business connection
+        :type business_connection_id: :obj:`str`
 
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -3142,7 +3146,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_message(
                 self.token, chat_id, text,
                 reply_markup, parse_mode, disable_notification, timeout,
-                entities, protect_content, message_thread_id, reply_parameters, link_preview_options))
+                entities, protect_content, message_thread_id, reply_parameters, link_preview_options, business_connection_id))
 
     async def forward_message(
             self, chat_id: Union[int, str], from_chat_id: Union[int, str], 
@@ -3415,7 +3419,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send an animated emoji that will display a random value. On success, the sent Message is returned.
 
@@ -3454,6 +3459,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Unique identifier for the target business connection
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3484,8 +3492,8 @@ class AsyncTeleBot:
         return types.Message.de_json(
             await asyncio_helper.send_dice(
                 self.token, chat_id, emoji, disable_notification,
-                reply_markup, timeout, protect_content, message_thread_id, reply_parameters)
-        )
+                reply_markup, timeout, protect_content, message_thread_id, reply_parameters, business_connection_id))
+        
 
     async def send_photo(
             self, chat_id: Union[int, str], photo: Union[Any, str], 
@@ -3499,7 +3507,8 @@ class AsyncTeleBot:
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send photos. On success, the sent Message is returned.
 
@@ -3550,6 +3559,9 @@ class AsyncTeleBot:
         
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
+        :param business_connection_id: Unique identifier for the target business connection
+        :type business_connection_id: :obj:`str`
         
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -3583,7 +3595,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_photo(
                 self.token, chat_id, photo, caption, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
-                protect_content, message_thread_id, has_spoiler, reply_parameters))
+                protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id))
 
     async def send_audio(
             self, chat_id: Union[int, str], audio: Union[Any, str], 
@@ -3600,7 +3612,8 @@ class AsyncTeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player.
         Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size,
@@ -3670,6 +3683,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Unique identifier for the target business connection
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3706,7 +3722,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_audio(
                 self.token, chat_id, audio, caption, duration, performer, title,
                 reply_markup, parse_mode, disable_notification, timeout, thumbnail,
-                caption_entities, protect_content, message_thread_id, reply_parameters))
+                caption_entities, protect_content, message_thread_id, reply_parameters, business_connection_id))
 
     async def send_voice(
             self, chat_id: Union[int, str], voice: Union[Any, str], 
@@ -3720,7 +3736,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
         For this to work, your audio must be in an .OGG file encoded with OPUS (other formats may be sent as Audio or Document).
@@ -3773,6 +3790,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Unique identifier for the target business connection
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
@@ -3804,7 +3824,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_voice(
                 self.token, chat_id, voice, caption, duration, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
-                protect_content, message_thread_id, reply_parameters))
+                protect_content, message_thread_id, reply_parameters, business_connection_id))
 
     async def send_document(
             self, chat_id: Union[int, str], document: Union[Any, str],
@@ -3823,7 +3843,8 @@ class AsyncTeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send general files.
 
@@ -3886,6 +3907,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Unique identifier for the target business connection
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3930,7 +3954,7 @@ class AsyncTeleBot:
                 disable_notification = disable_notification, timeout = timeout, caption = caption, thumbnail= thumbnail,
                 caption_entities = caption_entities,
                 disable_content_type_detection = disable_content_type_detection, visible_file_name = visible_file_name, protect_content = protect_content,
-                message_thread_id = message_thread_id, reply_parameters=reply_parameters))
+                message_thread_id = message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id))
 
     async def send_sticker(
             self, chat_id: Union[int, str], sticker: Union[Any, str], 
@@ -3943,7 +3967,8 @@ class AsyncTeleBot:
             data: Union[Any, str]=None,
             message_thread_id: Optional[int]=None,
             emoji: Optional[str]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers.
         On success, the sent Message is returned.
@@ -3989,6 +4014,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Unique identifier for the target business connection
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4027,7 +4055,7 @@ class AsyncTeleBot:
                 reply_markup=reply_markup,
                 disable_notification=disable_notification, timeout=timeout, 
                 protect_content=protect_content,
-                message_thread_id=message_thread_id, emoji=emoji, reply_parameters=reply_parameters))
+                message_thread_id=message_thread_id, emoji=emoji, reply_parameters=reply_parameters, business_connection_id=business_connection_id))
 
     async def send_video(
             self, chat_id: Union[int, str], video: Union[Any, str], 
@@ -4049,7 +4077,8 @@ class AsyncTeleBot:
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
             thumb: Optional[Union[Any, str]]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
         
@@ -4120,6 +4149,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4161,7 +4193,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_video(
                 self.token, chat_id, video, duration, caption, reply_markup,
                 parse_mode, supports_streaming, disable_notification, timeout, thumbnail, width, height,
-                caption_entities, protect_content, message_thread_id, has_spoiler, reply_parameters))
+                caption_entities, protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id))
 
     async def send_animation(
             self, chat_id: Union[int, str], animation: Union[Any, str], 
@@ -4181,7 +4213,8 @@ class AsyncTeleBot:
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
             thumb: Optional[Union[Any, str]]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
@@ -4251,6 +4284,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4287,7 +4323,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_animation(
                 self.token, chat_id, animation, duration, caption,
                 reply_markup, parse_mode, disable_notification, timeout, thumbnail,
-                caption_entities, width, height, protect_content, message_thread_id, has_spoiler, reply_parameters))
+                caption_entities, width, height, protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id))
 
     async def send_video_note(
             self, chat_id: Union[int, str], data: Union[Any, str], 
@@ -4302,7 +4338,8 @@ class AsyncTeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         As of v.4.0, Telegram clients support rounded square MPEG4 videos of up to 1 minute long.
         Use this method to send video messages. On success, the sent Message is returned.
@@ -4357,6 +4394,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4391,7 +4431,7 @@ class AsyncTeleBot:
         return types.Message.de_json(
             await asyncio_helper.send_video_note(
                 self.token, chat_id, data, duration, length, reply_markup,
-                disable_notification, timeout, thumbnail, protect_content, message_thread_id, reply_parameters))
+                disable_notification, timeout, thumbnail, protect_content, message_thread_id, reply_parameters, business_connection_id))
 
     async def send_media_group(
             self, chat_id: Union[int, str], 
@@ -4404,7 +4444,8 @@ class AsyncTeleBot:
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> List[types.Message]:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> List[types.Message]:
         """
         Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files
         can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned.
@@ -4438,6 +4479,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, an array of Messages that were sent is returned.
         :rtype: List[types.Message]
         """
@@ -4466,7 +4510,7 @@ class AsyncTeleBot:
             reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         result = await asyncio_helper.send_media_group(
-            self.token, chat_id, media, disable_notification, timeout, protect_content, message_thread_id, reply_parameters)
+            self.token, chat_id, media, disable_notification, timeout, protect_content, message_thread_id, reply_parameters, business_connection_id)
         return [types.Message.de_json(msg) for msg in result]
 
     async def send_location(
@@ -4483,7 +4527,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send point on the map. On success, the sent Message is returned.
 
@@ -4536,6 +4581,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4568,7 +4616,7 @@ class AsyncTeleBot:
                 self.token, chat_id, latitude, longitude, live_period, 
                 reply_markup, disable_notification, timeout, 
                 horizontal_accuracy, heading, proximity_alert_radius, 
-                protect_content, message_thread_id, reply_parameters))
+                protect_content, message_thread_id, reply_parameters, business_connection_id))
 
     async def edit_message_live_location(
             self, latitude: float, longitude: float, 
@@ -4677,7 +4725,8 @@ class AsyncTeleBot:
             google_place_type: Optional[str]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send information about a venue. On success, the sent Message is returned.
         
@@ -4738,6 +4787,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4769,8 +4821,8 @@ class AsyncTeleBot:
             await asyncio_helper.send_venue(
                 self.token, chat_id, latitude, longitude, title, address, foursquare_id, foursquare_type,
                 disable_notification, reply_markup, timeout,
-                google_place_id, google_place_type, protect_content, message_thread_id, reply_parameters)
-        )
+                google_place_id, google_place_type, protect_content, message_thread_id, reply_parameters, business_connection_id))
+        
 
     async def send_contact(
             self, chat_id: Union[int, str], phone_number: str, 
@@ -4783,7 +4835,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send phone contacts. On success, the sent Message is returned.
 
@@ -4831,6 +4884,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4862,8 +4918,8 @@ class AsyncTeleBot:
             await asyncio_helper.send_contact(
                 self.token, chat_id, phone_number, first_name, last_name, vcard,
                 disable_notification, reply_markup, timeout,
-                protect_content, message_thread_id, reply_parameters)
-        )
+                protect_content, message_thread_id, reply_parameters, business_connection_id))
+        
 
     async def send_chat_action(
             self, chat_id: Union[int, str], action: str, timeout: Optional[int]=None, message_thread_id: Optional[int]=None) -> bool:
@@ -5968,7 +6024,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Used to send the game.
 
@@ -6004,6 +6061,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of the business connection.
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -6034,7 +6094,7 @@ class AsyncTeleBot:
         result = await asyncio_helper.send_game(
             self.token, chat_id, game_short_name, disable_notification,
             reply_markup, timeout, 
-            protect_content, message_thread_id, reply_parameters)
+            protect_content, message_thread_id, reply_parameters, business_connection_id)
         return types.Message.de_json(result)
 
     async def set_game_score(
@@ -6396,7 +6456,8 @@ class AsyncTeleBot:
             explanation_entities: Optional[List[types.MessageEntity]]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            business_connection_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send a native poll.
         On success, the sent Message is returned.
@@ -6470,6 +6531,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param business_connection_id: Identifier of the business connection to send the message through
+        :type business_connection_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -6508,7 +6572,7 @@ class AsyncTeleBot:
                 is_anonymous, type, allows_multiple_answers, correct_option_id,
                 explanation, explanation_parse_mode, open_period, close_date, is_closed,
                 disable_notification,
-                reply_markup, timeout, explanation_entities, protect_content, message_thread_id, reply_parameters))
+                reply_markup, timeout, explanation_entities, protect_content, message_thread_id, reply_parameters, business_connection_id))
 
     async def stop_poll(
             self, chat_id: Union[int, str], message_id: int, 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6866,7 +6866,7 @@ class AsyncTeleBot:
         return types.UserChatBoosts.de_json(result)
     
 
-    async def set_sticker_set_thumbnail(self, name: str, user_id: int, thumbnail: Union[Any, str]=None):
+    async def set_sticker_set_thumbnail(self, name: str, user_id: int, format: str, thumbnail: Union[Any, str]=None):
         """
         Use this method to set the thumbnail of a sticker set. 
         Animated thumbnails can be set for animated sticker sets only. Returns True on success.
@@ -6885,7 +6885,7 @@ class AsyncTeleBot:
         :return: On success, True is returned.
         :rtype: :obj:`bool`
         """
-        return await asyncio_helper.set_sticker_set_thumbnail(self.token, name, user_id, thumbnail)
+        return await asyncio_helper.set_sticker_set_thumbnail(self.token, name, user_id, thumbnail, format)
     
     @util.deprecated(deprecation_text="Use set_sticker_set_thumbnail instead")
     async def set_sticker_set_thumb(self, name: str, user_id: int, thumb: Union[Any, str]=None):

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7051,6 +7051,30 @@ class AsyncTeleBot:
 
         return await asyncio_helper.delete_sticker_set(self.token, name)
     
+    async def replace_sticker_in_set(self, user_id: int, name: str, old_sticker: str, sticker: types.InputSticker) -> bool:
+        """
+        Use this method to replace an existing sticker in a sticker set with a new one. The method is equivalent to calling deleteStickerFromSet, then addStickerToSet,
+            then setStickerPositionInSet. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#replaceStickerInSet
+
+        :param user_id: User identifier of the sticker set owner
+        :type user_id: :obj:`int`
+
+        :param name: Sticker set name
+        :type name: :obj:`str`
+
+        :param old_sticker: File identifier of the replaced sticker
+        :type old_sticker: :obj:`str`
+
+        :param sticker: A JSON-serialized object with information about the added sticker. If exactly the same sticker had already been added to the set, then the set remains unchanged.
+        :type sticker: :class:`telebot.types.InputSticker`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        result = await asyncio_helper.replace_sticker_in_set(self.token, user_id, name, old_sticker, sticker)
+        return result
 
     async def set_sticker_emoji_list(self, name: str, emoji_list: List[str]) -> bool:
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -4922,7 +4922,8 @@ class AsyncTeleBot:
         
 
     async def send_chat_action(
-            self, chat_id: Union[int, str], action: str, timeout: Optional[int]=None, message_thread_id: Optional[int]=None) -> bool:
+            self, chat_id: Union[int, str], action: str, timeout: Optional[int]=None, message_thread_id: Optional[int]=None,
+            business_connection_id: Optional[str]=None) -> bool:
         """
         Use this method when you need to tell the user that something is happening on the bot's side.
         The status is set for 5 seconds or less (when a message arrives from your bot, Telegram clients clear its typing status).
@@ -4948,10 +4949,13 @@ class AsyncTeleBot:
         :param message_thread_id: The thread to which the message will be sent(supergroups only)
         :type message_thread_id: :obj:`int`
 
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
         :return: Returns True on success.
         :rtype: :obj:`bool`
         """
-        return await asyncio_helper.send_chat_action(self.token, chat_id, action, timeout, message_thread_id)
+        return await asyncio_helper.send_chat_action(self.token, chat_id, action, timeout, message_thread_id, business_connection_id)
 
     async def kick_chat_member(
             self, chat_id: Union[int, str], user_id: int, 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -5647,6 +5647,26 @@ class AsyncTeleBot:
         """
         
         return types.ChatAdministratorRights.de_json(await asyncio_helper.get_my_default_administrator_rights(self.token, for_channels))
+    
+    async def get_business_connection(self, business_connection_id: str) -> types.BusinessConnection:
+        """
+        Use this method to get information about the connection of the bot with a business account.
+        Returns a BusinessConnection object on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#getbusinessconnection
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :return: Returns a BusinessConnection object on success.
+        :rtype: :class:`telebot.types.BusinessConnection`
+        """
+        result = await asyncio_helper.get_business_connection(self.token, business_connection_id)
+
+        return types.BusinessConnection.de_json(
+            result
+        )
+    
 
     async def set_my_commands(self, commands: List[types.BotCommand], 
             scope: Optional[types.BotCommandScope]=None,

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -2484,7 +2484,7 @@ class AsyncTeleBot:
         def decorator(handler):
             handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
 
-            self.add_deleted_message_handler(handler_dict)
+            self.add_deleted_business_messages_handler(handler_dict)
             return handler
         
         return decorator
@@ -2496,7 +2496,7 @@ class AsyncTeleBot:
 
         :meta private:
         """
-        self.deleted_message_handlers.append(handler_dict)
+        self.deleted_business_messages_handlers.append(handler_dict)
 
     def register_deleted_business_messages_handler(self, callback: Callable, func: Optional[Callable]=None, pass_bot: Optional[bool]=False, **kwargs):
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6883,12 +6883,12 @@ class AsyncTeleBot:
         return types.UserChatBoosts.de_json(result)
     
 
-    async def set_sticker_set_thumbnail(self, name: str, user_id: int, format: str, thumbnail: Union[Any, str]=None):
+    async def set_sticker_set_thumbnail(self, name: str, user_id: int, thumbnail: Union[Any, str]=None, format: Optional[str]=None) -> bool:
         """
         Use this method to set the thumbnail of a sticker set. 
         Animated thumbnails can be set for animated sticker sets only. Returns True on success.
 
-        Telegram documentation: https://core.telegram.org/bots/api#setstickersetthumb
+        Telegram documentation: https://core.telegram.org/bots/api#setstickersetthumbnail
 
         :param name: Sticker set name
         :type name: :obj:`str`
@@ -6896,12 +6896,20 @@ class AsyncTeleBot:
         :param user_id: User identifier
         :type user_id: :obj:`int`
 
-        :param thumbnail: A .WEBP or .PNG image with the thumbnail, must be up to 128 kilobytes in size and have a width and height of exactly 100px, or a .TGS animation with a thumbnail up to 32 kilobytes in size (see https://core.telegram.org/stickers#animated-sticker-requirements for animated sticker technical requirements), or a WEBM video with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/stickers#video-sticker-requirements for video sticker technical requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More information on Sending Files ». Animated and video sticker set thumbnails can't be uploaded via HTTP URL. If omitted, then the thumbnail is dropped and the first sticker is used as the thumbnail.
+        :param thumbnail: A .WEBP or .PNG image with the thumbnail, must be up to 128 kilobytes in size and have a width and height of exactly 100px, or a .TGS animation
+            with a thumbnail up to 32 kilobytes in size (see https://core.telegram.org/stickers#animated-sticker-requirements for animated sticker technical requirements),
+            or a WEBM video with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/stickers#video-sticker-requirements for video sticker technical
+            requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from
+            the Internet, or upload a new one using multipart/form-data. More information on Sending Files ». Animated and video sticker set thumbnails can't be uploaded via
+            HTTP URL. If omitted, then the thumbnail is dropped and the first sticker is used as the thumbnail.
         :type thumbnail: :obj:`filelike object`
 
         :return: On success, True is returned.
         :rtype: :obj:`bool`
         """
+        if format is None:
+            logger.warning("Format in set_sticker_set_thumbnail cannot be None. Setting format to 'static'.")
+            format = "static"
         return await asyncio_helper.set_sticker_set_thumbnail(self.token, name, user_id, thumbnail, format)
     
     @util.deprecated(deprecation_text="Use set_sticker_set_thumbnail instead")

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -999,6 +999,23 @@ class AsyncTeleBot:
 
         self.middlewares.append(middleware)
 
+    @staticmethod
+    def check_commands_input(commands, method_name):
+        """
+        :meta private:
+        """
+        if not isinstance(commands, list) or not all(isinstance(item, str) for item in commands):
+            logger.error(f"{method_name}: Commands filter should be list of strings (commands), unknown type supplied to the 'commands' filter list. Not able to use the supplied type.")
+
+
+    @staticmethod
+    def check_regexp_input(regexp, method_name):
+        """
+        :meta private:
+        """
+        if not isinstance(regexp, str):
+            logger.error(f"{method_name}: Regexp filter should be string. Not able to use the supplied type.")
+
     def message_handler(self, commands=None, regexp=None, func=None, content_types=None, chat_types=None, **kwargs):
         """
         Handles ew incoming message of any kind - text, photo, sticker, etc.
@@ -2308,7 +2325,7 @@ class AsyncTeleBot:
                                                     regexp=regexp,
                                                     func=func,
                                                     **kwargs)
-            self.add_message_handler(handler_dict)
+            self.add_business_message_handler(handler_dict)
             return handler
 
         return decorator
@@ -2399,7 +2416,7 @@ class AsyncTeleBot:
                                                     regexp=regexp,
                                                     func=func,
                                                     **kwargs)
-            self.add_edited_message_handler(handler_dict)
+            self.add_edited_business_message_handler(handler_dict)
             return handler
 
         return decorator
@@ -2415,7 +2432,7 @@ class AsyncTeleBot:
         :param handler_dict:
         :return:
         """
-        self.edited_message_handlers.append(handler_dict)
+        self.edited_business_message_handlers.append(handler_dict)
 
 
     def register_edited_business_message_handler(self, callback: Callable, content_types: Optional[List[str]]=None,

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -173,6 +173,11 @@ class AsyncTeleBot:
         self.chat_join_request_handlers = []
         self.removed_chat_boost_handlers = []
         self.chat_boost_handlers = []
+        self.business_connection_handlers = []
+        self.business_message_handlers = []
+        self.edited_business_message_handlers = []
+        self.deleted_business_messages_handlers = []
+
         self.custom_filters = {}
         self.state_handlers = []
         self.middlewares = []
@@ -594,6 +599,12 @@ class AsyncTeleBot:
         chat_join_request = None
         removed_chat_boost_handlers = None
         chat_boost_handlers = None
+        new_business_connections = None
+        new_business_messages = None
+        new_edited_business_messages = None
+        new_deleted_business_messages = None
+
+
         for update in updates:
             logger.debug('Processing updates: {0}'.format(update))
             if update.message:
@@ -650,6 +661,18 @@ class AsyncTeleBot:
             if update.removed_chat_boost:
                 if removed_chat_boost_handlers is None: removed_chat_boost_handlers = []
                 removed_chat_boost_handlers.append(update.removed_chat_boost)
+            if update.business_connection:
+                if new_business_connections is None: new_business_connections = []
+                new_business_connections.append(update.business_connection)
+            if update.business_message:
+                if new_business_messages is None: new_business_messages = []
+                new_business_messages.append(update.business_message)
+            if update.edited_business_message:
+                if new_edited_business_messages is None: new_edited_business_messages = []
+                new_edited_business_messages.append(update.edited_business_message)
+            if update.deleted_business_messages:
+                if new_deleted_business_messages is None: new_deleted_business_messages = []
+                new_deleted_business_messages.append(update.deleted_business_messages)
 
 
         if new_messages:
@@ -686,6 +709,14 @@ class AsyncTeleBot:
             await self.process_new_message_reaction_count(new_message_reaction_count_handlers)
         if chat_boost_handlers:
             await self.process_new_chat_boost(chat_boost_handlers)
+        if new_business_connections:
+            await self.process_new_business_connection(new_business_connections)
+        if new_business_messages:
+            await self.process_new_business_message(new_business_messages)
+        if new_edited_business_messages:
+            await self.process_new_edited_business_message(new_edited_business_messages)
+        if new_deleted_business_messages:
+            await self.process_new_deleted_business_messages(new_deleted_business_messages)
 
     async def process_new_messages(self, new_messages):
         """
@@ -795,6 +826,30 @@ class AsyncTeleBot:
         :meta private:
         """
         await self._process_updates(self.removed_chat_boost_handlers, removed_chat_boost, 'removed_chat_boost')
+
+    async def process_new_business_connection(self, new_business_connections):
+        """
+        :meta private:
+        """
+        await self._process_updates(self.business_connection_handlers, new_business_connections, 'business_connection')
+
+    async def process_new_business_message(self, new_business_messages):
+        """
+        :meta private:
+        """
+        await self._process_updates(self.business_message_handlers, new_business_messages, 'business_message')
+
+    async def process_new_edited_business_message(self, new_edited_business_messages):
+        """
+        :meta private:
+        """
+        await self._process_updates(self.edited_business_message_handlers, new_edited_business_messages, 'edited_business_message')
+        
+    async def process_new_deleted_business_messages(self, new_deleted_business_messages):
+        """
+        :meta private:
+        """
+        await self._process_updates(self.deleted_business_messages_handlers, new_deleted_business_messages, 'deleted_business_messages')
 
     async def _get_middlewares(self, update_type):
         """
@@ -2124,6 +2179,345 @@ class AsyncTeleBot:
         """
         handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
         self.add_removed_chat_boost_handler(handler_dict)
+
+
+    def business_connection_handler(self, func=None, **kwargs):
+        """
+        Handles new incoming business connection state.
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+        :return: None
+        """
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
+            self.add_business_connection_handler(handler_dict)
+            return handler
+        
+        return decorator
+    
+    def add_business_connection_handler(self, handler_dict):
+        """
+        Adds a business_connection handler.
+        Note that you should use register_business_connection_handler to add business_connection_handler to the bot.
+
+        :meta private:
+
+        :param handler_dict:
+        :return:
+        """
+        self.business_connection_handlers.append(handler_dict)
+
+    def register_business_connection_handler(
+            self, callback: Callable, func: Optional[Callable]=None, pass_bot:Optional[bool]=False, **kwargs):
+        """
+        Registers business connection handler.
+
+        :param callback: function to be called
+        :type callback: :obj:`function`
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
+        :type pass_bot: :obj:`bool`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return: None
+        """
+        handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
+        self.add_business_connection_handler(handler_dict)
+
+    def business_message_handler(
+            self,
+            commands: Optional[List[str]]=None,
+            regexp: Optional[str]=None,
+            func: Optional[Callable]=None,
+            content_types: Optional[List[str]]=None,
+            **kwargs):
+        """
+        Handles New incoming message of any kind(for business accounts, see bot api 7.2 for more) - text, photo, sticker, etc.
+        As a parameter to the decorator function, it passes :class:`telebot.types.Message` object.
+        All message handlers are tested in the order they were added.
+
+        Example:
+
+        .. code-block:: python3
+            :caption: Usage of business_message_handler
+
+            bot = TeleBot('TOKEN')
+
+            # Handles all messages which text matches regexp.
+            @bot.business_message_handler(regexp='someregexp')
+            def command_help(message):
+                bot.send_message(message.chat.id, 'Did someone call for help?')
+
+            # Handle all sent documents of type 'text/plain'.
+            @bot.business_message_handler(func=lambda message: message.document.mime_type == 'text/plain',
+                content_types=['document'])
+            def command_handle_document(message):
+                bot.send_message(message.chat.id, 'Document received, sir!')
+
+            # Handle all other messages.
+            @bot.business_message_handler(func=lambda message: True, content_types=['audio', 'photo', 'voice', 'video', 'document',
+                'text', 'location', 'contact', 'sticker'])
+            def default_command(message):
+                bot.send_message(message.chat.id, "This is the default command handler.")
+
+        :param commands: Optional list of strings (commands to handle).
+        :type commands: :obj:`list` of :obj:`str`
+
+        :param regexp: Optional regular expression.
+        :type regexp: :obj:`str`
+
+        :param func: Optional lambda function. The lambda receives the message to test as the first parameter.
+            It must return True if the command should handle the message.
+        :type func: :obj:`lambda`
+
+        :param content_types: Supported message content types. Must be a list. Defaults to ['text'].
+        :type content_types: :obj:`list` of :obj:`str`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return: decorated function
+        """
+        if content_types is None:
+            content_types = ["text"]
+
+        method_name = "business_message_handler"
+
+        if commands is not None:
+            self.check_commands_input(commands, method_name)
+            if isinstance(commands, str):
+                commands = [commands]
+
+        if regexp is not None:
+            self.check_regexp_input(regexp, method_name)
+
+        if isinstance(content_types, str):
+            logger.warning("business_message_handler: 'content_types' filter should be List of strings (content types), not string.")
+            content_types = [content_types]
+
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler,
+                                                    content_types=content_types,
+                                                    commands=commands,
+                                                    regexp=regexp,
+                                                    func=func,
+                                                    **kwargs)
+            self.add_message_handler(handler_dict)
+            return handler
+
+        return decorator
+    
+    def add_business_message_handler(self, handler_dict):
+        """
+        Adds a business_message handler.
+        Note that you should use register_business_message_handler to add business_message_handler to the bot.
+
+        :meta private:
+
+        :param handler_dict:
+        :return:
+        """
+        self.business_message_handlers.append(handler_dict)
+
+    def register_business_message_handler(self,
+            callback: Callable,
+            commands: Optional[List[str]]=None,
+            regexp: Optional[str]=None,
+            func: Optional[Callable]=None,
+            content_types: Optional[List[str]]=None,
+            **kwargs):
+        """
+        Registers business connection handler.
+
+        :param callback: function to be called
+        :type callback: :obj:`function`
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
+        :type pass_bot: :obj:`bool`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return: None
+        """
+        handler_dict = self._build_handler_dict(callback, content_types=content_types, commands=commands, regexp=regexp, func=func, **kwargs)
+        self.add_business_message_handler(handler_dict)
+
+    
+    
+
+    def edited_business_message_handler(self, commands=None, regexp=None, func=None, content_types=None, **kwargs):
+        """
+        Handles new version of a message(business accounts) that is known to the bot and was edited.
+        As a parameter to the decorator function, it passes :class:`telebot.types.Message` object.
+
+        :param commands: Optional list of strings (commands to handle).
+        :type commands: :obj:`list` of :obj:`str`
+
+        :param regexp: Optional regular expression.
+        :type regexp: :obj:`str`
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param content_types: Supported message content types. Must be a list. Defaults to ['text'].
+        :type content_types: :obj:`list` of :obj:`str`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return: None
+        """
+        if content_types is None:
+            content_types = ["text"]
+
+        method_name = "edited_business_message_handler"
+
+        if commands is not None:
+            self.check_commands_input(commands, method_name)
+            if isinstance(commands, str):
+                commands = [commands]
+
+        if regexp is not None:
+            self.check_regexp_input(regexp, method_name)
+
+        if isinstance(content_types, str):
+            logger.warning("edited_business_message_handler: 'content_types' filter should be List of strings (content types), not string.")
+            content_types = [content_types]
+
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler,
+                                                    content_types=content_types,
+                                                    commands=commands,
+                                                    regexp=regexp,
+                                                    func=func,
+                                                    **kwargs)
+            self.add_edited_message_handler(handler_dict)
+            return handler
+
+        return decorator
+
+
+    def add_edited_business_message_handler(self, handler_dict):
+        """
+        Adds the edit message handler
+        Note that you should use register_edited_business_message_handler to add edited_business_message_handler to the bot.
+        
+        :meta private:
+
+        :param handler_dict:
+        :return:
+        """
+        self.edited_message_handlers.append(handler_dict)
+
+
+    def register_edited_business_message_handler(self, callback: Callable, content_types: Optional[List[str]]=None,
+        commands: Optional[List[str]]=None, regexp: Optional[str]=None, func: Optional[Callable]=None,
+        pass_bot: Optional[bool]=False, **kwargs):
+        """
+        Registers edited message handler for business accounts.
+
+        :param callback: function to be called
+        :type callback: :obj:`function`
+
+        :param content_types: Supported message content types. Must be a list. Defaults to ['text'].
+        :type content_types: :obj:`list` of :obj:`str`
+
+        :param commands: list of commands
+        :type commands: :obj:`list` of :obj:`str`
+
+        :param regexp: Regular expression
+        :type regexp: :obj:`str`
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
+        :type pass_bot: :obj:`bool`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return: None
+        """
+        method_name = "edited_business_message_handler"
+
+        if commands is not None:
+            self.check_commands_input(commands, method_name)
+            if isinstance(commands, str):
+                commands = [commands]
+
+        if regexp is not None:
+            self.check_regexp_input(regexp, method_name)
+
+        if isinstance(content_types, str):
+            logger.warning("edited_business_message_handler: 'content_types' filter should be List of strings (content types), not string.")
+            content_types = [content_types]
+
+        handler_dict = self._build_handler_dict(callback,
+                                                content_types=content_types,
+                                                commands=commands,
+                                                regexp=regexp,
+                                                func=func,
+                                                pass_bot=pass_bot,
+                                                **kwargs)
+        self.add_edited_business_message_handler(handler_dict)
+
+    
+    def deleted_business_messages_handler(self, func=None, **kwargs):
+        """
+        Handles new incoming deleted messages state.
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+        :return: None
+
+        """
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
+
+            self.add_deleted_message_handler(handler_dict)
+            return handler
+        
+        return decorator
+    
+    def add_deleted_business_messages_handler(self, handler_dict):
+        """
+        Adds a deleted_business_messages handler.
+        Note that you should use register_deleted_business_messages_handler to add deleted_business_messages_handler to the bot.
+
+        :meta private:
+        """
+        self.deleted_message_handlers.append(handler_dict)
+
+    def register_deleted_business_messages_handler(self, callback: Callable, func: Optional[Callable]=None, pass_bot: Optional[bool]=False, **kwargs):
+        """
+        Registers deleted business messages handler.
+
+        :param callback: function to be called
+        :type callback: :obj:`function`
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
+        :type pass_bot: :obj:`bool`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+
+        :return: None
+        """
+
+        handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
+        self.add_deleted_business_messages_handler(handler_dict)
 
     @staticmethod
     def _build_handler_dict(handler, pass_bot=False, **filters):

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -352,15 +352,16 @@ async def get_chat_member_count(token, chat_id):
     return await _process_request(token, method_url, params=payload)
 
 
-async def set_sticker_set_thumbnail(token, name, user_id, thumbnail):
+async def set_sticker_set_thumbnail(token, name, user_id, thumbnail, format):
     method_url = r'setStickerSetThumbnail'
-    payload = {'name': name, 'user_id': user_id}
+    payload = {'name': name, 'user_id': user_id, 'format': format}
     files = {}
     if thumbnail:
         if not isinstance(thumbnail, str):
             files['thumbnail'] = thumbnail
         else:
             payload['thumbnail'] = thumbnail
+        
     return await _process_request(token, method_url, params=payload, files=files or None)
 
 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -659,13 +659,15 @@ async def send_contact(
     return await _process_request(token, method_url, params=payload)
 
 
-async def send_chat_action(token, chat_id, action, timeout=None, message_thread_id=None):
+async def send_chat_action(token, chat_id, action, timeout=None, message_thread_id=None, business_connection_id=None):
     method_url = r'sendChatAction'
     payload = {'chat_id': chat_id, 'action': action}
     if timeout:
         payload['timeout'] = timeout
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload)
 
 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1234,6 +1234,10 @@ async def set_my_commands(token, commands, scope=None, language_code=None):
         payload['language_code'] = language_code
     return await _process_request(token, method_url, params=payload, method='post')
 
+async def get_business_connection(token, business_connection_id):
+    method_url = 'getBusinessConnection'
+    payload = {'business_connection_id': business_connection_id}
+    return await _process_request(token, method_url, params=payload , method='post')
 
 async def delete_my_commands(token, scope=None, language_code=None):
     method_url = r'deleteMyCommands'

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -281,7 +281,7 @@ async def send_message(
         reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
         entities=None, protect_content=None,
-        message_thread_id=None, reply_parameters=None, link_preview_options=None):
+        message_thread_id=None, reply_parameters=None, link_preview_options=None, business_connection_id=None):
     method_name = 'sendMessage'
     params = {'chat_id': str(chat_id), 'text': text}
     if link_preview_options is not None:
@@ -302,6 +302,8 @@ async def send_message(
         params['protect_content'] = protect_content
     if message_thread_id:
         params['message_thread_id'] = message_thread_id
+    if business_connection_id:
+        params['business_connection_id'] = business_connection_id
     
     return await _process_request(token, method_name, params=params)
 
@@ -433,7 +435,7 @@ async def send_dice(
         token, chat_id,
         emoji=None, disable_notification=None, 
         reply_markup=None, timeout=None,  protect_content=None,
-        message_thread_id=None,reply_parameters=None):
+        message_thread_id=None,reply_parameters=None, business_connection_id=None):
     method_url = r'sendDice'
     payload = {'chat_id': chat_id}
     if emoji:
@@ -450,6 +452,8 @@ async def send_dice(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -458,7 +462,8 @@ async def send_photo(
         caption=None,  reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
         caption_entities=None,  protect_content=None,
-        message_thread_id=None, has_spoiler=None,reply_parameters=None):
+        message_thread_id=None, has_spoiler=None,reply_parameters=None,
+        business_connection_id=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None
@@ -488,13 +493,15 @@ async def send_photo(
         payload['message_thread_id'] = message_thread_id
     if has_spoiler is not None:
         payload['has_spoiler'] = has_spoiler
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_media_group(
         token, chat_id, media,
         disable_notification=None, 
-        timeout=None,  protect_content=None, message_thread_id=None,reply_parameters=None):
+        timeout=None,  protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None):
     method_url = r'sendMediaGroup'
     media_json, files = await convert_input_media_array(media)
     payload = {'chat_id': chat_id, 'media': media_json}
@@ -508,6 +515,8 @@ async def send_media_group(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(
         token, method_url, params=payload,
         method='post' if files else 'get',
@@ -519,7 +528,7 @@ async def send_location(
         live_period=None,  
         reply_markup=None, disable_notification=None, 
         timeout=None, horizontal_accuracy=None, heading=None,
-        proximity_alert_radius=None,  protect_content=None, message_thread_id=None,reply_parameters=None):
+        proximity_alert_radius=None,  protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None):
     method_url = r'sendLocation'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude}
     if live_period:
@@ -542,6 +551,8 @@ async def send_location(
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -593,7 +604,7 @@ async def send_venue(
         foursquare_id=None, foursquare_type=None, disable_notification=None,
          reply_markup=None, timeout=None,
          google_place_id=None,
-        google_place_type=None, protect_content=None, message_thread_id=None,reply_parameters=None):
+        google_place_type=None, protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None):
     method_url = r'sendVenue'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude, 'title': title, 'address': address}
     if foursquare_id:
@@ -616,13 +627,15 @@ async def send_venue(
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload)
 
 
 async def send_contact(
         token, chat_id, phone_number, first_name, last_name=None, vcard=None,
         disable_notification=None,  reply_markup=None, timeout=None,
-         protect_content=None, message_thread_id=None,reply_parameters=None):
+         protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None):
     method_url = r'sendContact'
     payload = {'chat_id': chat_id, 'phone_number': phone_number, 'first_name': first_name}
     if last_name:
@@ -641,6 +654,8 @@ async def send_contact(
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -657,7 +672,7 @@ async def send_chat_action(token, chat_id, action, timeout=None, message_thread_
 async def send_video(token, chat_id, data, duration=None, caption=None,  reply_markup=None,
                      parse_mode=None, supports_streaming=None, disable_notification=None, timeout=None,
                      thumbnail=None, width=None, height=None, caption_entities=None, 
-                     protect_content=None, message_thread_id=None, has_spoiler=None,reply_parameters=None):
+                     protect_content=None, message_thread_id=None, has_spoiler=None,reply_parameters=None, business_connection_id=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -701,6 +716,8 @@ async def send_video(token, chat_id, data, duration=None, caption=None,  reply_m
         payload['message_thread_id'] = message_thread_id
     if has_spoiler is not None:
         payload['has_spoiler'] = has_spoiler
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -708,7 +725,7 @@ async def send_animation(
         token, chat_id, data, duration=None, caption=None,  reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None, thumbnail=None, caption_entities=None,
          width=None, height=None, protect_content=None, message_thread_id=None,
-        has_spoiler=None,reply_parameters=None):
+        has_spoiler=None,reply_parameters=None, business_connection_id=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}
     files = None
@@ -750,12 +767,14 @@ async def send_animation(
         payload['message_thread_id'] = message_thread_id
     if has_spoiler is not None:
         payload['has_spoiler'] = has_spoiler
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_voice(token, chat_id, voice, caption=None, duration=None,  reply_markup=None,
                parse_mode=None, disable_notification=None, timeout=None, caption_entities=None,
-                protect_content=None, message_thread_id=None,reply_parameters=None):
+                protect_content=None, message_thread_id=None,reply_parameters=None,business_connection_id=None):
     method_url = r'sendVoice'
     payload = {'chat_id': chat_id}
     files = None
@@ -783,12 +802,14 @@ async def send_voice(token, chat_id, voice, caption=None, duration=None,  reply_
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_video_note(token, chat_id, data, duration=None, length=None,  reply_markup=None,
                           disable_notification=None, timeout=None, thumbnail=None,  protect_content=None,
-                          message_thread_id=None,reply_parameters=None):
+                          message_thread_id=None,reply_parameters=None, business_connection_id=None):
     method_url = r'sendVideoNote'
     payload = {'chat_id': chat_id}
     files = None
@@ -822,12 +843,14 @@ async def send_video_note(token, chat_id, data, duration=None, length=None,  rep
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None, 
                      reply_markup=None, parse_mode=None, disable_notification=None, timeout=None, thumbnail=None,
-                     caption_entities=None,  protect_content=None, message_thread_id=None,reply_parameters=None):
+                     caption_entities=None,  protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None):
     method_url = r'sendAudio'
     payload = {'chat_id': chat_id}
     files = None
@@ -867,13 +890,15 @@ async def send_audio(token, chat_id, audio, caption=None, duration=None, perform
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_data(token, chat_id, data, data_type,  reply_markup=None, parse_mode=None,
                     disable_notification=None, timeout=None, caption=None, thumbnail=None, caption_entities=None,
                      disable_content_type_detection=None, visible_file_name=None, protect_content=None,
-                    message_thread_id=None, emoji=None,reply_parameters=None):
+                    message_thread_id=None, emoji=None,reply_parameters=None, business_connection_id=None):
     method_url = await get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None
@@ -914,6 +939,8 @@ async def send_data(token, chat_id, data, data_type,  reply_markup=None, parse_m
         payload['message_thread_id'] = message_thread_id
     if emoji:
         payload['emoji'] = emoji
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1363,7 +1390,7 @@ async def delete_message(token, chat_id, message_id, timeout=None):
 async def send_game(
         token, chat_id, game_short_name,
         disable_notification=None,  reply_markup=None, timeout=None,
-         protect_content=None, message_thread_id=None,reply_parameters=None):
+         protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None):
     method_url = r'sendGame'
     payload = {'chat_id': chat_id, 'game_short_name': game_short_name}
     if disable_notification is not None:
@@ -1378,6 +1405,8 @@ async def send_game(
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -1763,7 +1792,7 @@ async def send_poll(
         is_anonymous = None, type = None, allows_multiple_answers = None, correct_option_id = None,
         explanation = None, explanation_parse_mode=None, open_period = None, close_date = None, is_closed = None,
         disable_notification=False,  
-        reply_markup=None, timeout=None, explanation_entities=None, protect_content=None, message_thread_id=None,reply_parameters=None):
+        reply_markup=None, timeout=None, explanation_entities=None, protect_content=None, message_thread_id=None,reply_parameters=None,business_connection_id=None):
     method_url = r'sendPoll'
     payload = {
         'chat_id': str(chat_id),
@@ -1807,6 +1836,8 @@ async def send_poll(
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload)
 
 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -352,6 +352,12 @@ async def get_chat_member_count(token, chat_id):
     return await _process_request(token, method_url, params=payload)
 
 
+
+async def replace_sticker_in_set(token, user_id, name, old_sticker, sticker):
+    method_url = r'replaceStickerInSet'
+    payload = {'user_id': user_id, 'name': name, 'old_sticker': old_sticker, 'sticker': sticker.to_json()}
+    return await _process_request(token, method_url, params=payload)
+
 async def set_sticker_set_thumbnail(token, name, user_id, thumbnail, format):
     method_url = r'setStickerSetThumbnail'
     payload = {'name': name, 'user_id': user_id, 'format': format}

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -181,6 +181,15 @@ class Update(JsonDeserializable):
     :param business_connection: Optional. The bot was connected to or disconnected from a business account, or a user edited an existing connection with the bot
     :type business_connection: :class:`telebot.types.BusinessConnection`
 
+    :param business_message: Optional. New non-service message from a connected business account
+    :type business_message: :class:`telebot.types.Message`
+
+    :param edited_business_message: Optional. New version of a non-service message from a connected business account that is known to the bot and was edited
+    :type edited_business_message: :class:`telebot.types.Message`
+
+    :param deleted_business_messages: Optional. Service message: the chat connected to the business account was deleted
+    :type deleted_business_messages: :class:`telebot.types.Message`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.Update`
 
@@ -209,15 +218,19 @@ class Update(JsonDeserializable):
         removed_chat_boost = ChatBoostRemoved.de_json(obj.get('removed_chat_boost'))
         chat_boost = ChatBoostUpdated.de_json(obj.get('chat_boost'))
         business_connection = BusinessConnection.de_json(obj.get('business_connection'))
+        business_message = Message.de_json(obj.get('business_message'))
+        edited_business_message = Message.de_json(obj.get('edited_business_message'))
+        deleted_business_messages = Message.de_json(obj.get('deleted_business_messages'))
+
         return cls(update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                    chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
                    my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, removed_chat_boost, chat_boost,
-                     business_connection)
+                     business_connection, business_message, edited_business_message, deleted_business_messages, **obj)
 
     def __init__(self, update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                  chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
                  my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, removed_chat_boost, chat_boost,
-                    business_connection, **kwargs): 
+                    business_connection, business_message, edited_business_message, deleted_business_messages, **kwargs):
         self.update_id = update_id
         self.message = message
         self.edited_message = edited_message
@@ -238,6 +251,9 @@ class Update(JsonDeserializable):
         self.removed_chat_boost = removed_chat_boost
         self.chat_boost = chat_boost
         self.business_connection = business_connection
+        self.business_message = business_message
+        self.edited_business_message = edited_business_message
+        self.deleted_business_messages = deleted_business_messages
 
 
 
@@ -9363,3 +9379,36 @@ class BusinessConnection(JsonDeserializable):
         self.is_enabled: bool = is_enabled
 
 
+
+class BusinessMessagesDeleted(JsonDeserializable):
+    """
+    This object is received when messages are deleted from a connected business account.
+
+    Telegram documentation: https://core.telegram.org/bots/api#businessmessagesdeleted
+
+    :param business_connection_id: Unique identifier of the business connection
+    :type business_connection_id: :obj:`str`
+
+    :param chat: Information about a chat in the business account. The bot may not have access to the chat or the corresponding user.
+    :type chat: :class:`Chat`
+
+    :param message_ids: A JSON-serialized list of identifiers of deleted messages in the chat of the business account
+    :type message_ids: :obj:`list` of :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`BusinessMessagesDeleted`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['chat'] = Chat.de_json(obj['chat'])
+        return cls(**obj)
+    
+
+    def __init__(self, business_connection_id, chat, message_ids, **kwargs):
+        self.business_connection_id: str = business_connection_id
+        self.chat: Chat = chat
+        self.message_ids: List[int] = message_ids
+        

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -9043,13 +9043,13 @@ class UsersShared(JsonDeserializable):
     :param request_id: Identifier of the request
     :type request_id: :obj:`int`
 
-    :param user_ids: Identifiers of the shared users. These numbers may have more than 32 significant bits
+    :param user_ids: Array of :obj:`types.SharedUser` of the shared users. These numbers may have more than 32 significant bits
                      and some programming languages may have difficulty/silent defects in interpreting them.
                      But they have at most 52 significant bits, so 64-bit integers or double-precision float
                      types are safe for storing these identifiers. The bot may not have access to the users and
                      could be unable to use these identifiers unless the users are already known to the bot by
                      some other means.
-    :type user_ids: :obj:`list` of :obj:`int`
+    :type user_ids: :obj:`list` of :obj:`types.SharedUser`
 
     :return: Instance of the class
     :rtype: :class:`UsersShared`
@@ -9058,9 +9058,12 @@ class UsersShared(JsonDeserializable):
     def de_json(cls, json_string):
         if json_string is None: return None
         obj = cls.check_json(json_string)
+
+        obj['user_ids'] = [SharedUser.de_json(user) for user in obj['user_ids']]
+
         return cls(**obj)
 
-    def __init__(self, request_id, user_ids, **kwargs):
+    def __init__(self, request_id, user_ids: SharedUser, **kwargs):
         self.request_id = request_id
         self.user_ids = user_ids
 
@@ -9607,3 +9610,43 @@ class BusinessOpeningHours(JsonDeserializable):
         self.time_zone_name: str = time_zone_name
         self.opening_hours: List[BusinessOpeningHoursInterval] = opening_hours
 
+
+class SharedUser(JsonDeserializable):
+    """
+    This object contains information about a user that was shared with the bot using a KeyboardButtonRequestUser button.
+
+    Telegram documentation: https://core.telegram.org/bots/api#shareduser
+
+    :param user_id: Identifier of the shared user. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so 64-bit integers or double-precision float types are safe for storing these identifiers. The bot may not have access to the user and could be unable to use this identifier, unless the user is already known to the bot by some other means.
+    :type user_id: :obj:`int`
+
+    :param first_name: Optional. First name of the user, if the name was requested by the bot
+    :type first_name: :obj:`str`
+
+    :param last_name: Optional. Last name of the user, if the name was requested by the bot
+    :type last_name: :obj:`str`
+
+    :param username: Optional. Username of the user, if the username was requested by the bot
+    :type username: :obj:`str`
+
+    :param photo: Optional. Available sizes of the chat photo, if the photo was requested by the bot
+    :type photo: :obj:`list` of :class:`PhotoSize`
+
+    :return: Instance of the class
+    :rtype: :class:`SharedUser`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        if 'photo' in obj:
+            obj['photo'] = [PhotoSize.de_json(photo) for photo in obj['photo']]
+        return cls(**obj)
+    
+    def __init__(self, user_id, first_name=None, last_name=None, username=None, photo=None, **kwargs):
+        self.user_id: int = user_id
+        self.first_name: Optional[str] = first_name
+        self.last_name: Optional[str] = last_name
+        self.username: Optional[str] = username
+        self.photo: Optional[List[PhotoSize]] = photo

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -225,7 +225,7 @@ class Update(JsonDeserializable):
         return cls(update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                    chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
                    my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, removed_chat_boost, chat_boost,
-                     business_connection, business_message, edited_business_message, deleted_business_messages, **obj)
+                     business_connection, business_message, edited_business_message, deleted_business_messages)
 
     def __init__(self, update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                  chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -178,6 +178,9 @@ class Update(JsonDeserializable):
     :param removed_chat_boost: Optional. A chat boost was removed. The bot must be an administrator in the chat to receive these updates.
     :type removed_chat_boost: :class:`telebot.types.RemovedChatBoost`
 
+    :param business_connection: Optional. The bot was connected to or disconnected from a business account, or a user edited an existing connection with the bot
+    :type business_connection: :class:`telebot.types.BusinessConnection`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.Update`
 
@@ -205,13 +208,16 @@ class Update(JsonDeserializable):
         message_reaction_count = MessageReactionCountUpdated.de_json(obj.get('message_reaction_count'))
         removed_chat_boost = ChatBoostRemoved.de_json(obj.get('removed_chat_boost'))
         chat_boost = ChatBoostUpdated.de_json(obj.get('chat_boost'))
+        business_connection = BusinessConnection.de_json(obj.get('business_connection'))
         return cls(update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                    chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                   my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, removed_chat_boost, chat_boost)
+                   my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, removed_chat_boost, chat_boost,
+                     business_connection)
 
     def __init__(self, update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                  chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                 my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, removed_chat_boost, chat_boost):
+                 my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, removed_chat_boost, chat_boost,
+                    business_connection, **kwargs): 
         self.update_id = update_id
         self.message = message
         self.edited_message = edited_message
@@ -231,6 +237,8 @@ class Update(JsonDeserializable):
         self.message_reaction_count = message_reaction_count
         self.removed_chat_boost = removed_chat_boost
         self.chat_boost = chat_boost
+        self.business_connection = business_connection
+
 
 
 class ChatMemberUpdated(JsonDeserializable):
@@ -9308,3 +9316,50 @@ class ChatBoostAdded(JsonDeserializable):
     
     def __init__(self, boost_count, **kwargs):
         self.boost_count: int = boost_count
+
+
+
+class BusinessConnection(JsonDeserializable):
+    """
+    This object describes the connection of the bot with a business account.
+
+    Telegram documentation: https://core.telegram.org/bots/api#businessconnection
+
+    :param id: Unique identifier of the business connection
+    :type id: :obj:`str`
+
+    :param user: Business account user that created the business connection
+    :type user: :class:`User`
+
+    :param user_chat_id: Identifier of a private chat with the user who created the business connection
+    :type user_chat_id: :obj:`int`
+
+    :param date: Date the connection was established in Unix time
+    :type date: :obj:`int`
+
+    :param can_reply: True, if the bot can act on behalf of the business account in chats that were active in the last 24 hours
+    :type can_reply: :obj:`bool`
+
+    :param is_enabled: True, if the connection is active
+    :type is_enabled: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`BusinessConnection`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['user'] = User.de_json(obj['user'])
+        return cls(**obj)
+    
+    def __init__(self, id, user, user_chat_id, date, can_reply, is_enabled, **kwargs):
+        self.id: str = id
+        self.user: User = user
+        self.user_chat_id: int = user_chat_id
+        self.date: int = date
+        self.can_reply: bool = can_reply
+        self.is_enabled: bool = is_enabled
+
+

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -584,6 +584,15 @@ class Chat(JsonDeserializable):
         Returned only in getChat.
     :type active_usernames: :obj:`list` of :obj:`str`
 
+    :param business_intro: Optional. Business intro for the chat. Returned only in getChat.
+    :type business_intro: :class:`telebot.types.BusinessIntro`
+
+    :param business_location: Optional. Business location for the chat. Returned only in getChat.
+    :type business_location: :class:`telebot.types.BusinessLocation`
+
+    :param business_opening_hours : Optional. Business opening hours for the chat. Returned only in getChat.
+    :type business_opening_hours: :class:`telebot.types.BusinessHours`
+
     :param available_reactions: Optional. List of available chat reactions; for private chats, supergroups and channels.
         Returned only in getChat.
     :type available_reactions: :obj:`list` of :class:`telebot.types.ReactionType`
@@ -711,6 +720,12 @@ class Chat(JsonDeserializable):
             obj['location'] = ChatLocation.de_json(obj['location'])
         if 'available_reactions' in obj:
             obj['available_reactions'] = [ReactionType(reaction) for reaction in obj['available_reactions']]
+        if 'business_intro' in obj:
+            obj['business_intro'] = BusinessIntro.de_json(obj['business_intro'])
+        if 'business_location' in obj:
+            obj['business_location'] = BusinessLocation.de_json(obj['business_location'])
+        if 'business_opening_hours' in obj:
+            obj['business_opening_hours'] = BusinessOpeningHours.de_json(obj['business_opening_hours'])
         return cls(**obj)
 
     def __init__(self, id, type, title=None, username=None, first_name=None,
@@ -724,7 +739,8 @@ class Chat(JsonDeserializable):
                  has_hidden_members=None, has_aggressive_anti_spam_enabled=None, emoji_status_expiration_date=None, 
                  available_reactions=None, accent_color_id=None, background_custom_emoji_id=None, profile_accent_color_id=None,
                  profile_background_custom_emoji_id=None, has_visible_history=None, 
-                 unrestrict_boost_count=None, custom_emoji_sticker_set_name=None, **kwargs):
+                 unrestrict_boost_count=None, custom_emoji_sticker_set_name=None, business_intro=None, business_location=None,
+                    business_opening_hours=None, **kwargs):
         self.id: int = id
         self.type: str = type
         self.title: str = title
@@ -762,6 +778,9 @@ class Chat(JsonDeserializable):
         self.has_visible_history: bool = has_visible_history
         self.unrestrict_boost_count: int = unrestrict_boost_count
         self.custom_emoji_sticker_set_name: str = custom_emoji_sticker_set_name
+        self.business_intro: BusinessIntro = business_intro
+        self.business_location: BusinessLocation = business_location
+        self.business_opening_hours: BusinessOpeningHours = business_opening_hours
 
 
 
@@ -9426,3 +9445,122 @@ class BusinessMessagesDeleted(JsonDeserializable):
         self.chat: Chat = chat
         self.message_ids: List[int] = message_ids
         
+
+class BusinessIntro(JsonDeserializable):
+    """
+    This object represents a business intro.
+
+    Telegram documentation: https://core.telegram.org/bots/api#businessintro
+
+    :param title: Optional. Title text of the business intro
+    :type title: :obj:`str`
+
+    :param message: Optional. Message text of the business intro
+    :type message: :obj:`str`
+
+    :param sticker: Optional. Sticker of the business intro
+    :type sticker: :class:`Sticker`
+
+    :return: Instance of the class
+    :rtype: :class:`BusinessIntro`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        if 'sticker' in obj:
+            obj['sticker'] = Sticker.de_json(obj['sticker'])
+        return cls(**obj)
+    
+    def __init__(self, title=None, message=None, sticker=None, **kwargs):
+        self.title: Optional[str] = title
+        self.message: Optional[str] = message
+        self.sticker: Optional[Sticker] = sticker
+
+
+class BusinessLocation(JsonDeserializable):
+    """
+    This object represents a business location.
+
+    Telegram documentation: https://core.telegram.org/bots/api#businesslocation
+
+    :param address: Address of the business
+    :type address: :obj:`str`
+
+    :param location: Optional. Location of the business
+    :type location: :class:`Location`
+
+    :return: Instance of the class
+    :rtype: :class:`BusinessLocation`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        if 'location' in obj:
+            obj['location'] = Location.de_json(obj['location'])
+        return cls(**obj)
+    
+    def __init__(self, address, location=None, **kwargs):
+        self.address: str = address
+        self.location: Optional[Location] = location
+
+
+class BusinessOpeningHoursInterval(JsonDeserializable):
+    """
+    This object represents a business opening hours interval.
+
+    Telegram documentation: https://core.telegram.org/bots/api#businessopeninghoursinterval
+
+    :param opening_minute: The minute's sequence number in a week, starting on Monday, marking the start of the time interval during which the business is open; 0 - 7 24 60
+    :type opening_minute: :obj:`int`
+
+    :param closing_minute: The minute's sequence number in a week, starting on Monday, marking the end of the time interval during which the business is open; 0 - 8 24 60
+    :type closing_minute: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`BusinessOpeningHoursInterval`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+    
+    def __init__(self, opening_minute, closing_minute, **kwargs):
+        self.opening_minute: int = opening_minute
+        self.closing_minute: int = closing_minute
+
+
+class BusinessOpeningHours(JsonDeserializable):
+    """
+
+    This object represents business opening hours.
+
+    Telegram documentation: https://core.telegram.org/bots/api#businessopeninghours
+
+    :param time_zone_name: Unique name of the time zone for which the opening hours are defined
+    :type time_zone_name: :obj:`str`
+
+    :param opening_hours: List of time intervals describing business opening hours
+    :type opening_hours: :obj:`list` of :class:`BusinessOpeningHoursInterval`
+
+    :return: Instance of the class
+
+    :rtype: :class:`BusinessOpeningHours`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['opening_hours'] = [BusinessOpeningHoursInterval.de_json(interval) for interval in obj['opening_hours']]
+        return cls(**obj)
+    
+    def __init__(self, time_zone_name, opening_hours, **kwargs):
+        self.time_zone_name: str = time_zone_name
+        self.opening_hours: List[BusinessOpeningHoursInterval] = opening_hours
+

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -220,7 +220,7 @@ class Update(JsonDeserializable):
         business_connection = BusinessConnection.de_json(obj.get('business_connection'))
         business_message = Message.de_json(obj.get('business_message'))
         edited_business_message = Message.de_json(obj.get('edited_business_message'))
-        deleted_business_messages = Message.de_json(obj.get('deleted_business_messages'))
+        deleted_business_messages = BusinessMessagesDeleted.de_json(obj.get('deleted_business_messages'))
 
         return cls(update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                    chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -481,6 +481,9 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
     :param supports_inline_queries: Optional. True, if the bot supports inline queries. Returned only in getMe.
     :type supports_inline_queries: :obj:`bool`
 
+    :param can_connect_to_business: Optional. True, if the bot can be connected to a Telegram Business account to receive its messages. Returned only in getMe.
+    :type can_connect_to_business: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.User`
     """
@@ -492,7 +495,7 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
 
     def __init__(self, id, is_bot, first_name, last_name=None, username=None, language_code=None, 
                  can_join_groups=None, can_read_all_group_messages=None, supports_inline_queries=None, 
-                 is_premium=None, added_to_attachment_menu=None, **kwargs):
+                 is_premium=None, added_to_attachment_menu=None, can_connect_to_business=None, **kwargs):
         self.id: int = id
         self.is_bot: bool = is_bot
         self.first_name: str = first_name
@@ -504,6 +507,7 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
         self.supports_inline_queries: bool = supports_inline_queries
         self.is_premium: bool = is_premium
         self.added_to_attachment_menu: bool = added_to_attachment_menu
+        self.can_connect_to_business: bool = can_connect_to_business
 
 
     @property
@@ -530,7 +534,9 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
                 'can_read_all_group_messages': self.can_read_all_group_messages,
                 'supports_inline_queries': self.supports_inline_queries,
                 'is_premium': self.is_premium,
-                'added_to_attachment_menu': self.added_to_attachment_menu}
+                'added_to_attachment_menu': self.added_to_attachment_menu,
+                'can_connect_to_business': self.can_connect_to_business}
+    
 
 
 class GroupChat(JsonDeserializable):
@@ -592,6 +598,9 @@ class Chat(JsonDeserializable):
 
     :param business_opening_hours : Optional. Business opening hours for the chat. Returned only in getChat.
     :type business_opening_hours: :class:`telebot.types.BusinessHours`
+
+    :param personal_chat: Optional. For private chats, the personal channel of the user. Returned only in getChat.
+    :type personal_chat: :class:`telebot.types.Chat`
 
     :param available_reactions: Optional. List of available chat reactions; for private chats, supergroups and channels.
         Returned only in getChat.
@@ -726,6 +735,8 @@ class Chat(JsonDeserializable):
             obj['business_location'] = BusinessLocation.de_json(obj['business_location'])
         if 'business_opening_hours' in obj:
             obj['business_opening_hours'] = BusinessOpeningHours.de_json(obj['business_opening_hours'])
+        if 'personal_chat' in obj:
+            obj['personal_chat'] = Chat.de_json(obj['personal_chat'])
         return cls(**obj)
 
     def __init__(self, id, type, title=None, username=None, first_name=None,
@@ -740,7 +751,7 @@ class Chat(JsonDeserializable):
                  available_reactions=None, accent_color_id=None, background_custom_emoji_id=None, profile_accent_color_id=None,
                  profile_background_custom_emoji_id=None, has_visible_history=None, 
                  unrestrict_boost_count=None, custom_emoji_sticker_set_name=None, business_intro=None, business_location=None,
-                    business_opening_hours=None, **kwargs):
+                    business_opening_hours=None, personal_chat=None, **kwargs):
         self.id: int = id
         self.type: str = type
         self.title: str = title
@@ -781,6 +792,7 @@ class Chat(JsonDeserializable):
         self.business_intro: BusinessIntro = business_intro
         self.business_location: BusinessLocation = business_location
         self.business_opening_hours: BusinessOpeningHours = business_opening_hours
+        self.personal_chat: Chat = personal_chat
 
 
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -2578,16 +2578,29 @@ class KeyboardButtonRequestUsers(Dictionaryable):
     :param max_quantity: Optional. The maximum number of users to be selected; 1-10. Defaults to 1.
     :type max_quantity: :obj:`int`
 
+    :param request_name: Optional. Request name
+    :type request_name: :obj:`bool`
+
+    :param request_username: Optional. Request username
+    :type request_username: :obj:`bool`
+
+    :param request_photo: Optional. Request photo
+    :type request_photo: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.KeyboardButtonRequestUsers`
     """
     def __init__(
             self, request_id: int, user_is_bot: Optional[bool]=None, user_is_premium: Optional[bool]=None,
-            max_quantity: Optional[int]=None) -> None:
+            max_quantity: Optional[int]=None, request_name: Optional[str]=None, request_username: Optional[bool]=None,
+            request_photo: Optional[bool]=None) -> None:
         self.request_id: int = request_id
         self.user_is_bot: Optional[bool] = user_is_bot
         self.user_is_premium: Optional[bool] = user_is_premium
         self.max_quantity: Optional[int] = max_quantity
+        self.request_name: Optional[str] = request_name
+        self.request_username: Optional[bool] = request_username
+        self.request_photo: Optional[bool] = request_photo
 
     def to_dict(self) -> dict:
         data = {'request_id': self.request_id}
@@ -2597,6 +2610,12 @@ class KeyboardButtonRequestUsers(Dictionaryable):
             data['user_is_premium'] = self.user_is_premium
         if self.max_quantity is not None:
             data['max_quantity'] = self.max_quantity
+        if self.request_name is not None:
+            data['request_name'] = self.request_name
+        if self.request_username is not None:
+            data['request_username'] = self.request_username
+        if self.request_photo is not None:
+            data['request_photo'] = self.request_photo
         return data
 
 
@@ -2645,6 +2664,15 @@ class KeyboardButtonRequestChat(Dictionaryable):
     :param bot_is_member: Optional. Pass True to request a chat where the bot is a member. Otherwise, no additional restrictions are applied.
     :type bot_is_member: :obj:`bool`
 
+    :param request_title: Optional. Request title
+    :type request_title: :obj:`bool`
+
+    :param request_photo: Optional. Request photo
+    :type request_photo: :obj:`bool`
+
+    :param request_username: Optional. Request username
+    :type request_username: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.KeyboardButtonRequestChat`
     """
@@ -2652,7 +2680,8 @@ class KeyboardButtonRequestChat(Dictionaryable):
     def __init__(self, request_id: int, chat_is_channel: bool, chat_is_forum: Optional[bool]=None,
                  chat_has_username: Optional[bool]=None, chat_is_created: Optional[bool]=None,
                  user_administrator_rights: Optional[ChatAdministratorRights]=None,
-                 bot_administrator_rights: Optional[ChatAdministratorRights]=None, bot_is_member: Optional[bool]=None) -> None:
+                 bot_administrator_rights: Optional[ChatAdministratorRights]=None, bot_is_member: Optional[bool]=None,
+                 request_title: Optional[str]=None, request_photo: Optional[bool]=None, request_username: Optional[bool]=None):
         self.request_id: int = request_id
         self.chat_is_channel: bool = chat_is_channel
         self.chat_is_forum: Optional[bool] = chat_is_forum
@@ -2661,6 +2690,9 @@ class KeyboardButtonRequestChat(Dictionaryable):
         self.user_administrator_rights: Optional[ChatAdministratorRights] = user_administrator_rights
         self.bot_administrator_rights: Optional[ChatAdministratorRights] = bot_administrator_rights
         self.bot_is_member: Optional[bool] = bot_is_member
+        self.request_title: Optional[str] = request_title
+        self.request_photo: Optional[bool] = request_photo
+        self.request_username: Optional[bool] = request_username
 
 
     def to_dict(self) -> dict:
@@ -2677,6 +2709,12 @@ class KeyboardButtonRequestChat(Dictionaryable):
             data['bot_administrator_rights'] = self.bot_administrator_rights.to_dict()
         if self.bot_is_member is not None:
             data['bot_is_member'] = self.bot_is_member
+        if self.request_title is not None:
+            data['request_title'] = self.request_title
+        if self.request_photo is not None:
+            data['request_photo'] = self.request_photo
+        if self.request_username is not None:
+            data['request_username'] = self.request_username
         return data
 
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -590,6 +590,9 @@ class Chat(JsonDeserializable):
         Returned only in getChat.
     :type active_usernames: :obj:`list` of :obj:`str`
 
+    :param birthdate: Optional. Birthdate of the other party in a private chat. Returned only in getChat.
+    :type birthdate: :obj:`str`
+
     :param business_intro: Optional. Business intro for the chat. Returned only in getChat.
     :type business_intro: :class:`telebot.types.BusinessIntro`
 
@@ -737,6 +740,8 @@ class Chat(JsonDeserializable):
             obj['business_opening_hours'] = BusinessOpeningHours.de_json(obj['business_opening_hours'])
         if 'personal_chat' in obj:
             obj['personal_chat'] = Chat.de_json(obj['personal_chat'])
+        if 'birthdate' in obj:
+            obj['birthdate'] = Birthdate.de_json(obj['birthdate'])
         return cls(**obj)
 
     def __init__(self, id, type, title=None, username=None, first_name=None,
@@ -751,7 +756,7 @@ class Chat(JsonDeserializable):
                  available_reactions=None, accent_color_id=None, background_custom_emoji_id=None, profile_accent_color_id=None,
                  profile_background_custom_emoji_id=None, has_visible_history=None, 
                  unrestrict_boost_count=None, custom_emoji_sticker_set_name=None, business_intro=None, business_location=None,
-                    business_opening_hours=None, personal_chat=None, **kwargs):
+                    business_opening_hours=None, personal_chat=None, birthdate=None, **kwargs):
         self.id: int = id
         self.type: str = type
         self.title: str = title
@@ -793,6 +798,7 @@ class Chat(JsonDeserializable):
         self.business_location: BusinessLocation = business_location
         self.business_opening_hours: BusinessOpeningHours = business_opening_hours
         self.personal_chat: Chat = personal_chat
+        self.birthdate: Birthdate = birthdate
 
 
 
@@ -9682,3 +9688,34 @@ class SharedUser(JsonDeserializable):
         self.last_name: Optional[str] = last_name
         self.username: Optional[str] = username
         self.photo: Optional[List[PhotoSize]] = photo
+
+
+class Birthdate(JsonDeserializable):
+    """
+    This object represents a user's birthdate.
+
+    Telegram documentation: https://core.telegram.org/bots/api#birthdate
+
+    :param day: Day of the user's birth; 1-31
+    :type day: :obj:`int`
+
+    :param month: Month of the user's birth; 1-12
+    :type month: :obj:`int`
+
+    :param year: Optional. Year of the user's birth
+    :type year: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`Birthdate`
+    """
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+    
+    def __init__(self, day, month, year=None, **kwargs):
+        self.day: int = day
+        self.month: int = month
+        self.year: Optional[int] = year

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -926,6 +926,10 @@ class Message(JsonDeserializable):
     :param has_protected_content: Optional. :obj:`bool`, if the message can't be forwarded
     :type has_protected_content: :obj:`bool`
 
+    :param is_from_offline: Optional. True, if the message was sent by an implicit action, for example,
+        as an away or a greeting business message, or as a scheduled message
+    :type is_from_offline: :obj:`bool`
+
     :param media_group_id: Optional. The unique identifier of a media message group this message belongs to
     :type media_group_id: :obj:`str`
 
@@ -1356,6 +1360,8 @@ class Message(JsonDeserializable):
             opts['sender_business_bot'] = User.de_json(obj['sender_business_bot'])
         if 'business_connection_id' in obj:
             opts['business_connection_id'] = obj['business_connection_id']
+        if 'is_from_offline' in obj:
+            opts['is_from_offline'] = obj['is_from_offline']
 
 
 
@@ -1463,6 +1469,7 @@ class Message(JsonDeserializable):
         self.reply_to_story: Optional[Story] = None
         self.sender_business_bot: Optional[User] = None
         self.business_connection_id: Optional[str] = None
+        self.is_from_offline: Optional[bool] = None
 
         for key in options:
             setattr(self, key, options[key])

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -7950,15 +7950,19 @@ class InputSticker(Dictionaryable, JsonSerializable):
         For “regular” and “custom_emoji” stickers only.
     :type keywords: :obj:`list` of :obj:`str`
 
+    :param format: 	Format of the added sticker, must be one of “static” for a .WEBP or .PNG image, “animated” for a .TGS animation, “video” for a WEBM video
+    :type format: :obj:`str`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.InputSticker`
     """
 
-    def __init__(self, sticker: Union[str, InputFile], emoji_list: List[str], mask_position: Optional[MaskPosition]=None, keywords: Optional[List[str]]=None) -> None:
+    def __init__(self, sticker: Union[str, InputFile], emoji_list: List[str],  format: str, mask_position: Optional[MaskPosition]=None, keywords: Optional[List[str]]=None) -> None:
         self.sticker: Union[str, InputFile] = sticker
         self.emoji_list: List[str] = emoji_list
         self.mask_position: Optional[MaskPosition] = mask_position
         self.keywords: Optional[List[str]] = keywords
+        self.format: str = format
 
         if service_utils.is_string(self.sticker):
             self._sticker_name = ''
@@ -7973,7 +7977,8 @@ class InputSticker(Dictionaryable, JsonSerializable):
     def to_dict(self) -> dict:
         json_dict = {
             'sticker': self._sticker_dic,
-            'emoji_list': self.emoji_list
+            'emoji_list': self.emoji_list,
+            'format': self.format
         }
 
         if self.mask_position is not None:

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -843,8 +843,15 @@ class Message(JsonDeserializable):
     :param sender_boost_count: Optional. If the sender of the message boosted the chat, the number of boosts added by the user
     :type sender_boost_count: :obj:`int`
 
+    :param sender_business_bot info: Optional. Information about the business bot that sent the message
+    :type sender_business_bot_info: :class:`telebot.types.User`
+
     :param date: Date the message was sent in Unix time
     :type date: :obj:`int`
+
+    :param business_connection_id: Optional. Unique identifier of the business connection from which the message was received. If non-empty,
+        the message belongs to a chat of the corresponding business account that is independent from any potential bot chat which might share the same identifier.
+    :type business_connection_id: :obj:`str`
 
     :param chat: Conversation the message belongs to
     :type chat: :class:`telebot.types.Chat`
@@ -1326,6 +1333,11 @@ class Message(JsonDeserializable):
             opts['sender_boost_count'] = obj['sender_boost_count']
         if 'reply_to_story' in obj:
             opts['reply_to_story'] = Story.de_json(obj['reply_to_story'])
+        if 'sender_business_bot' in obj:
+            opts['sender_business_bot'] = User.de_json(obj['sender_business_bot'])
+        if 'business_connection_id' in obj:
+            opts['business_connection_id'] = obj['business_connection_id']
+
 
 
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
@@ -1430,6 +1442,8 @@ class Message(JsonDeserializable):
         self.boost_added: Optional[ChatBoostAdded] = None
         self.sender_boost_count: Optional[int] = None
         self.reply_to_story: Optional[Story] = None
+        self.sender_business_bot: Optional[User] = None
+        self.business_connection_id: Optional[str] = None
 
         for key in options:
             setattr(self, key, options[key])

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -7908,6 +7908,15 @@ class ChatShared(JsonDeserializable):
         and could be unable to use this identifier, unless the chat is already known to the bot by some other means.
     :type chat_id: :obj:`int`
 
+    :param title: Optional. Title of the shared chat
+    :type title: :obj:`str`
+
+    :param photo: Optional. Array of Photosize
+    :type photo: :obj:`list` of :class:`telebot.types.PhotoSize`
+
+    :param username: Optional. Username of the shared chat
+    :type username: :obj:`str`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatShared`
     """
@@ -7918,9 +7927,13 @@ class ChatShared(JsonDeserializable):
         obj = cls.check_json(json_string)
         return cls(**obj)
 
-    def __init__(self, request_id: int, chat_id: int, **kwargs) -> None:
+    def __init__(self, request_id: int, chat_id: int, title: Optional[str]=None, photo: Optional[List[PhotoSize]]=None,
+                    username: Optional[str]=None, **kwargs) -> None:
         self.request_id: int = request_id
         self.chat_id: int = chat_id
+        self.title: Optional[str] = title
+        self.photo: Optional[List[PhotoSize]] = photo
+        self.username: Optional[str] = username
 
 
 class BotDescription(JsonDeserializable):

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -48,6 +48,7 @@ update_types = [
     "message", "edited_message", "channel_post", "edited_channel_post", "inline_query", "chosen_inline_result",
     "callback_query", "shipping_query", "pre_checkout_query", "poll", "poll_answer", "my_chat_member", "chat_member",
     "chat_join_request", "message_reaction", "message_reaction_count", "chat_boost", "removed_chat_boost",
+    "business_connection", "business_message", "edited_business_message", "deleted_business_messages"
 ]
 
 

--- a/tests/test_handler_backends.py
+++ b/tests/test_handler_backends.py
@@ -71,7 +71,7 @@ def update_type(message):
     chat_boost_removed = None
     return types.Update(1001234038283, message, edited_message, channel_post, edited_channel_post, inline_query,
                         chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                        my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, chat_boost, chat_boost_removed)
+                        my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, chat_boost, chat_boost_removed, None, None, None, None)
 
 
 @pytest.fixture()
@@ -95,7 +95,7 @@ def reply_to_message_update_type(reply_to_message):
     chat_boost_removed = None
     return types.Update(1001234038284, reply_to_message, edited_message, channel_post, edited_channel_post,
                         inline_query, chosen_inline_result, callback_query, shipping_query, pre_checkout_query, 
-                        poll, poll_answer, my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, chat_boost, chat_boost_removed)
+                        poll, poll_answer, my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, chat_boost, chat_boost_removed, None, None, None, None)
 
 
 def next_handler(message):


### PR DESCRIPTION
Not promising anything, let's see how far I can go.

Bot API 7.2

Integration with Business Accounts


- [x] Added the class [BusinessConnection](https://core.telegram.org/bots/api#businessconnection) and updates about the connection or disconnection of the bot to a business account, represented by the field business_connection in the class [Update](https://core.telegram.org/bots/api#update).

- [x] Added updates about new messages in a business account connected to the bot, represented by the field business_message in the class [Update](https://core.telegram.org/bots/api#update).
- [x] Added updates about message edits in a business account connected to the bot, represented by the field edited_business_message in the class [Update](https://core.telegram.org/bots/api#update).
- [x] Added updates about message deletion in a business account connected to the bot, represented by the class [BusinessMessagesDeleted](https://core.telegram.org/bots/api#businessmessagesdeleted) and the field deleted_business_messages in the class [Update](https://core.telegram.org/bots/api#update).
- [x] Added the method [getBusinessConnection](https://core.telegram.org/bots/api#getbusinessconnection).
Working on Behalf of Business Accounts

- [x] Added the parameter business_connection_id to the methods [sendMessage](https://core.telegram.org/bots/api#sendmessage), [sendPhoto](https://core.telegram.org/bots/api#sendphoto), [sendVideo](https://core.telegram.org/bots/api#sendvideo), [sendAnimation](https://core.telegram.org/bots/api#sendanimation), [sendAudio](https://core.telegram.org/bots/api#sendaudio), [sendDocument](https://core.telegram.org/bots/api#senddocument), [sendSticker](https://core.telegram.org/bots/api#sendsticker), [sendVideoNote](https://core.telegram.org/bots/api#sendvideonote), [sendVoice](https://core.telegram.org/bots/api#sendvoice), [sendLocation](https://core.telegram.org/bots/api#sendlocation), [sendVenue](https://core.telegram.org/bots/api#sendvenue), [sendContact](https://core.telegram.org/bots/api#sendcontact), [sendPoll](https://core.telegram.org/bots/api#sendpoll), [sendDice](https://core.telegram.org/bots/api#senddice), [sendGame](https://core.telegram.org/bots/api#sendgame), and [sendMediaGroup](https://core.telegram.org/bots/api#sendmediagroup).
- [x] Added the parameter business_connection_id to the method [sendChatAction](https://core.telegram.org/bots/api#sendchataction).
- [x] Added the field business_connection_id to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the field sender_business_bot to the class [Message](https://core.telegram.org/bots/api#message).
Information about Business Accounts

- [x] Added the class [BusinessIntro](https://core.telegram.org/bots/api#businessintro) and the field business_intro to the class [Chat](https://core.telegram.org/bots/api#chat).
- [x] Added the class [BusinessLocation](https://core.telegram.org/bots/api#businesslocation) and the field business_location to the class [Chat](https://core.telegram.org/bots/api#chat).
- [x] Added the classes [BusinessOpeningHours](https://core.telegram.org/bots/api#businessopeninghours) and [BusinessOpeningHoursInterval](https://core.telegram.org/bots/api#businessopeninghoursinterval) and the field business_opening_hours to the class [Chat](https://core.telegram.org/bots/api#chat).
Mixed-Format Sticker Packs

- [ ] Removed the fields is_animated and is_video from the class [StickerSet](https://core.telegram.org/bots/api#stickerset).
- [x] Added the field format to the class [InputSticker](https://core.telegram.org/bots/api#inputsticker).
- [ ] Removed the parameter sticker_format from the method [createNewStickerSet](https://core.telegram.org/bots/api#createnewstickerset).
- [x] Added the parameter format to the method [setStickerSetThumbnail](https://core.telegram.org/bots/api#setstickersetthumbnail).
- [x] Increased the maximum number of stickers in any regular and mask sticker set to 120.
- [x] Allowed to upload WEBM stickers using [SendSticker](https://core.telegram.org/bots/api#sendsticker).
Request Chat Improvements

- [x] Added the fields request_name, request_username, and request_photo to the class [KeyboardButtonRequestUsers](https://core.telegram.org/bots/api#keyboardbuttonrequestusers).
- [x] Added the fields request_title, request_username, and request_photo to the class [KeyboardButtonRequestChat](https://core.telegram.org/bots/api#keyboardbuttonrequestchat).
- [x] Added the class SharedUser and replaced the field user_ids in the class [UsersShared](https://core.telegram.org/bots/api#usersshared) with the field users.
- [x] Added the fields title, username, and photo to the class [ChatShared](https://core.telegram.org/bots/api#chatshared).
Other Changes

- [x] Added the field is_from_offline to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the field can_connect_to_business to the class [User](https://core.telegram.org/bots/api#user).
- [x] Added the field personal_chat to the class [Chat](https://core.telegram.org/bots/api#chat).
- [x] Added the method [replaceStickerInSet](https://core.telegram.org/bots/api#replacestickerinset),
- [x] Added the class [Birthdate](https://core.telegram.org/bots/api#birthdate) and the field birthdate to the class [Chat](https://core.telegram.org/bots/api#chat).
- [x] Added the field BiometricManager to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).
