### PR TITLE
Update to resolve Issue with outdated `_convert_entities` function in `copy_message` method

### DIFF
--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -432,7 +432,7 @@ def copy_message(token, chat_id, from_chat_id, message_id, caption=None, parse_m
     if parse_mode:
         payload['parse_mode'] = parse_mode
     if caption_entities is not None:
-        payload['caption_entities'] = _convert_entites(caption_entities)
+        payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
     if reply_parameters is not None:
@@ -1996,17 +1996,6 @@ def _convert_markup(markup):
     if isinstance(markup, types.JsonSerializable):
         return markup.to_json()
     return markup
-
-
-def _convert_entites(entites):
-    if entites is None:
-        return None
-    elif len(entites) == 0:
-        return []
-    elif isinstance(entites[0], types.JsonSerializable):
-        return [entity.to_json() for entity in entites]
-    else:
-        return entites
 
 
 def _convert_poll_options(poll_options):

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -422,7 +422,7 @@ async def copy_message(token, chat_id, from_chat_id, message_id, caption=None, p
     if parse_mode:
         payload['parse_mode'] = parse_mode
     if caption_entities is not None:
-        payload['caption_entities'] = await _convert_entites(caption_entities)
+        payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
     if reply_parameters is not None:
@@ -1973,18 +1973,6 @@ async def _convert_list_json_serializable(results):
     if len(ret) > 0:
         ret = ret[:-1]
     return '[' + ret + ']'
-
-
-
-async def _convert_entites(entites):
-    if entites is None:
-        return None
-    elif len(entites) == 0:
-        return []
-    elif isinstance(entites[0], types.JsonSerializable):
-        return [entity.to_json() for entity in entites]
-    else:
-        return entites
 
 
 async def _convert_poll_options(poll_options):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1612,10 +1612,12 @@ class MessageEntity(Dictionaryable, JsonSerializable, JsonDeserializable):
         """
         Converts a list of MessageEntity objects to a list of dictionaries.
         """
-        res = []
-        for e in entity_list:
-            res.append(MessageEntity.to_dict(e))
-        return res or None
+        if entity_list is None or len(entity_list) == 0:
+            return None
+        elif isinstance(entity_list[0], MessageEntity):
+            return [MessageEntity.to_dict(e) for e in entity_list]
+        else:
+            return entity_list
 
     @classmethod
     def de_json(cls, json_string):


### PR DESCRIPTION
## Description
I identified an issue with the outdated function `_convert_entities` used in both the sync and async versions of the `copy_message` method. This function was not functioning correctly, resulting in invalid entities. While all other methods were using a more updated method for converting entities, this particular method was still relying on `_convert_entities`. 

To address this issue, I have removed `_convert_entities` and replaced it with more better `json.dumps(types.MessageEntity.to_list_of_dicts(...))`. This change ensures that the entities are properly converted and are valid

Python version:
3.12

OS:
windows 10

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async
