### PR TITLE
Sticker set initialization fix

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -6308,7 +6308,7 @@ class StickerSet(JsonDeserializable):
             obj['thumbnail'] = None
         return cls(**obj)
 
-    def __init__(self, name, title, sticker_type, is_animated, is_video, stickers, thumbnail=None, **kwargs):
+    def __init__(self, name, title, sticker_type, stickers, thumbnail=None, is_animated=False, is_video=False, **kwargs):
         self.name: str = name
         self.title: str = title
         self.sticker_type: str = sticker_type


### PR DESCRIPTION
## Description

Fixed 

```
 __init__() missing 2 required positional arguments: 'is_animated' and 'is_video'
```

by re-arranging arguments and assigning default values.

Tested on frequently updating stickers https://t.me/addstickers/hcn_by_SatoshiSaysBot