### PR TITLE
Add type hints to SimpleCustomFilter

### DIFF
--- a/telebot/asyncio_filters.py
+++ b/telebot/asyncio_filters.py
@@ -27,7 +27,7 @@ class SimpleCustomFilter(ABC):
 
     key: str = None
 
-    async def check(self, message):
+    async def check(self, message: types.Message) -> bool:
         """
         Perform a check.
         """


### PR DESCRIPTION
## Description
Resolves https://github.com/eternnoir/pyTelegramBotAPI/issues/2250

## Describe your tests
How did you test your change?

Python version: 3.12.3

OS: Arch Linux

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [ ] I made changes both for sync and async
