### PR TITLE
Fixed a bug with hiding the token

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1034,6 +1034,8 @@ class TeleBot:
         if self.token in message:
             code = self.token.split(':')[1]
             return message.replace(code, "*" * len(code))
+        else:
+            return message
 
     def infinity_polling(self, timeout: Optional[int]=20, skip_pending: Optional[bool]=False, long_polling_timeout: Optional[int]=20,
                          logger_level: Optional[int]=logging.ERROR, allowed_updates: Optional[List[str]]=None,

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -391,6 +391,8 @@ class AsyncTeleBot:
         if self.token in message:
             code = self.token.split(':')[1]
             return message.replace(code, "*" * len(code))
+        else:
+            return message
 
     async def _process_polling(self, non_stop: bool=False, interval: int=0, timeout: int=20,
             request_timeout: int=None, allowed_updates: Optional[List[str]]=None):


### PR DESCRIPTION
## Description
Include changes, new features and etc:
If there is no token in the error, it displays
```
2024-04-26 11:20:41,862 (__init__.py:1091 MainThread) ERROR - TeleBot: "Infinity polling exception: None"
2024-04-26 11:20:41,863 (__init__.py:1093 MainThread) ERROR - TeleBot: "Exception traceback:
None"
```

## Describe your tests
How did you test your change?

Python version:
3.11.6

OS:
Windows 10

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [X] My changes won't break backward compatibility
- [X] I made changes both for sync and async
