### PR TITLE
Bot API 7.2 u1

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5890,7 +5890,7 @@ class TeleBot:
             stickers = [types.InputSticker(sticker=stickers, emoji_list=emojis, mask_position=mask_position)]
 
         if sticker_format:
-            logger.warning('The parameter "sticker_format" is deprecated since Bot API 7.2+. Stickers can now be mixed')
+            logger.warning('The parameter "sticker_format" is deprecated since Bot API 7.2. Stickers can now be mixed')
 
         return apihelper.create_new_sticker_set(
             self.token, user_id, name, title, stickers, sticker_type=sticker_type, needs_repainting=needs_repainting)

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -213,6 +213,7 @@ class TeleBot:
         # handlers
         self.exception_handler = exception_handler
         self.update_listener = []
+
         self.message_handlers = []
         self.edited_message_handlers = []
         self.channel_post_handlers = []
@@ -247,6 +248,8 @@ class TeleBot:
                 'edited_message': [],
                 'channel_post': [],
                 'edited_channel_post': [],
+                'message_reaction': [],
+                'message_reaction_count': [],
                 'inline_query': [],
                 'chosen_inline_result': [],
                 'callback_query': [],
@@ -256,7 +259,13 @@ class TeleBot:
                 'poll_answer': [],
                 'my_chat_member': [],
                 'chat_member': [],
-                'chat_join_request': []
+                'chat_join_request': [],
+                'chat_boost': [],
+                'removed_chat_boost': [],
+                'business_connection': [],
+                'business_message': [],
+                'edited_business_message': [],
+                'deleted_business_messages': [],
             }
             self.default_middleware_handlers = []
         if apihelper.ENABLE_MIDDLEWARE and use_class_middlewares:
@@ -5570,8 +5579,8 @@ class TeleBot:
         :return: On success, True is returned.
         :rtype: :obj:`bool`
         """
-        if format is None:
-            logger.warning("Format in set_sticker_set_thumbnail cannot be None. Setting format to 'static'.")
+        if not format:
+            logger.warning("Deprecation warning. 'format' parameter is required in set_sticker_set_thumbnail. Setting format to 'static'.")
             format = "static"
 
         return apihelper.set_sticker_set_thumbnail(self.token, name, user_id, thumbnail, format)
@@ -5856,7 +5865,7 @@ class TeleBot:
         :param stickers: List of stickers to be added to the set
         :type stickers: :obj:`list` of :class:`telebot.types.InputSticker`
 
-        :param sticker_format: Format of stickers in the set, must be one of “static”, “animated”, “video”
+        :param sticker_format: deprecated
         :type sticker_format: :obj:`str`
 
         :return: On success, True is returned.
@@ -5880,9 +5889,11 @@ class TeleBot:
                 raise ValueError('You must pass at least one sticker')
             stickers = [types.InputSticker(sticker=stickers, emoji_list=emojis, mask_position=mask_position)]
 
+        if sticker_format:
+            logger.warning('The parameter "sticker_format" is deprecated.')
+
         return apihelper.create_new_sticker_set(
-            self.token, user_id, name, title, stickers, sticker_format, sticker_type=sticker_type,
-            needs_repainting=needs_repainting)
+            self.token, user_id, name, title, stickers, sticker_type=sticker_type, needs_repainting=needs_repainting)
 
 
     def add_sticker_to_set(

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1708,23 +1708,26 @@ def set_sticker_set_title(token, name, title):
     payload = {'name': name, 'title': title}
     return _make_request(token, method_url, params=payload, method='post')
 
+
 def delete_sticker_set(token, name):
     method_url = 'deleteStickerSet'
     payload = {'name': name}
     return _make_request(token, method_url, params=payload, method='post')
+
 
 def set_sticker_emoji_list(token, sticker, emoji_list):
     method_url = 'setStickerEmojiList'
     payload = {'sticker': sticker, 'emoji_list': json.dumps(emoji_list)}
     return _make_request(token, method_url, params=payload, method='post')
 
+
 def create_new_sticker_set(
-        token, user_id, name, title, stickers, sticker_format, sticker_type=None, needs_repainting=None):
+        token, user_id, name, title, stickers, sticker_type=None, needs_repainting=None):
     method_url = 'createNewStickerSet'
-    payload = {'user_id': user_id, 'name': name, 'title': title, 'sticker_format': sticker_format}
+    payload = {'user_id': user_id, 'name': name, 'title': title}
     if sticker_type:
         payload['sticker_type'] = sticker_type
-    if needs_repainting:
+    if needs_repainting is not None:
         payload['needs_repainting'] = needs_repainting
 
     files = {}
@@ -1741,8 +1744,6 @@ def create_new_sticker_set(
     
     payload['stickers'] = json.dumps(lst)
 
-
-
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1750,7 +1751,6 @@ def add_sticker_to_set(token, user_id, name, sticker):
     method_url = 'addStickerToSet'
     json_dict, files = sticker.convert_input_sticker()
     payload = {'user_id': user_id, 'name': name, 'sticker': json_dict}
-
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7209,7 +7209,7 @@ class AsyncTeleBot:
             stickers = [types.InputSticker(sticker=stickers, emoji_list=emojis, mask_position=mask_position)]
             
         if sticker_format:
-            logger.warning('The parameter "sticker_format" is deprecated.')
+            logger.warning('The parameter "sticker_format" is deprecated since Bot API 7.2. Stickers can now be mixed')
 
         return await asyncio_helper.create_new_sticker_set(
             self.token, user_id, name, title, stickers, sticker_type, needs_repainting)

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6907,8 +6907,8 @@ class AsyncTeleBot:
         :return: On success, True is returned.
         :rtype: :obj:`bool`
         """
-        if format is None:
-            logger.warning("Format in set_sticker_set_thumbnail cannot be None. Setting format to 'static'.")
+        if not format:
+            logger.warning("Deprecation warning. 'format' parameter is required in set_sticker_set_thumbnail. Setting format to 'static'.")
             format = "static"
         return await asyncio_helper.set_sticker_set_thumbnail(self.token, name, user_id, thumbnail, format)
     
@@ -7184,7 +7184,7 @@ class AsyncTeleBot:
         :param stickers: List of stickers to be added to the set
         :type stickers: :obj:`list` of :class:`telebot.types.InputSticker`
 
-        :param sticker_format: Format of stickers in the set, must be one of “static”, “animated”, “video”
+        :param sticker_format: deprecated
         :type sticker_format: :obj:`str`
 
         :return: On success, True is returned.
@@ -7208,10 +7208,11 @@ class AsyncTeleBot:
                 raise ValueError('You must pass at least one sticker')
             stickers = [types.InputSticker(sticker=stickers, emoji_list=emojis, mask_position=mask_position)]
             
+        if sticker_format:
+            logger.warning('The parameter "sticker_format" is deprecated.')
 
-               
         return await asyncio_helper.create_new_sticker_set(
-            self.token, user_id, name, title, stickers, sticker_format, sticker_type, needs_repainting)
+            self.token, user_id, name, title, stickers, sticker_type, needs_repainting)
 
 
     async def add_sticker_to_set(

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1481,7 +1481,7 @@ async def send_invoice(
         send_phone_number_to_provider = None, send_email_to_provider = None, is_flexible=None,
         disable_notification=None,  reply_markup=None, provider_data=None,
         timeout=None,  max_tip_amount=None, suggested_tip_amounts=None,
-        protect_content=None, message_thread_id=None,reply_parameters=None):
+        protect_content=None, message_thread_id=None, reply_parameters=None):
     """
     Use this method to send invoices. On success, the sent Message is returned.
     :param token: Bot's token (you don't need to fill this)
@@ -1513,6 +1513,7 @@ async def send_invoice(
         At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed max_tip_amount.
     :param protect_content: Protects the contents of the sent message from forwarding and saving
     :param message_thread_id: Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    :param reply_parameters: A JSON-serialized object for an inline keyboard. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button.
     :return:
     """
     method_url = r'sendInvoice'
@@ -1648,7 +1649,7 @@ async def answer_inline_query(token, inline_query_id, results, cache_time=None, 
         payload['next_offset'] = next_offset
     if button is not None:
         payload["button"] = button.to_json()
-    
+
 
     return await _process_request(token, method_url, params=payload, method='post')
 
@@ -1706,12 +1707,12 @@ async def set_sticker_set_title(token, name, title):
     return await _process_request(token, method_url, params=payload, method='post')
 
 async def create_new_sticker_set(
-        token, user_id, name, title, stickers, sticker_format, sticker_type=None, needs_repainting=None):
+        token, user_id, name, title, stickers, sticker_type=None, needs_repainting=None):
     method_url = 'createNewStickerSet'
-    payload = {'user_id': user_id, 'name': name, 'title': title, 'sticker_format': sticker_format}
+    payload = {'user_id': user_id, 'name': name, 'title': title}
     if sticker_type:
         payload['sticker_type'] = sticker_type
-    if needs_repainting:
+    if needs_repainting is not None:
         payload['needs_repainting'] = needs_repainting
 
     files = {}
@@ -1728,7 +1729,7 @@ async def create_new_sticker_set(
     
     payload['stickers'] = json.dumps(lst)
 
-    
+
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1736,7 +1737,7 @@ async def add_sticker_to_set(token, user_id, name, sticker):
     method_url = 'addStickerToSet'
     json_dict, files = sticker.convert_input_sticker()
     payload = {'user_id': user_id, 'name': name, 'sticker': json_dict}
-    
+
 
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -893,24 +893,6 @@ class Message(JsonDeserializable):
     :param chat: Conversation the message belongs to
     :type chat: :class:`telebot.types.Chat`
 
-    :param forward_from: deprecated.
-    :type forward_from: :class:`telebot.types.User`
-
-    :param forward_from_chat: deprecated.
-    :type forward_from_chat: :class:`telebot.types.Chat`
-
-    :param forward_from_message_id: deprecated.
-    :type forward_from_message_id: :obj:`int`
-
-    :param forward_signature: deprecated.
-    :type forward_signature: :obj:`str`
-
-    :param forward_sender_name: deprecated.
-    :type forward_sender_name: :obj:`str`
-
-    :param forward_date: deprecated.
-    :type forward_date: :obj:`int`
-
     :forward_origin: Optional. For forwarded messages, information about the original message;
     :type forward_origin: :class:`telebot.types.MessageOrigin`
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -6395,15 +6395,6 @@ class StickerSet(JsonDeserializable):
     :param sticker_type: Type of stickers in the set, currently one of “regular”, “mask”, “custom_emoji”
     :type sticker_type: :obj:`str`
 
-    :param is_animated:  deprecated
-    :type is_animated: :obj:`bool`
-
-    :param is_video:  deprecated
-    :type is_video: :obj:`bool`
-
-    :param contains_masks: deprecated
-    :type contains_masks: :obj:`bool`
-
     :param stickers: List of all set stickers
     :type stickers: :obj:`list` of :class:`telebot.types.Sticker`
 
@@ -6427,19 +6418,12 @@ class StickerSet(JsonDeserializable):
             obj['thumbnail'] = None
         return cls(**obj)
 
-    def __init__(self, name, title, sticker_type, is_animated=None, is_video=None, stickers=None, thumbnail=None, **kwargs):
+    def __init__(self, name, title, sticker_type, stickers, thumbnail=None, **kwargs):
         self.name: str = name
         self.title: str = title
         self.sticker_type: str = sticker_type
         self.stickers: List[Sticker] = stickers
         self.thumbnail: PhotoSize = thumbnail
-
-        if is_animated is not None:
-            logger.warning('The parameter "is_animated" is deprecated.')
-        if is_video is not None:
-            logger.warning('The parameter "is_video" is deprecated.')
-        if stickers is None:
-            raise ValueError('The parameter "stickers" is required for StickerSet.')
 
     @property
     def thumb(self):
@@ -6453,6 +6437,22 @@ class StickerSet(JsonDeserializable):
         """
         logger.warning('The parameter "contains_masks" is deprecated, use "sticker_type instead"')
         return self.sticker_type == 'mask'
+
+    @property
+    def is_animated(self):
+        """
+        Deprecated since Bot API 7.2. Stickers can be mixed now.
+        """
+        logger.warning('The parameter "is_animated" is deprecated since Bot API 7.2. Stickers can now be mixed')
+        return False
+
+    @property
+    def is_video(self):
+        """
+        Deprecated since Bot API 7.2. Stickers can be mixed now.
+        """
+        logger.warning('The parameter "is_video" is deprecated since Bot API 7.2. Stickers can now be mixed')
+        return False
 
 
 class Sticker(JsonDeserializable):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -900,7 +900,6 @@ class Message(JsonDeserializable):
     :type forward_from_chat: :class:`telebot.types.Chat`
 
     :param forward_from_message_id: deprecated.
-        message in the channel
     :type forward_from_message_id: :obj:`int`
 
     :param forward_signature: deprecated.
@@ -6396,10 +6395,10 @@ class StickerSet(JsonDeserializable):
     :param sticker_type: Type of stickers in the set, currently one of “regular”, “mask”, “custom_emoji”
     :type sticker_type: :obj:`str`
 
-    :param is_animated: True, if the sticker set contains animated stickers
+    :param is_animated:  deprecated
     :type is_animated: :obj:`bool`
 
-    :param is_video: True, if the sticker set contains video stickers
+    :param is_video:  deprecated
     :type is_video: :obj:`bool`
 
     :param contains_masks: deprecated
@@ -6428,14 +6427,19 @@ class StickerSet(JsonDeserializable):
             obj['thumbnail'] = None
         return cls(**obj)
 
-    def __init__(self, name, title, sticker_type, is_animated, is_video, stickers, thumbnail=None, **kwargs):
+    def __init__(self, name, title, sticker_type, is_animated=None, is_video=None, stickers=None, thumbnail=None, **kwargs):
         self.name: str = name
         self.title: str = title
         self.sticker_type: str = sticker_type
-        self.is_animated: bool = is_animated
-        self.is_video: bool = is_video
         self.stickers: List[Sticker] = stickers
         self.thumbnail: PhotoSize = thumbnail
+
+        if is_animated is not None:
+            logger.warning('The parameter "is_animated" is deprecated.')
+        if is_video is not None:
+            logger.warning('The parameter "is_video" is deprecated.')
+        if stickers is None:
+            raise ValueError('The parameter "stickers" is required for StickerSet.')
 
     @property
     def thumb(self):
@@ -8033,12 +8037,17 @@ class InputSticker(Dictionaryable, JsonSerializable):
     :rtype: :class:`telebot.types.InputSticker`
     """
 
-    def __init__(self, sticker: Union[str, InputFile], emoji_list: List[str],  format: str, mask_position: Optional[MaskPosition]=None, keywords: Optional[List[str]]=None) -> None:
+    def __init__(self, sticker: Union[str, InputFile], emoji_list: List[str],  format: Optional[str]=None,
+                 mask_position: Optional[MaskPosition]=None, keywords: Optional[List[str]]=None) -> None:
         self.sticker: Union[str, InputFile] = sticker
         self.emoji_list: List[str] = emoji_list
         self.mask_position: Optional[MaskPosition] = mask_position
         self.keywords: Optional[List[str]] = keywords
         self.format: str = format
+
+        if not self.format:
+            logger.warning("Deprecation warning. 'format' parameter is required in InputSticker. Setting format to 'static'.")
+            self.format = "static"
 
         if service_utils.is_string(self.sticker):
             self._sticker_name = ''


### PR DESCRIPTION
- Removed the fields is_animated and is_video from the class [StickerSet](https://core.telegram.org/bots/api#stickerset).
- Removed the parameter sticker_format from the method [createNewStickerSet](https://core.telegram.org/bots/api#createnewstickerset).

Aded handlers to self.typed_middleware_handlers.
Minor deprecation fixes.