### PR TITLE
Bot API 7.4: Stars, effects, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">A simple, but extensible Python implementation for the <a href="https://core.telegram.org/bots/api">Telegram Bot API</a>.</p>
 <p align="center">Both synchronous and asynchronous.</p>
 
-## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#may-6-2024">7.3</a>!
+## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api-changelog#may-28-2024">7.4</a>!
 
 <h2><a href='https://pytba.readthedocs.io/en/latest/index.html'>Official documentation</a></h2>
 <h2><a href='https://pytba.readthedocs.io/ru/latest/index.html'>Official ru documentation</a></h2>

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -4954,7 +4954,7 @@ class TeleBot:
 
     def send_invoice(
             self, chat_id: Union[int, str], title: str, description: str, 
-            invoice_payload: str, provider_token: str, currency: str, 
+            invoice_payload: str, provider_token: Union[str, None], currency: str, 
             prices: List[types.LabeledPrice], start_parameter: Optional[str]=None, 
             photo_url: Optional[str]=None, photo_size: Optional[int]=None, 
             photo_width: Optional[int]=None, photo_height: Optional[int]=None,
@@ -4993,7 +4993,8 @@ class TeleBot:
             use for your internal processes.
         :type invoice_payload: :obj:`str`
 
-        :param provider_token: Payments provider token, obtained via @Botfather
+        :param provider_token: Payments provider token, obtained via @Botfather; Pass None to omit the parameter
+            to use "XTR" currency
         :type provider_token: :obj:`str`
 
         :param currency: Three-letter ISO 4217 currency code,
@@ -5125,7 +5126,7 @@ class TeleBot:
         )
 
     def create_invoice_link(self,
-            title: str, description: str, payload:str, provider_token: str, 
+            title: str, description: str, payload:str, provider_token: Union[str, None], 
             currency: str, prices: List[types.LabeledPrice],
             max_tip_amount: Optional[int] = None, 
             suggested_tip_amounts: Optional[List[int]]=None,
@@ -5159,7 +5160,8 @@ class TeleBot:
             use for your internal processes.
         :type payload: :obj:`str`
 
-        :param provider_token: Payments provider token, obtained via @Botfather
+        :param provider_token: Payments provider token, obtained via @Botfather; Pass None to omit the parameter
+            to use "XTR" currency
         :type provider_token: :obj:`str`
 
         :param currency: Three-letter ISO 4217 currency code,

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1818,7 +1818,7 @@ class TeleBot:
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.MessageID:
+            reply_parameters: Optional[types.ReplyParameters]=None,
         """
         Use this method to copy messages of any kind.
 
@@ -1866,6 +1866,9 @@ class TeleBot:
 
         :param reply_parameters: Additional parameters for replies to messages
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
+        :param show_caption_above_media: Pass True, if the caption must be shown above the message media. Supported only for animation, photo and video messages.
+        :type show_caption_above_media: :obj:`bool`
         
         :return: On success, the MessageId of the sent message is returned.
         :rtype: :class:`telebot.types.MessageID`
@@ -1896,7 +1899,7 @@ class TeleBot:
             apihelper.copy_message(self.token, chat_id, from_chat_id, message_id, caption=caption,
                 parse_mode=parse_mode, caption_entities=caption_entities, disable_notification=disable_notification,
                 reply_markup=reply_markup, timeout=timeout, protect_content=protect_content,
-                message_thread_id=message_thread_id, reply_parameters=reply_parameters))
+                message_thread_id=message_thread_id, reply_parameters=reply_parameters, show_caption_above_media=show_caption_above_media))
 
 
     def delete_message(self, chat_id: Union[int, str], message_id: int, 
@@ -2138,7 +2141,8 @@ class TeleBot:
             has_spoiler: Optional[bool]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
             business_connection_id: Optional[str]=None,
-            message_effect_id: Optional[str]=None) -> types.Message:
+            message_effect_id: Optional[str]=None,
+            show_caption_above_media: Optional[bool]=None) -> types.Message:
         """
         Use this method to send photos. On success, the sent Message is returned.
 
@@ -2195,6 +2199,9 @@ class TeleBot:
 
         :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
         :type message_effect_id: :obj:`str`
+
+        :param show_caption_above_media: Pass True, if the caption must be shown above the message media. Supported only for animation, photo and video messages.
+        :type show_caption_above_media: :obj:`bool`
         
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -2227,7 +2234,7 @@ class TeleBot:
                 parse_mode=parse_mode, disable_notification=disable_notification, timeout=timeout,
                 caption_entities=caption_entities, protect_content=protect_content,
                 message_thread_id=message_thread_id, has_spoiler=has_spoiler, reply_parameters=reply_parameters, business_connection_id=business_connection_id,
-                message_effect_id=message_effect_id))
+                message_effect_id=message_effect_id, show_caption_above_media=show_caption_above_media))
         
 
 
@@ -2724,7 +2731,8 @@ class TeleBot:
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
             business_connection_id: Optional[str]=None,
-            message_effect_id: Optional[str]=None) -> types.Message:
+            message_effect_id: Optional[str]=None,
+            show_caption_above_media: Optional[bool]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
         
@@ -2801,6 +2809,9 @@ class TeleBot:
         :param message_effect_id: Identifier of a message effect
         :type message_effect_id: :obj:`str`
 
+        :param show_caption_above_media: Pass True, if the caption must be shown above the message media. Supported only for animation, photo and video messages.
+        :type show_caption_above_media: :obj:`bool`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2841,7 +2852,8 @@ class TeleBot:
                 supports_streaming=supports_streaming, disable_notification=disable_notification, timeout=timeout,
                 thumbnail=thumbnail, height=height, width=width, caption_entities=caption_entities,
                 protect_content=protect_content, message_thread_id=message_thread_id, has_spoiler=has_spoiler,
-                reply_parameters=reply_parameters, business_connection_id=business_connection_id, message_effect_id=message_effect_id)
+                reply_parameters=reply_parameters, business_connection_id=business_connection_id, message_effect_id=message_effect_id,
+                show_caption_above_media=show_caption_above_media)
         )
 
 
@@ -2865,7 +2877,8 @@ class TeleBot:
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
             business_connection_id: Optional[str]=None,
-            message_effect_id: Optional[str]=None) -> types.Message:
+            message_effect_id: Optional[str]=None,
+            show_caption_above_media: Optional[bool]=None) -> types.Message:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
@@ -2941,6 +2954,9 @@ class TeleBot:
         :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
         :type message_effect_id: :obj:`str`
 
+        :param show_caption_above_media: Pass True, if the caption must be shown above the message media. Supported only for animation, photo and video messages.
+        :type show_caption_above_media: :obj:`bool`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2976,7 +2992,8 @@ class TeleBot:
                 parse_mode=parse_mode, disable_notification=disable_notification, timeout=timeout,
                 thumbnail=thumbnail, caption_entities=caption_entities, protect_content=protect_content,
                 width=width, height=height, message_thread_id=message_thread_id, reply_parameters=reply_parameters,
-                has_spoiler=has_spoiler, business_connection_id=business_connection_id, message_effect_id=message_effect_id)
+                has_spoiler=has_spoiler, business_connection_id=business_connection_id, message_effect_id=message_effect_id,
+                show_caption_above_media=show_caption_above_media)
             )
 
 
@@ -5479,7 +5496,8 @@ class TeleBot:
             inline_message_id: Optional[str]=None,
             parse_mode: Optional[str]=None, 
             caption_entities: Optional[List[types.MessageEntity]]=None,
-            reply_markup: Optional[types.InlineKeyboardMarkup]=None) -> Union[types.Message, bool]:
+            reply_markup: Optional[types.InlineKeyboardMarkup]=None,
+            show_caption_above_media: Optional[bool]=None) -> Union[types.Message, bool]:
         """
         Use this method to edit captions of messages.
 
@@ -5506,6 +5524,9 @@ class TeleBot:
         :param reply_markup: A JSON-serialized object for an inline keyboard.
         :type reply_markup: :obj:`InlineKeyboardMarkup`
 
+        :param show_caption_above_media: Pass True, if the caption must be shown above the message media. Supported only for animation, photo and video messages.
+        :type show_caption_above_media: :obj:`bool`
+
         :return: On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
         :rtype: :obj:`types.Message` | :obj:`bool`
         """
@@ -5513,7 +5534,7 @@ class TeleBot:
 
         result = apihelper.edit_message_caption(
             self.token, caption, chat_id=chat_id, message_id=message_id, inline_message_id=inline_message_id,
-            parse_mode=parse_mode, caption_entities=caption_entities, reply_markup=reply_markup)
+            parse_mode=parse_mode, caption_entities=caption_entities, reply_markup=reply_markup, show_caption_above_media=show_caption_above_media)
 
         if type(result) == bool:
             return result

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -2360,7 +2360,6 @@ class TeleBot:
                 timeout=timeout, thumbnail=thumbnail, caption_entities=caption_entities, protect_content=protect_content,
                 message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id,
                 message_effect_id=message_effect_id))
-        )
 
 
     def send_voice(

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1819,6 +1819,7 @@ class TeleBot:
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
+            show_caption_above_media: Optional[bool]=None) -> types.MessageID:
         """
         Use this method to copy messages of any kind.
 
@@ -1829,6 +1830,7 @@ class TeleBot:
 
         :param from_chat_id: Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
         :type from_chat_id: :obj:`int` or :obj:`str`
+
         :param message_id: Message identifier in the chat specified in from_chat_id
         :type message_id: :obj:`int`
 
@@ -1872,7 +1874,9 @@ class TeleBot:
         
         :return: On success, the MessageId of the sent message is returned.
         :rtype: :class:`telebot.types.MessageID`
+
         """
+        
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         protect_content = self.protect_content if (protect_content is None) else protect_content

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1649,7 +1649,8 @@ class TeleBot:
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
             link_preview_options : Optional[types.LinkPreviewOptions]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send text messages.
 
@@ -1705,6 +1706,9 @@ class TeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -1752,7 +1756,8 @@ class TeleBot:
                 self.token, chat_id, text,
                 reply_markup=reply_markup, parse_mode=parse_mode, disable_notification=disable_notification,
                 timeout=timeout, entities=entities, protect_content=protect_content, message_thread_id=message_thread_id,
-                reply_parameters=reply_parameters, link_preview_options=link_preview_options, business_connection_id=business_connection_id))
+                reply_parameters=reply_parameters, link_preview_options=link_preview_options, business_connection_id=business_connection_id,
+                message_effect_id=message_effect_id))
 
 
     def forward_message(
@@ -2040,7 +2045,8 @@ class TeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send an animated emoji that will display a random value. On success, the sent Message is returned.
 
@@ -2082,6 +2088,9 @@ class TeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2110,7 +2119,8 @@ class TeleBot:
             apihelper.send_dice(
                 self.token, chat_id, emoji=emoji, disable_notification=disable_notification,
                 reply_markup=reply_markup, timeout=timeout, protect_content=protect_content,
-                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id))
+                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id,
+                message_effect_id=message_effect_id))
 
 
 
@@ -2127,7 +2137,8 @@ class TeleBot:
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send photos. On success, the sent Message is returned.
 
@@ -2181,6 +2192,9 @@ class TeleBot:
 
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
+
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
         
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -2212,7 +2226,8 @@ class TeleBot:
                 self.token, chat_id, photo, caption=caption, reply_markup=reply_markup,
                 parse_mode=parse_mode, disable_notification=disable_notification, timeout=timeout,
                 caption_entities=caption_entities, protect_content=protect_content,
-                message_thread_id=message_thread_id, has_spoiler=has_spoiler, reply_parameters=reply_parameters, business_connection_id=business_connection_id))
+                message_thread_id=message_thread_id, has_spoiler=has_spoiler, reply_parameters=reply_parameters, business_connection_id=business_connection_id,
+                message_effect_id=message_effect_id))
         
 
 
@@ -2232,7 +2247,8 @@ class TeleBot:
             message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player.
         Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size,
@@ -2305,6 +2321,9 @@ class TeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2339,7 +2358,8 @@ class TeleBot:
                 self.token, chat_id, audio, caption=caption, duration=duration, performer=performer, title=title,
                 reply_markup=reply_markup, parse_mode=parse_mode, disable_notification=disable_notification,
                 timeout=timeout, thumbnail=thumbnail, caption_entities=caption_entities, protect_content=protect_content,
-                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
+                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id,
+                message_effect_id=message_effect_id))
         )
 
 
@@ -2356,7 +2376,8 @@ class TeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .OGG file encoded with OPUS, or in .MP3 format, or in .M4A format (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
 
@@ -2410,6 +2431,9 @@ class TeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
@@ -2439,7 +2463,8 @@ class TeleBot:
                 self.token, chat_id, voice, caption=caption, duration=duration, reply_markup=reply_markup,
                 parse_mode=parse_mode, disable_notification=disable_notification, timeout=timeout,
                 caption_entities=caption_entities, protect_content=protect_content,
-                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
+                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id,
+                message_effect_id=message_effect_id)
         )
 
 
@@ -2460,7 +2485,8 @@ class TeleBot:
             protect_content: Optional[bool]=None, message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send general files.
 
@@ -2526,6 +2552,9 @@ class TeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2565,7 +2594,8 @@ class TeleBot:
                 reply_markup=reply_markup, parse_mode=parse_mode, disable_notification=disable_notification,
                 timeout=timeout, caption=caption, thumbnail=thumbnail, caption_entities=caption_entities,
                 disable_content_type_detection=disable_content_type_detection, visible_file_name=visible_file_name,
-                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
+                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters,
+                business_connection_id=business_connection_id, message_effect_id=message_effect_id)
         )
 
 
@@ -2582,7 +2612,8 @@ class TeleBot:
             message_thread_id: Optional[int]=None,
             emoji: Optional[str]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers.
         On success, the sent Message is returned.
@@ -2631,6 +2662,9 @@ class TeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2664,7 +2698,8 @@ class TeleBot:
                 self.token, chat_id, sticker, 'sticker',
                 reply_markup=reply_markup, disable_notification=disable_notification, timeout=timeout,
                 protect_content=protect_content, message_thread_id=message_thread_id, emoji=emoji,
-                reply_parameters=reply_parameters, business_connection_id=business_connection_id)
+                reply_parameters=reply_parameters, business_connection_id=business_connection_id,
+                message_effect_id=message_effect_id)
         )
 
 
@@ -2689,7 +2724,8 @@ class TeleBot:
             has_spoiler: Optional[bool]=None,
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
         
@@ -2763,6 +2799,9 @@ class TeleBot:
         :param business_connection_id: Identifier of a business connection
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Identifier of a message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2803,7 +2842,7 @@ class TeleBot:
                 supports_streaming=supports_streaming, disable_notification=disable_notification, timeout=timeout,
                 thumbnail=thumbnail, height=height, width=width, caption_entities=caption_entities,
                 protect_content=protect_content, message_thread_id=message_thread_id, has_spoiler=has_spoiler,
-                reply_parameters=reply_parameters, business_connection_id=business_connection_id)
+                reply_parameters=reply_parameters, business_connection_id=business_connection_id, message_effect_id=message_effect_id)
         )
 
 
@@ -2826,7 +2865,8 @@ class TeleBot:
             has_spoiler: Optional[bool]=None,
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
@@ -2899,6 +2939,9 @@ class TeleBot:
         :param business_connection_id: Identifier of a business connection
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2934,7 +2977,7 @@ class TeleBot:
                 parse_mode=parse_mode, disable_notification=disable_notification, timeout=timeout,
                 thumbnail=thumbnail, caption_entities=caption_entities, protect_content=protect_content,
                 width=width, height=height, message_thread_id=message_thread_id, reply_parameters=reply_parameters,
-                has_spoiler=has_spoiler, business_connection_id=business_connection_id)
+                has_spoiler=has_spoiler, business_connection_id=business_connection_id, message_effect_id=message_effect_id)
             )
 
 
@@ -2952,7 +2995,8 @@ class TeleBot:
             message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         As of v.4.0, Telegram clients support rounded square MPEG4 videos of up to 1 minute long.
         Use this method to send video messages. On success, the sent Message is returned.
@@ -3010,6 +3054,9 @@ class TeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3042,7 +3089,8 @@ class TeleBot:
             apihelper.send_video_note(
                 self.token, chat_id, data, duration=duration, length=length, reply_markup=reply_markup,
                 disable_notification=disable_notification, timeout=timeout, thumbnail=thumbnail,
-                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
+                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters,
+                business_connection_id=business_connection_id, message_effect_id=message_effect_id)
         )
 
 
@@ -3058,7 +3106,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> List[types.Message]:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> List[types.Message]:
         """
         Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files
         can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned.
@@ -3095,6 +3144,9 @@ class TeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
         :return: On success, an array of Messages that were sent is returned.
         :rtype: List[types.Message]
         """
@@ -3128,7 +3180,7 @@ class TeleBot:
         result = apihelper.send_media_group(
             self.token, chat_id, media, disable_notification=disable_notification, timeout=timeout,
             protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters,
-            business_connection_id=business_connection_id)
+            business_connection_id=business_connection_id, message_effect_id=message_effect_id)
         return [types.Message.de_json(msg) for msg in result]
 
 
@@ -3147,7 +3199,8 @@ class TeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send point on the map. On success, the sent Message is returned.
 
@@ -3203,6 +3256,9 @@ class TeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :parameter message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3232,7 +3288,8 @@ class TeleBot:
                 self.token, chat_id, latitude, longitude, live_period=live_period, reply_markup=reply_markup,
                 disable_notification=disable_notification, timeout=timeout, horizontal_accuracy=horizontal_accuracy,
                 heading=heading, proximity_alert_radius=proximity_alert_radius, protect_content=protect_content,
-                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
+                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id,
+                message_effect_id=message_effect_id)
             )
 
 
@@ -3354,7 +3411,8 @@ class TeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send information about a venue. On success, the sent Message is returned.
         
@@ -3417,6 +3475,9 @@ class TeleBot:
         :param business_connection_id: Identifier of a business connection
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3446,7 +3507,8 @@ class TeleBot:
                 self.token, chat_id, latitude, longitude, title, address, foursquare_id=foursquare_id,
                 foursquare_type=foursquare_type, disable_notification=disable_notification, reply_markup=reply_markup,
                 timeout=timeout, google_place_id=google_place_id, google_place_type=google_place_type,
-                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
+                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id,
+                message_effect_id=message_effect_id)
             )
 
 
@@ -3461,7 +3523,8 @@ class TeleBot:
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             protect_content: Optional[bool]=None, message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send phone contacts. On success, the sent Message is returned.
 
@@ -3511,6 +3574,9 @@ class TeleBot:
         :param business_connection_id: Identifier of a business connection
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3539,7 +3605,8 @@ class TeleBot:
             apihelper.send_contact(
                 self.token, chat_id, phone_number, first_name, last_name=last_name, vcard=vcard,
                 disable_notification=disable_notification, reply_markup=reply_markup, timeout=timeout,
-                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
+                protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters,
+                business_connection_id=business_connection_id, message_effect_id=message_effect_id)
             )
 
 
@@ -4707,7 +4774,8 @@ class TeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Used to send the game.
 
@@ -4746,6 +4814,9 @@ class TeleBot:
         :param business_connection_id: Unique identifier of the business connection
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -4777,7 +4848,8 @@ class TeleBot:
             apihelper.send_game(
                 self.token, chat_id, game_short_name, disable_notification=disable_notification,
                 reply_markup=reply_markup, timeout=timeout, protect_content=protect_content,
-                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id)
+                message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id,
+                message_effect_id=message_effect_id)
         )
 
 
@@ -4881,7 +4953,8 @@ class TeleBot:
             suggested_tip_amounts: Optional[List[int]]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Sends invoice.
 
@@ -4986,6 +5059,9 @@ class TeleBot:
         :param reply_parameters: Required if the message is a reply. Additional interface options.
         :type reply_parameters: :obj:`types.ReplyParameters`
 
+        :param message_effect_id: The identifier of a message effect, which will be applied to the sent message
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -5024,7 +5100,8 @@ class TeleBot:
                 disable_notification=disable_notification, reply_markup=reply_markup,
                 provider_data=provider_data, timeout=timeout, protect_content=protect_content,
                 message_thread_id=message_thread_id, reply_parameters=reply_parameters,
-                max_tip_amount=max_tip_amount, suggested_tip_amounts=suggested_tip_amounts)
+                max_tip_amount=max_tip_amount, suggested_tip_amounts=suggested_tip_amounts,
+                message_effect_id=message_effect_id)
         )
 
     def create_invoice_link(self,
@@ -5155,7 +5232,7 @@ class TeleBot:
             business_connection_id: Optional[str]=None,
             question_parse_mode: Optional[str] = None,
             question_entities: Optional[List[types.MessageEntity]] = None,
-    ) -> types.Message:
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send a native poll.
         On success, the sent Message is returned.
@@ -5234,6 +5311,9 @@ class TeleBot:
         :param question_entities: A JSON-serialized list of special entities that appear in the poll question. It can be specified instead of question_parse_mode
         :type question_entities: :obj:`list` of :obj:`MessageEntity`
 
+        :param message_effect_id: Unique identifier of the message effect to apply to the sent message
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -5288,7 +5368,8 @@ class TeleBot:
                 reply_markup=reply_markup, timeout=timeout, explanation_entities=explanation_entities,
                 protect_content=protect_content, message_thread_id=message_thread_id,
                 reply_parameters=reply_parameters, business_connection_id=business_connection_id,
-                question_parse_mode=question_parse_mode, question_entities=question_entities)
+                question_parse_mode=question_parse_mode, question_entities=question_entities,
+                message_effect_id=message_effect_id)
             )
 
 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5375,7 +5375,23 @@ class TeleBot:
         """
         return apihelper.answer_pre_checkout_query(
             self.token, pre_checkout_query_id, ok, error_message=error_message)
+    
+    def refund_star_payment(self, user_id: int, telegram_payment_charge_id: str) -> bool:
+        """
+        Refunds a successful payment in Telegram Stars. Returns True on success.
 
+        Telegram documentation: https://core.telegram.org/bots/api#refundstarpayment
+
+        :param user_id: Identifier of the user whose payment will be refunded
+        :type user_id: :obj:`int`
+
+        :param telegram_payment_charge_id: Telegram payment identifier
+        :type telegram_payment_charge_id: :obj:`str`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.refund_star_payment(self.token, user_id, telegram_payment_charge_id)
 
     def edit_message_caption(
             self, caption: str, chat_id: Optional[Union[int, str]]=None, 

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1616,6 +1616,11 @@ def answer_pre_checkout_query(token, pre_checkout_query_id, ok, error_message=No
         payload['error_message'] = error_message
     return _make_request(token, method_url, params=payload)
 
+def refund_star_payment(token, user_id, telegram_payment_charge_id):
+    method_url = 'refundStarPayment'
+    payload = {'user_id': user_id, 'telegram_payment_charge_id': telegram_payment_charge_id}
+    return _make_request(token, method_url, params=payload, method='post')
+
 
 def unpin_all_general_forum_topic_messages(token, chat_id):
     method_url = 'unpinAllGeneralForumTopicMessages'

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -485,7 +485,8 @@ def send_photo(
         caption=None, reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
         caption_entities=None, protect_content=None,
-        message_thread_id=None, has_spoiler=None, reply_parameters=None, business_connection_id=None, message_effect_id=None):
+        message_thread_id=None, has_spoiler=None, reply_parameters=None, business_connection_id=None, message_effect_id=None,
+        show_caption_above_media=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None
@@ -519,6 +520,8 @@ def send_photo(
         payload['business_connection_id'] = business_connection_id
     if message_effect_id:
         payload['message_effect_id'] = message_effect_id
+    if show_caption_above_media is not None:
+        payload['show_caption_above_media'] = show_caption_above_media
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -712,7 +715,8 @@ def send_chat_action(token, chat_id, action, timeout=None, message_thread_id=Non
 def send_video(token, chat_id, data, duration=None, caption=None, reply_markup=None,
                parse_mode=None, supports_streaming=None, disable_notification=None, timeout=None,
                thumbnail=None, width=None, height=None, caption_entities=None, protect_content=None,
-               message_thread_id=None, has_spoiler=None, reply_parameters=None, business_connection_id=None, message_effect_id=None):
+               message_thread_id=None, has_spoiler=None, reply_parameters=None, business_connection_id=None, message_effect_id=None,
+               show_caption_above_media=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -760,6 +764,8 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_markup=N
         payload['business_connection_id'] = business_connection_id
     if message_effect_id:
         payload['message_effect_id'] = message_effect_id
+    if show_caption_above_media is not None:
+        payload['show_caption_above_media'] = show_caption_above_media
     
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
@@ -768,7 +774,7 @@ def send_animation(
         token, chat_id, data, duration=None, caption=None,  reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None, thumbnail=None, caption_entities=None,
         protect_content=None, width=None, height=None, message_thread_id=None, reply_parameters=None,
-        has_spoiler=None, business_connection_id=None, message_effect_id=None):
+        has_spoiler=None, business_connection_id=None, message_effect_id=None, show_caption_above_media=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}
     files = None
@@ -814,6 +820,8 @@ def send_animation(
         payload['business_connection_id'] = business_connection_id
     if message_effect_id:
         payload['message_effect_id'] = message_effect_id
+    if show_caption_above_media is not None:
+        payload['show_caption_above_media'] = show_caption_above_media
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1390,7 +1398,7 @@ def edit_message_text(token, text, chat_id=None, message_id=None, inline_message
 
 
 def edit_message_caption(token, caption, chat_id=None, message_id=None, inline_message_id=None,
-                         parse_mode=None, caption_entities=None,reply_markup=None):
+                         parse_mode=None, caption_entities=None,reply_markup=None, show_caption_above_media=None):
     method_url = r'editMessageCaption'
     payload = {'caption': caption}
     if chat_id:
@@ -1405,6 +1413,8 @@ def edit_message_caption(token, caption, chat_id=None, message_id=None, inline_m
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
     if reply_markup:
         payload['reply_markup'] = _convert_markup(reply_markup)
+    if show_caption_above_media is not None:
+        payload['show_caption_above_media'] = show_caption_above_media
     return _make_request(token, method_url, params=payload, method='post')
 
 
@@ -2016,7 +2026,7 @@ def forward_messages(token, chat_id, from_chat_id, message_ids, disable_notifica
     return _make_request(token, method_url, params=payload)
 
 def copy_messages(token, chat_id, from_chat_id, message_ids, disable_notification=None,
-                        message_thread_id=None, protect_content=None, remove_caption=None):
+                        message_thread_id=None, protect_content=None, remove_caption=None, show_caption_above_media=None):
     method_url = 'copyMessages'
     payload = {
         'chat_id': chat_id,
@@ -2031,6 +2041,8 @@ def copy_messages(token, chat_id, from_chat_id, message_ids, disable_notificatio
         payload['protect_content'] = protect_content
     if remove_caption is not None:
         payload['remove_caption'] = remove_caption
+    if show_caption_above_media is not None:
+        payload['show_caption_above_media'] = show_caption_above_media
     return _make_request(token, method_url, params=payload)
 
 

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1580,7 +1580,7 @@ def send_invoice(
     """
     method_url = r'sendInvoice'
     payload = {'chat_id': chat_id, 'title': title, 'description': description, 'payload': invoice_payload,
-               'provider_token': provider_token, 'currency': currency,
+                'currency': currency,
                'prices': _convert_list_json_serializable(prices)}
     if start_parameter:
         payload['start_parameter'] = start_parameter
@@ -1626,6 +1626,8 @@ def send_invoice(
         payload['reply_parameters'] = reply_parameters.to_json()
     if message_effect_id:
         payload['message_effect_id'] = message_effect_id
+    if provider_token is not None:
+        payload['provider_token'] = provider_token
     return _make_request(token, method_url, params=payload)
 
 
@@ -1666,13 +1668,13 @@ def answer_pre_checkout_query(token, pre_checkout_query_id, ok, error_message=No
 def refund_star_payment(token, user_id, telegram_payment_charge_id):
     method_url = 'refundStarPayment'
     payload = {'user_id': user_id, 'telegram_payment_charge_id': telegram_payment_charge_id}
-    return _make_request(token, method_url, params=payload, method='post')
+    return _make_request(token, method_url, params=payload)
 
 
 def unpin_all_general_forum_topic_messages(token, chat_id):
     method_url = 'unpinAllGeneralForumTopicMessages'
     payload = {'chat_id': chat_id}
-    return _make_request(token, method_url, params=payload, method='post')
+    return _make_request(token, method_url, params=payload)
 
 # InlineQuery
 
@@ -1835,7 +1837,7 @@ def create_invoice_link(token, title, description, payload, provider_token,
             need_email=None, need_shipping_address=None, send_phone_number_to_provider=None,
             send_email_to_provider=None, is_flexible=None):
     method_url = r'createInvoiceLink'
-    payload = {'title': title, 'description': description, 'payload': payload, 'provider_token': provider_token,
+    payload = {'title': title, 'description': description, 'payload': payload,
                 'currency': currency, 'prices': _convert_list_json_serializable(prices)}
     if max_tip_amount:
         payload['max_tip_amount'] = max_tip_amount
@@ -1865,6 +1867,8 @@ def create_invoice_link(token, title, description, payload, provider_token,
         payload['send_email_to_provider'] = send_email_to_provider
     if is_flexible is not None:
         payload['is_flexible'] = is_flexible
+    if provider_token is not None:
+        payload['provider_token'] = provider_token
     return _make_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -245,7 +245,7 @@ def send_message(
         parse_mode=None, disable_notification=None, timeout=None,
         entities=None, protect_content=None,
         message_thread_id=None, reply_parameters=None, link_preview_options=None,
-        business_connection_id=None):
+        business_connection_id=None, message_effect_id=None):
     method_url = r'sendMessage'
     payload = {'chat_id': str(chat_id), 'text': text}
     if link_preview_options is not None:
@@ -268,6 +268,8 @@ def send_message(
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(token, method_url, params=payload, method='post')
 
 
@@ -454,7 +456,7 @@ def send_dice(
         token, chat_id,
         emoji=None, disable_notification=None,
         reply_markup=None, timeout=None, protect_content=None, message_thread_id=None, reply_parameters=None,
-        business_connection_id=None):
+        business_connection_id=None, message_effect_id=None):
     method_url = r'sendDice'
     payload = {'chat_id': chat_id}
     if emoji:
@@ -473,6 +475,8 @@ def send_dice(
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(token, method_url, params=payload)
 
 
@@ -481,7 +485,7 @@ def send_photo(
         caption=None, reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
         caption_entities=None, protect_content=None,
-        message_thread_id=None, has_spoiler=None, reply_parameters=None, business_connection_id=None):
+        message_thread_id=None, has_spoiler=None, reply_parameters=None, business_connection_id=None, message_effect_id=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None
@@ -513,13 +517,16 @@ def send_photo(
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_media_group(
         token, chat_id, media,
         disable_notification=None,
-        timeout=None, protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None):
+        timeout=None, protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None,
+        message_effect_id=None):
     method_url = r'sendMediaGroup'
     media_json, files = convert_input_media_array(media)
     payload = {'chat_id': chat_id, 'media': media_json}
@@ -535,6 +542,8 @@ def send_media_group(
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(
         token, method_url, params=payload,
         method='post' if files else 'get',
@@ -547,7 +556,8 @@ def send_location(
         reply_markup=None, disable_notification=None, 
         timeout=None, horizontal_accuracy=None, heading=None,
         proximity_alert_radius=None, protect_content=None,
-        message_thread_id=None, reply_parameters=None, business_connection_id=None):
+        message_thread_id=None, reply_parameters=None, business_connection_id=None,
+        message_effect_id=None):
     method_url = r'sendLocation'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude}
     if live_period:
@@ -572,6 +582,8 @@ def send_location(
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(token, method_url, params=payload)
 
 
@@ -623,7 +635,8 @@ def send_venue(
         token, chat_id, latitude, longitude, title, address,
         foursquare_id=None, foursquare_type=None, disable_notification=None,
         reply_markup=None, timeout=None, google_place_id=None,
-        google_place_type=None, protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None):
+        google_place_type=None, protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None,
+        message_effect_id=None):
     method_url = r'sendVenue'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude, 'title': title, 'address': address}
     if foursquare_id:
@@ -648,13 +661,16 @@ def send_venue(
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(token, method_url, params=payload)
 
 
 def send_contact(
         token, chat_id, phone_number, first_name, last_name=None, vcard=None,
         disable_notification=None, reply_markup=None, timeout=None,
-        protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None):
+        protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None,
+        message_effect_id=None):
     method_url = r'sendContact'
     payload = {'chat_id': chat_id, 'phone_number': phone_number, 'first_name': first_name}
     if last_name:
@@ -675,6 +691,8 @@ def send_contact(
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
 
     return _make_request(token, method_url, params=payload)
 
@@ -694,7 +712,7 @@ def send_chat_action(token, chat_id, action, timeout=None, message_thread_id=Non
 def send_video(token, chat_id, data, duration=None, caption=None, reply_markup=None,
                parse_mode=None, supports_streaming=None, disable_notification=None, timeout=None,
                thumbnail=None, width=None, height=None, caption_entities=None, protect_content=None,
-               message_thread_id=None, has_spoiler=None, reply_parameters=None, business_connection_id=None):
+               message_thread_id=None, has_spoiler=None, reply_parameters=None, business_connection_id=None, message_effect_id=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -740,6 +758,8 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_markup=N
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
@@ -748,7 +768,7 @@ def send_animation(
         token, chat_id, data, duration=None, caption=None,  reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None, thumbnail=None, caption_entities=None,
         protect_content=None, width=None, height=None, message_thread_id=None, reply_parameters=None,
-        has_spoiler=None, business_connection_id=None):
+        has_spoiler=None, business_connection_id=None, message_effect_id=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}
     files = None
@@ -792,12 +812,15 @@ def send_animation(
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_voice(token, chat_id, voice, caption=None, duration=None, reply_markup=None,
                parse_mode=None, disable_notification=None, timeout=None, caption_entities=None,
-                 protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None):
+                 protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None,
+                 message_effect_id=None):
     method_url = r'sendVoice'
     payload = {'chat_id': chat_id}
     files = None
@@ -827,12 +850,14 @@ def send_voice(token, chat_id, voice, caption=None, duration=None, reply_markup=
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_video_note(token, chat_id, data, duration=None, length=None, reply_markup=None,
                     disable_notification=None, timeout=None, thumbnail=None, protect_content=None,
-                    message_thread_id=None, reply_parameters=None,business_connection_id=None):
+                    message_thread_id=None, reply_parameters=None,business_connection_id=None, message_effect_id=None):
     method_url = r'sendVideoNote'
     payload = {'chat_id': chat_id}
     files = None
@@ -868,12 +893,15 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_mark
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None,
                reply_markup=None, parse_mode=None, disable_notification=None, timeout=None, thumbnail=None,
-               caption_entities=None, protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None):
+               caption_entities=None, protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None,
+               message_effect_id=None):
     method_url = r'sendAudio'
     payload = {'chat_id': chat_id}
     files = None
@@ -915,13 +943,16 @@ def send_audio(token, chat_id, audio, caption=None, duration=None, performer=Non
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_data(token, chat_id, data, data_type, reply_markup=None, parse_mode=None,
               disable_notification=None, timeout=None, caption=None, thumbnail=None, caption_entities=None,
               disable_content_type_detection=None, visible_file_name=None,
-              protect_content = None, message_thread_id=None, emoji=None, reply_parameters=None, business_connection_id=None):
+              protect_content = None, message_thread_id=None, emoji=None, reply_parameters=None, business_connection_id=None,
+              message_effect_id=None):
     method_url = get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None
@@ -964,6 +995,8 @@ def send_data(token, chat_id, data, data_type, reply_markup=None, parse_mode=Non
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1417,7 +1450,7 @@ def delete_message(token, chat_id, message_id, timeout=None):
 def send_game(
         token, chat_id, game_short_name,
         disable_notification=None, reply_markup=None, timeout=None,
-       protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None):
+       protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None, message_effect_id=None):
     method_url = r'sendGame'
     payload = {'chat_id': chat_id, 'game_short_name': game_short_name}
     if disable_notification is not None:
@@ -1434,6 +1467,8 @@ def send_game(
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(token, method_url, params=payload)
 
 
@@ -1499,7 +1534,7 @@ def send_invoice(
         send_phone_number_to_provider = None, send_email_to_provider = None, is_flexible=None,
         disable_notification=None, reply_markup=None, provider_data=None,
         timeout=None, max_tip_amount=None, suggested_tip_amounts=None,
-        protect_content=None, message_thread_id=None, reply_parameters=None):
+        protect_content=None, message_thread_id=None, reply_parameters=None, message_effect_id=None):
     """
     Use this method to send invoices. On success, the sent Message is returned.
     :param token: Bot's token (you don't need to fill this)
@@ -1579,6 +1614,8 @@ def send_invoice(
         payload['message_thread_id'] = message_thread_id
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(token, method_url, params=payload)
 
 
@@ -1827,7 +1864,7 @@ def send_poll(
         is_anonymous = None, type = None, allows_multiple_answers = None, correct_option_id = None, explanation = None,
         explanation_parse_mode=None, open_period = None, close_date = None, is_closed = None, disable_notification=False,
         reply_markup=None, timeout=None, explanation_entities=None, protect_content=None, message_thread_id=None,
-        reply_parameters=None, business_connection_id=None, question_parse_mode=None, question_entities=None):
+        reply_parameters=None, business_connection_id=None, question_parse_mode=None, question_entities=None, message_effect_id=None):
     method_url = r'sendPoll'
     payload = {
         'chat_id': str(chat_id),
@@ -1876,6 +1913,8 @@ def send_poll(
         payload['question_parse_mode'] = question_parse_mode
     if question_entities:
         payload['question_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(question_entities))
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return _make_request(token, method_url, params=payload)
 
 def create_forum_topic(token, chat_id, name, icon_color=None, icon_custom_emoji_id=None):

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -3061,7 +3061,8 @@ class AsyncTeleBot:
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
             link_preview_options: Optional[types.LinkPreviewOptions]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send text messages.
 
@@ -3117,6 +3118,9 @@ class AsyncTeleBot:
         :param business_connection_id: Unique identifier for the target business connection
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier for the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3171,7 +3175,8 @@ class AsyncTeleBot:
             await asyncio_helper.send_message(
                 self.token, chat_id, text,
                 reply_markup, parse_mode, disable_notification, timeout,
-                entities, protect_content, message_thread_id, reply_parameters, link_preview_options, business_connection_id))
+                entities, protect_content, message_thread_id, reply_parameters, link_preview_options, business_connection_id,
+                message_effect_id=message_effect_id))
 
     async def forward_message(
             self, chat_id: Union[int, str], from_chat_id: Union[int, str], 
@@ -3445,7 +3450,8 @@ class AsyncTeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send an animated emoji that will display a random value. On success, the sent Message is returned.
 
@@ -3487,6 +3493,9 @@ class AsyncTeleBot:
         :param business_connection_id: Unique identifier for the target business connection
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier for the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3517,7 +3526,7 @@ class AsyncTeleBot:
         return types.Message.de_json(
             await asyncio_helper.send_dice(
                 self.token, chat_id, emoji, disable_notification,
-                reply_markup, timeout, protect_content, message_thread_id, reply_parameters, business_connection_id))
+                reply_markup, timeout, protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id))
         
 
     async def send_photo(
@@ -3533,7 +3542,8 @@ class AsyncTeleBot:
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send photos. On success, the sent Message is returned.
 
@@ -3587,6 +3597,9 @@ class AsyncTeleBot:
 
         :param business_connection_id: Unique identifier for the target business connection
         :type business_connection_id: :obj:`str`
+
+        :param message_effect_id: Unique identifier for the message effect
+        :type message_effect_id: :obj:`str`
         
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -3620,7 +3633,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_photo(
                 self.token, chat_id, photo, caption, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
-                protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id))
+                protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id, message_effect_id=message_effect_id))
 
     async def send_audio(
             self, chat_id: Union[int, str], audio: Union[Any, str], 
@@ -3638,7 +3651,8 @@ class AsyncTeleBot:
             message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player.
         Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size,
@@ -3711,6 +3725,9 @@ class AsyncTeleBot:
         :param business_connection_id: Unique identifier for the target business connection
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier for the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3747,7 +3764,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_audio(
                 self.token, chat_id, audio, caption, duration, performer, title,
                 reply_markup, parse_mode, disable_notification, timeout, thumbnail,
-                caption_entities, protect_content, message_thread_id, reply_parameters, business_connection_id))
+                caption_entities, protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id))
 
     async def send_voice(
             self, chat_id: Union[int, str], voice: Union[Any, str], 
@@ -3762,7 +3779,8 @@ class AsyncTeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .OGG file encoded with OPUS, or in .MP3 format, or in .M4A format (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
 
@@ -3816,6 +3834,9 @@ class AsyncTeleBot:
         :param business_connection_id: Unique identifier for the target business connection
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier for the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
@@ -3847,7 +3868,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_voice(
                 self.token, chat_id, voice, caption, duration, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
-                protect_content, message_thread_id, reply_parameters, business_connection_id))
+                protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id))
 
     async def send_document(
             self, chat_id: Union[int, str], document: Union[Any, str],
@@ -3867,7 +3888,8 @@ class AsyncTeleBot:
             message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send general files.
 
@@ -3933,6 +3955,9 @@ class AsyncTeleBot:
         :param business_connection_id: Unique identifier for the target business connection
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier for the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3977,7 +4002,7 @@ class AsyncTeleBot:
                 disable_notification = disable_notification, timeout = timeout, caption = caption, thumbnail= thumbnail,
                 caption_entities = caption_entities,
                 disable_content_type_detection = disable_content_type_detection, visible_file_name = visible_file_name, protect_content = protect_content,
-                message_thread_id = message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id))
+                message_thread_id = message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id, message_effect_id=message_effect_id))
 
     async def send_sticker(
             self, chat_id: Union[int, str], sticker: Union[Any, str], 
@@ -3991,7 +4016,8 @@ class AsyncTeleBot:
             message_thread_id: Optional[int]=None,
             emoji: Optional[str]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers.
         On success, the sent Message is returned.
@@ -4040,6 +4066,9 @@ class AsyncTeleBot:
         :param business_connection_id: Unique identifier for the target business connection
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier for the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4078,7 +4107,7 @@ class AsyncTeleBot:
                 reply_markup=reply_markup,
                 disable_notification=disable_notification, timeout=timeout, 
                 protect_content=protect_content,
-                message_thread_id=message_thread_id, emoji=emoji, reply_parameters=reply_parameters, business_connection_id=business_connection_id))
+                message_thread_id=message_thread_id, emoji=emoji, reply_parameters=reply_parameters, business_connection_id=business_connection_id, message_effect_id=message_effect_id))
 
     async def send_video(
             self, chat_id: Union[int, str], video: Union[Any, str], 
@@ -4101,7 +4130,8 @@ class AsyncTeleBot:
             has_spoiler: Optional[bool]=None,
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
         
@@ -4175,6 +4205,9 @@ class AsyncTeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4216,7 +4249,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_video(
                 self.token, chat_id, video, duration, caption, reply_markup,
                 parse_mode, supports_streaming, disable_notification, timeout, thumbnail, width, height,
-                caption_entities, protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id))
+                caption_entities, protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id, message_effect_id=message_effect_id))
 
     async def send_animation(
             self, chat_id: Union[int, str], animation: Union[Any, str], 
@@ -4237,7 +4270,8 @@ class AsyncTeleBot:
             has_spoiler: Optional[bool]=None,
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
@@ -4310,6 +4344,9 @@ class AsyncTeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4346,7 +4383,8 @@ class AsyncTeleBot:
             await asyncio_helper.send_animation(
                 self.token, chat_id, animation, duration, caption,
                 reply_markup, parse_mode, disable_notification, timeout, thumbnail,
-                caption_entities, width, height, protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id))
+                caption_entities, width, height, protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id,
+                message_effect_id=message_effect_id))
 
     async def send_video_note(
             self, chat_id: Union[int, str], data: Union[Any, str], 
@@ -4362,7 +4400,8 @@ class AsyncTeleBot:
             message_thread_id: Optional[int]=None,
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         As of v.4.0, Telegram clients support rounded square MPEG4 videos of up to 1 minute long.
         Use this method to send video messages. On success, the sent Message is returned.
@@ -4420,6 +4459,9 @@ class AsyncTeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4454,7 +4496,7 @@ class AsyncTeleBot:
         return types.Message.de_json(
             await asyncio_helper.send_video_note(
                 self.token, chat_id, data, duration, length, reply_markup,
-                disable_notification, timeout, thumbnail, protect_content, message_thread_id, reply_parameters, business_connection_id))
+                disable_notification, timeout, thumbnail, protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id))
 
     async def send_media_group(
             self, chat_id: Union[int, str], 
@@ -4468,7 +4510,8 @@ class AsyncTeleBot:
             allow_sending_without_reply: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> List[types.Message]:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> List[types.Message]:
         """
         Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files
         can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned.
@@ -4505,6 +4548,9 @@ class AsyncTeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, an array of Messages that were sent is returned.
         :rtype: List[types.Message]
         """
@@ -4538,7 +4584,7 @@ class AsyncTeleBot:
             reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
         result = await asyncio_helper.send_media_group(
-            self.token, chat_id, media, disable_notification, timeout, protect_content, message_thread_id, reply_parameters, business_connection_id)
+            self.token, chat_id, media, disable_notification, timeout, protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id)
         return [types.Message.de_json(msg) for msg in result]
 
     async def send_location(
@@ -4556,7 +4602,8 @@ class AsyncTeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send point on the map. On success, the sent Message is returned.
 
@@ -4612,6 +4659,9 @@ class AsyncTeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4644,7 +4694,7 @@ class AsyncTeleBot:
                 self.token, chat_id, latitude, longitude, live_period, 
                 reply_markup, disable_notification, timeout, 
                 horizontal_accuracy, heading, proximity_alert_radius, 
-                protect_content, message_thread_id, reply_parameters, business_connection_id))
+                protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id))
 
     async def edit_message_live_location(
             self, latitude: float, longitude: float, 
@@ -4760,7 +4810,8 @@ class AsyncTeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send information about a venue. On success, the sent Message is returned.
         
@@ -4824,6 +4875,9 @@ class AsyncTeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4855,7 +4909,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_venue(
                 self.token, chat_id, latitude, longitude, title, address, foursquare_id, foursquare_type,
                 disable_notification, reply_markup, timeout,
-                google_place_id, google_place_type, protect_content, message_thread_id, reply_parameters, business_connection_id))
+                google_place_id, google_place_type, protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id))
         
 
     async def send_contact(
@@ -4870,7 +4924,8 @@ class AsyncTeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send phone contacts. On success, the sent Message is returned.
 
@@ -4921,6 +4976,9 @@ class AsyncTeleBot:
         :param business_connection_id: Identifier of a business connection, in which the message will be sent
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Unique identifier of the message effect
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4952,7 +5010,7 @@ class AsyncTeleBot:
             await asyncio_helper.send_contact(
                 self.token, chat_id, phone_number, first_name, last_name, vcard,
                 disable_notification, reply_markup, timeout,
-                protect_content, message_thread_id, reply_parameters, business_connection_id))
+                protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id))
         
 
     async def send_chat_action(
@@ -6063,7 +6121,8 @@ class AsyncTeleBot:
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
-            business_connection_id: Optional[str]=None) -> types.Message:
+            business_connection_id: Optional[str]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Used to send the game.
 
@@ -6102,6 +6161,9 @@ class AsyncTeleBot:
         :param business_connection_id: Identifier of the business connection.
         :type business_connection_id: :obj:`str`
 
+        :param message_effect_id: Identifier of the message effect.
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -6132,7 +6194,7 @@ class AsyncTeleBot:
         result = await asyncio_helper.send_game(
             self.token, chat_id, game_short_name, disable_notification,
             reply_markup, timeout, 
-            protect_content, message_thread_id, reply_parameters, business_connection_id)
+            protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id)
         return types.Message.de_json(result)
 
     async def set_game_score(
@@ -6230,7 +6292,8 @@ class AsyncTeleBot:
             suggested_tip_amounts: Optional[List[int]]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.Message:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Sends invoice.
 
@@ -6335,6 +6398,9 @@ class AsyncTeleBot:
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
+        :param message_effect_id: The identifier of a message effect to be applied to the message
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -6368,7 +6434,8 @@ class AsyncTeleBot:
             photo_height, need_name, need_phone_number, need_email, need_shipping_address,
             send_phone_number_to_provider, send_email_to_provider, is_flexible, disable_notification,
             reply_markup, provider_data, timeout,
-            max_tip_amount, suggested_tip_amounts, protect_content, message_thread_id, reply_parameters)
+            max_tip_amount, suggested_tip_amounts, protect_content, message_thread_id, reply_parameters,
+            message_effect_id=message_effect_id)
         return types.Message.de_json(result)
 
 
@@ -6498,7 +6565,7 @@ class AsyncTeleBot:
             business_connection_id: Optional[str]=None,
             question_parse_mode: Optional[str] = None,
             question_entities: Optional[List[types.MessageEntity]] = None,
-    ) -> types.Message:
+            message_effect_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send a native poll.
         On success, the sent Message is returned.
@@ -6581,6 +6648,9 @@ class AsyncTeleBot:
         :param question_entities: A JSON-serialized list of special entities that appear in the poll question. It can be specified instead of question_parse_mode
         :type question_entities: :obj:`list` of :obj:`MessageEntity`
 
+        :param message_effect_id: Identifier of the message effect to apply to the sent message
+        :type message_effect_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :obj:`types.Message`
         """
@@ -6632,7 +6702,8 @@ class AsyncTeleBot:
                 explanation, explanation_parse_mode, open_period, close_date, is_closed,
                 disable_notification,
                 reply_markup, timeout, explanation_entities, protect_content, message_thread_id, reply_parameters,
-                business_connection_id, question_parse_mode=question_parse_mode, question_entities=question_entities))
+                business_connection_id, question_parse_mode=question_parse_mode, question_entities=question_entities,
+                message_effect_id=message_effect_id))
 
     async def stop_poll(
             self, chat_id: Union[int, str], message_id: int, 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6711,6 +6711,23 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.answer_pre_checkout_query(self.token, pre_checkout_query_id, ok, error_message)
+    
+    async def refund_star_payment(self, user_id: int, telegram_payment_charge_id: str) -> bool:
+        """
+        Refunds a successful payment in Telegram Stars. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#refundstarpayment
+
+        :param user_id: Identifier of the user whose payment will be refunded
+        :type user_id: :obj:`int`
+
+        :param telegram_payment_charge_id: Telegram payment identifier
+        :type telegram_payment_charge_id: :obj:`str`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.refund_star_payment(self.token, user_id, telegram_payment_charge_id)
 
     async def edit_message_caption(
             self, caption: str, chat_id: Optional[Union[int, str]]=None, 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6291,7 +6291,7 @@ class AsyncTeleBot:
 
     async def send_invoice(
             self, chat_id: Union[int, str], title: str, description: str, 
-            invoice_payload: str, provider_token: str, currency: str, 
+            invoice_payload: str, provider_token: Union[str, None], currency: str, 
             prices: List[types.LabeledPrice], start_parameter: Optional[str]=None, 
             photo_url: Optional[str]=None, photo_size: Optional[int]=None, 
             photo_width: Optional[int]=None, photo_height: Optional[int]=None,
@@ -6330,7 +6330,8 @@ class AsyncTeleBot:
             use for your internal processes.
         :type invoice_payload: :obj:`str`
 
-        :param provider_token: Payments provider token, obtained via @Botfather
+        :param provider_token: Payments provider token, obtained via @Botfather; Pass None to omit the parameter
+            to use "XTR" currency
         :type provider_token: :obj:`str`
 
         :param currency: Three-letter ISO 4217 currency code,
@@ -6458,7 +6459,7 @@ class AsyncTeleBot:
 
 
     async def create_invoice_link(self,
-            title: str, description: str, payload:str, provider_token: str, 
+            title: str, description: str, payload:str, provider_token: Union[str, None], 
             currency: str, prices: List[types.LabeledPrice],
             max_tip_amount: Optional[int] = None, 
             suggested_tip_amounts: Optional[List[int]]=None,
@@ -6492,7 +6493,8 @@ class AsyncTeleBot:
             use for your internal processes.
         :type payload: :obj:`str`
 
-        :param provider_token: Payments provider token, obtained via @Botfather
+        :param provider_token: Payments provider token, obtained via @Botfather; Pass None to omit the parameter
+            to use "XTR" currency
         :type provider_token: :obj:`str`
 
         :param currency: Three-letter ISO 4217 currency code,

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -3234,7 +3234,8 @@ class AsyncTeleBot:
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
-            reply_parameters: Optional[types.ReplyParameters]=None) -> types.MessageID:
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            show_caption_above_media: Optional[bool]=None) -> types.MessageID:
         """
         Use this method to copy messages of any kind.
 
@@ -3282,6 +3283,9 @@ class AsyncTeleBot:
         
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
+        :param show_caption_above_media: Pass True, if the caption must be shown above the message media. Supported only for animation, photo and video messages.
+        :type show_caption_above_media: :obj:`bool`
         
         :return: On success, the MessageId of the sent message is returned.
         :rtype: :class:`telebot.types.MessageID`
@@ -3313,7 +3317,7 @@ class AsyncTeleBot:
         return types.MessageID.de_json(
             await asyncio_helper.copy_message(self.token, chat_id, from_chat_id, message_id, caption, parse_mode, caption_entities,
                                    disable_notification, reply_markup,
-                                   timeout, protect_content, message_thread_id, reply_parameters))
+                                   timeout, protect_content, message_thread_id, reply_parameters, show_caption_above_media=show_caption_above_media))
 
     async def delete_message(self, chat_id: Union[int, str], message_id: int, 
             timeout: Optional[int]=None) -> bool:
@@ -3543,7 +3547,8 @@ class AsyncTeleBot:
             has_spoiler: Optional[bool]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
             business_connection_id: Optional[str]=None,
-            message_effect_id: Optional[str]=None) -> types.Message:
+            message_effect_id: Optional[str]=None,
+            show_caption_above_media: Optional[bool]=None) -> types.Message:
         """
         Use this method to send photos. On success, the sent Message is returned.
 
@@ -3600,6 +3605,9 @@ class AsyncTeleBot:
 
         :param message_effect_id: Unique identifier for the message effect
         :type message_effect_id: :obj:`str`
+
+        :param show_caption_above_media: Pass True, if the caption must be shown above the message media. Supported only for animation, photo and video messages.
+        :type show_caption_above_media: :obj:`bool`
         
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
@@ -3633,7 +3641,8 @@ class AsyncTeleBot:
             await asyncio_helper.send_photo(
                 self.token, chat_id, photo, caption, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
-                protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id, message_effect_id=message_effect_id))
+                protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id, message_effect_id=message_effect_id,
+                show_caption_above_media=show_caption_above_media))
 
     async def send_audio(
             self, chat_id: Union[int, str], audio: Union[Any, str], 
@@ -4131,7 +4140,8 @@ class AsyncTeleBot:
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
             business_connection_id: Optional[str]=None,
-            message_effect_id: Optional[str]=None) -> types.Message:
+            message_effect_id: Optional[str]=None,
+            show_caption_above_media: Optional[bool]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
         
@@ -4208,6 +4218,9 @@ class AsyncTeleBot:
         :param message_effect_id: Unique identifier of the message effect
         :type message_effect_id: :obj:`str`
 
+        :param show_caption_above_media: Pass True, if the caption must be shown above the message media. Supported only for animation, photo and video messages.
+        :type show_caption_above_media: :obj:`bool`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4249,7 +4262,8 @@ class AsyncTeleBot:
             await asyncio_helper.send_video(
                 self.token, chat_id, video, duration, caption, reply_markup,
                 parse_mode, supports_streaming, disable_notification, timeout, thumbnail, width, height,
-                caption_entities, protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id, message_effect_id=message_effect_id))
+                caption_entities, protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id, message_effect_id=message_effect_id,
+                show_caption_above_media=show_caption_above_media))
 
     async def send_animation(
             self, chat_id: Union[int, str], animation: Union[Any, str], 
@@ -4271,7 +4285,8 @@ class AsyncTeleBot:
             thumb: Optional[Union[Any, str]]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
             business_connection_id: Optional[str]=None,
-            message_effect_id: Optional[str]=None) -> types.Message:
+            message_effect_id: Optional[str]=None,
+            show_caption_above_media: Optional[bool]=None) -> types.Message:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
@@ -4347,6 +4362,9 @@ class AsyncTeleBot:
         :param message_effect_id: Unique identifier of the message effect
         :type message_effect_id: :obj:`str`
 
+        :param show_caption_above_media: Pass True, if the caption must be shown above the message media. Supported only for animation, photo and video messages.
+        :type show_caption_above_media: :obj:`bool`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4384,7 +4402,7 @@ class AsyncTeleBot:
                 self.token, chat_id, animation, duration, caption,
                 reply_markup, parse_mode, disable_notification, timeout, thumbnail,
                 caption_entities, width, height, protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id,
-                message_effect_id=message_effect_id))
+                message_effect_id=message_effect_id, show_caption_above_media=show_caption_above_media))
 
     async def send_video_note(
             self, chat_id: Union[int, str], data: Union[Any, str], 
@@ -6806,7 +6824,8 @@ class AsyncTeleBot:
             inline_message_id: Optional[str]=None,
             parse_mode: Optional[str]=None, 
             caption_entities: Optional[List[types.MessageEntity]]=None,
-            reply_markup: Optional[types.InlineKeyboardMarkup]=None) -> Union[types.Message, bool]:
+            reply_markup: Optional[types.InlineKeyboardMarkup]=None,
+            show_caption_above_media: Optional[bool]=None) -> Union[types.Message, bool]:
         """
         Use this method to edit captions of messages.
 
@@ -6833,13 +6852,16 @@ class AsyncTeleBot:
         :param reply_markup: A JSON-serialized object for an inline keyboard.
         :type reply_markup: :obj:`InlineKeyboardMarkup`
 
+        :param show_caption_above_media: Pass True, if the caption must be shown above the message media. Supported only for animation, photo and video messages.
+        :type show_caption_above_media: :obj:`bool`
+
         :return: On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
         :rtype: :obj:`types.Message` | :obj:`bool`
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
 
         result = await asyncio_helper.edit_message_caption(self.token, caption, chat_id, message_id, inline_message_id,
-                                                parse_mode, caption_entities, reply_markup)
+                                                parse_mode, caption_entities, reply_markup, show_caption_above_media=show_caption_above_media)
         if type(result) == bool:
             return result
         return types.Message.de_json(result)

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -281,7 +281,7 @@ async def send_message(
         reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None,
         entities=None, protect_content=None,
-        message_thread_id=None, reply_parameters=None, link_preview_options=None, business_connection_id=None):
+        message_thread_id=None, reply_parameters=None, link_preview_options=None, business_connection_id=None, message_effect_id=None):
     method_name = 'sendMessage'
     params = {'chat_id': str(chat_id), 'text': text}
     if link_preview_options is not None:
@@ -304,6 +304,8 @@ async def send_message(
         params['message_thread_id'] = message_thread_id
     if business_connection_id:
         params['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        params['message_effect_id'] = message_effect_id
     
     return await _process_request(token, method_name, params=params)
 
@@ -442,7 +444,7 @@ async def send_dice(
         token, chat_id,
         emoji=None, disable_notification=None, 
         reply_markup=None, timeout=None,  protect_content=None,
-        message_thread_id=None,reply_parameters=None, business_connection_id=None):
+        message_thread_id=None,reply_parameters=None, business_connection_id=None, message_effect_id=None):
     method_url = r'sendDice'
     payload = {'chat_id': chat_id}
     if emoji:
@@ -461,6 +463,8 @@ async def send_dice(
         payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -470,7 +474,7 @@ async def send_photo(
         parse_mode=None, disable_notification=None, timeout=None,
         caption_entities=None,  protect_content=None,
         message_thread_id=None, has_spoiler=None,reply_parameters=None,
-        business_connection_id=None):
+        business_connection_id=None, message_effect_id=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None
@@ -502,13 +506,15 @@ async def send_photo(
         payload['has_spoiler'] = has_spoiler
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_media_group(
         token, chat_id, media,
         disable_notification=None, 
-        timeout=None,  protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None):
+        timeout=None,  protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None, message_effect_id=None):
     method_url = r'sendMediaGroup'
     media_json, files = await convert_input_media_array(media)
     payload = {'chat_id': chat_id, 'media': media_json}
@@ -524,6 +530,8 @@ async def send_media_group(
         payload['reply_parameters'] = json.dumps(reply_parameters.to_dict())
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(
         token, method_url, params=payload,
         method='post' if files else 'get',
@@ -535,7 +543,8 @@ async def send_location(
         live_period=None,  
         reply_markup=None, disable_notification=None, 
         timeout=None, horizontal_accuracy=None, heading=None,
-        proximity_alert_radius=None,  protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None):
+        proximity_alert_radius=None,  protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None,
+        message_effect_id=None):
     method_url = r'sendLocation'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude}
     if live_period:
@@ -560,6 +569,8 @@ async def send_location(
         payload['message_thread_id'] = message_thread_id
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -612,7 +623,8 @@ async def send_venue(
         foursquare_id=None, foursquare_type=None, disable_notification=None,
          reply_markup=None, timeout=None,
          google_place_id=None,
-        google_place_type=None, protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None):
+        google_place_type=None, protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None,
+        message_effect_id=None):
     method_url = r'sendVenue'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude, 'title': title, 'address': address}
     if foursquare_id:
@@ -637,13 +649,15 @@ async def send_venue(
         payload['message_thread_id'] = message_thread_id
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload)
 
 
 async def send_contact(
         token, chat_id, phone_number, first_name, last_name=None, vcard=None,
         disable_notification=None,  reply_markup=None, timeout=None,
-         protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None):
+         protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None, message_effect_id=None):
     method_url = r'sendContact'
     payload = {'chat_id': chat_id, 'phone_number': phone_number, 'first_name': first_name}
     if last_name:
@@ -664,6 +678,8 @@ async def send_contact(
         payload['message_thread_id'] = message_thread_id
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -682,7 +698,8 @@ async def send_chat_action(token, chat_id, action, timeout=None, message_thread_
 async def send_video(token, chat_id, data, duration=None, caption=None,  reply_markup=None,
                      parse_mode=None, supports_streaming=None, disable_notification=None, timeout=None,
                      thumbnail=None, width=None, height=None, caption_entities=None, 
-                     protect_content=None, message_thread_id=None, has_spoiler=None,reply_parameters=None, business_connection_id=None):
+                     protect_content=None, message_thread_id=None, has_spoiler=None,reply_parameters=None, business_connection_id=None,
+                     message_effect_id=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -728,6 +745,8 @@ async def send_video(token, chat_id, data, duration=None, caption=None,  reply_m
         payload['has_spoiler'] = has_spoiler
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -735,7 +754,7 @@ async def send_animation(
         token, chat_id, data, duration=None, caption=None,  reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None, thumbnail=None, caption_entities=None,
          width=None, height=None, protect_content=None, message_thread_id=None,
-        has_spoiler=None,reply_parameters=None, business_connection_id=None):
+        has_spoiler=None,reply_parameters=None, business_connection_id=None, message_effect_id=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}
     files = None
@@ -779,12 +798,14 @@ async def send_animation(
         payload['has_spoiler'] = has_spoiler
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_voice(token, chat_id, voice, caption=None, duration=None,  reply_markup=None,
                parse_mode=None, disable_notification=None, timeout=None, caption_entities=None,
-                protect_content=None, message_thread_id=None,reply_parameters=None,business_connection_id=None):
+                protect_content=None, message_thread_id=None,reply_parameters=None,business_connection_id=None, message_effect_id=None):
     method_url = r'sendVoice'
     payload = {'chat_id': chat_id}
     files = None
@@ -814,12 +835,14 @@ async def send_voice(token, chat_id, voice, caption=None, duration=None,  reply_
         payload['message_thread_id'] = message_thread_id
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_video_note(token, chat_id, data, duration=None, length=None,  reply_markup=None,
                           disable_notification=None, timeout=None, thumbnail=None,  protect_content=None,
-                          message_thread_id=None,reply_parameters=None, business_connection_id=None):
+                          message_thread_id=None,reply_parameters=None, business_connection_id=None, message_effect_id=None):
     method_url = r'sendVideoNote'
     payload = {'chat_id': chat_id}
     files = None
@@ -855,12 +878,15 @@ async def send_video_note(token, chat_id, data, duration=None, length=None,  rep
         payload['message_thread_id'] = message_thread_id
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None, 
                      reply_markup=None, parse_mode=None, disable_notification=None, timeout=None, thumbnail=None,
-                     caption_entities=None,  protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None):
+                     caption_entities=None,  protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None,
+                     message_effect_id=None):
     method_url = r'sendAudio'
     payload = {'chat_id': chat_id}
     files = None
@@ -902,13 +928,15 @@ async def send_audio(token, chat_id, audio, caption=None, duration=None, perform
         payload['message_thread_id'] = message_thread_id
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_data(token, chat_id, data, data_type,  reply_markup=None, parse_mode=None,
                     disable_notification=None, timeout=None, caption=None, thumbnail=None, caption_entities=None,
                      disable_content_type_detection=None, visible_file_name=None, protect_content=None,
-                    message_thread_id=None, emoji=None,reply_parameters=None, business_connection_id=None):
+                    message_thread_id=None, emoji=None,reply_parameters=None, business_connection_id=None, message_effect_id=None):
     method_url = await get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None
@@ -951,6 +979,8 @@ async def send_data(token, chat_id, data, data_type,  reply_markup=None, parse_m
         payload['emoji'] = emoji
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1400,7 +1430,7 @@ async def delete_message(token, chat_id, message_id, timeout=None):
 async def send_game(
         token, chat_id, game_short_name,
         disable_notification=None,  reply_markup=None, timeout=None,
-         protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None):
+         protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None, message_effect_id=None):
     method_url = r'sendGame'
     payload = {'chat_id': chat_id, 'game_short_name': game_short_name}
     if disable_notification is not None:
@@ -1417,6 +1447,8 @@ async def send_game(
         payload['message_thread_id'] = message_thread_id
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -1482,7 +1514,7 @@ async def send_invoice(
         send_phone_number_to_provider = None, send_email_to_provider = None, is_flexible=None,
         disable_notification=None,  reply_markup=None, provider_data=None,
         timeout=None,  max_tip_amount=None, suggested_tip_amounts=None,
-        protect_content=None, message_thread_id=None, reply_parameters=None):
+        protect_content=None, message_thread_id=None, reply_parameters=None, message_effect_id=None):
     """
     Use this method to send invoices. On success, the sent Message is returned.
     :param token: Bot's token (you don't need to fill this)
@@ -1563,6 +1595,8 @@ async def send_invoice(
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -1809,7 +1843,7 @@ async def send_poll(
         explanation = None, explanation_parse_mode=None, open_period = None, close_date = None, is_closed = None,
         disable_notification=False,  
         reply_markup=None, timeout=None, explanation_entities=None, protect_content=None, message_thread_id=None,
-        reply_parameters=None,business_connection_id=None, question_parse_mode=None, question_entities=None):
+        reply_parameters=None,business_connection_id=None, question_parse_mode=None, question_entities=None, message_effect_id=None):
     method_url = r'sendPoll'
     payload = {
         'chat_id': str(chat_id),
@@ -1859,6 +1893,8 @@ async def send_poll(
         payload['question_parse_mode'] = question_parse_mode
     if question_entities:
         payload['question_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(question_entities))
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
     return await _process_request(token, method_url, params=payload)
 
 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1601,6 +1601,12 @@ async def answer_pre_checkout_query(token, pre_checkout_query_id, ok, error_mess
     return await _process_request(token, method_url, params=payload)
 
 
+async def refund_star_payment(token, user_id, telegram_payment_charge_id):
+    method_url = 'refundStarPayment'
+    payload = {'user_id': user_id, 'telegram_payment_charge_id': telegram_payment_charge_id}
+    return await _process_request(token, method_url, params=payload, method='post')
+
+
 async def unpin_all_general_forum_topic_messages(token, chat_id):
     method_url = 'unpinAllGeneralForumTopicMessages'
     payload = {'chat_id': chat_id}

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1561,8 +1561,8 @@ async def send_invoice(
     """
     method_url = r'sendInvoice'
     payload = {'chat_id': chat_id, 'title': title, 'description': description, 'payload': invoice_payload,
-               'provider_token': provider_token, 'currency': currency,
-               'prices': await _convert_list_json_serializable(prices)}
+                'currency': currency,
+                'prices': await _convert_list_json_serializable(prices)}
     if start_parameter:
         payload['start_parameter'] = start_parameter
     if photo_url:
@@ -1607,6 +1607,8 @@ async def send_invoice(
         payload['message_thread_id'] = message_thread_id
     if message_effect_id:
         payload['message_effect_id'] = message_effect_id
+    if provider_token is not None:
+        payload['provider_token'] = provider_token
     return await _process_request(token, method_url, params=payload)
 
 
@@ -1648,13 +1650,13 @@ async def answer_pre_checkout_query(token, pre_checkout_query_id, ok, error_mess
 async def refund_star_payment(token, user_id, telegram_payment_charge_id):
     method_url = 'refundStarPayment'
     payload = {'user_id': user_id, 'telegram_payment_charge_id': telegram_payment_charge_id}
-    return await _process_request(token, method_url, params=payload, method='post')
+    return await _process_request(token, method_url, params=payload)
 
 
 async def unpin_all_general_forum_topic_messages(token, chat_id):
     method_url = 'unpinAllGeneralForumTopicMessages'
     payload = {'chat_id': chat_id}
-    return await _process_request(token, method_url, params=payload, method='post')
+    return await _process_request(token, method_url, params=payload)
 
 # InlineQuery
 
@@ -1812,7 +1814,7 @@ async def create_invoice_link(token, title, description, payload, provider_token
             need_email=None, need_shipping_address=None, send_phone_number_to_provider=None,
             send_email_to_provider=None, is_flexible=None):
     method_url = r'createInvoiceLink'
-    payload = {'title': title, 'description': description, 'payload': payload, 'provider_token': provider_token,
+    payload = {'title': title, 'description': description, 'payload': payload,
                 'currency': currency, 'prices': await _convert_list_json_serializable(prices)}
     if max_tip_amount:
         payload['max_tip_amount'] = max_tip_amount
@@ -1842,6 +1844,8 @@ async def create_invoice_link(token, title, description, payload, provider_token
         payload['send_email_to_provider'] = send_email_to_provider
     if is_flexible is not None:
         payload['is_flexible'] = is_flexible
+    if provider_token is not None:
+        payload['provider_token'] = provider_token
     return await _process_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -416,7 +416,7 @@ async def forward_message(
 
 async def copy_message(token, chat_id, from_chat_id, message_id, caption=None, parse_mode=None, caption_entities=None,
                  disable_notification=None,  
-                 reply_markup=None, timeout=None, protect_content=None, message_thread_id=None, reply_parameters=None):
+                 reply_markup=None, timeout=None, protect_content=None, message_thread_id=None, reply_parameters=None, show_caption_above_media=None):
     method_url = r'copyMessage'
     payload = {'chat_id': chat_id, 'from_chat_id': from_chat_id, 'message_id': message_id}
     if caption is not None:
@@ -437,6 +437,8 @@ async def copy_message(token, chat_id, from_chat_id, message_id, caption=None, p
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if show_caption_above_media is not None:
+        payload['show_caption_above_media'] = show_caption_above_media
     return await _process_request(token, method_url, params=payload)
 
 
@@ -474,7 +476,7 @@ async def send_photo(
         parse_mode=None, disable_notification=None, timeout=None,
         caption_entities=None,  protect_content=None,
         message_thread_id=None, has_spoiler=None,reply_parameters=None,
-        business_connection_id=None, message_effect_id=None):
+        business_connection_id=None, message_effect_id=None, show_caption_above_media=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None
@@ -508,6 +510,8 @@ async def send_photo(
         payload['business_connection_id'] = business_connection_id
     if message_effect_id:
         payload['message_effect_id'] = message_effect_id
+    if show_caption_above_media is not None:
+        payload['show_caption_above_media'] = show_caption_above_media
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -699,7 +703,7 @@ async def send_video(token, chat_id, data, duration=None, caption=None,  reply_m
                      parse_mode=None, supports_streaming=None, disable_notification=None, timeout=None,
                      thumbnail=None, width=None, height=None, caption_entities=None, 
                      protect_content=None, message_thread_id=None, has_spoiler=None,reply_parameters=None, business_connection_id=None,
-                     message_effect_id=None):
+                     message_effect_id=None, show_caption_above_media=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -747,6 +751,8 @@ async def send_video(token, chat_id, data, duration=None, caption=None,  reply_m
         payload['business_connection_id'] = business_connection_id
     if message_effect_id:
         payload['message_effect_id'] = message_effect_id
+    if show_caption_above_media is not None:
+        payload['show_caption_above_media'] = show_caption_above_media
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -754,7 +760,7 @@ async def send_animation(
         token, chat_id, data, duration=None, caption=None,  reply_markup=None,
         parse_mode=None, disable_notification=None, timeout=None, thumbnail=None, caption_entities=None,
          width=None, height=None, protect_content=None, message_thread_id=None,
-        has_spoiler=None,reply_parameters=None, business_connection_id=None, message_effect_id=None):
+        has_spoiler=None,reply_parameters=None, business_connection_id=None, message_effect_id=None, show_caption_above_media=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}
     files = None
@@ -800,6 +806,8 @@ async def send_animation(
         payload['business_connection_id'] = business_connection_id
     if message_effect_id:
         payload['message_effect_id'] = message_effect_id
+    if show_caption_above_media is not None:
+        payload['show_caption_above_media'] = show_caption_above_media
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1370,7 +1378,7 @@ async def edit_message_text(token, text, chat_id=None, message_id=None, inline_m
 
 
 async def edit_message_caption(token, caption, chat_id=None, message_id=None, inline_message_id=None,
-                         parse_mode=None, caption_entities=None,reply_markup=None):
+                         parse_mode=None, caption_entities=None,reply_markup=None, show_caption_above_media=None):
     method_url = r'editMessageCaption'
     payload = {'caption': caption}
     if chat_id:
@@ -1385,6 +1393,8 @@ async def edit_message_caption(token, caption, chat_id=None, message_id=None, in
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
     if reply_markup:
         payload['reply_markup'] = await _convert_markup(reply_markup)
+    if show_caption_above_media is not None:
+        payload['show_caption_above_media'] = show_caption_above_media
     return await _process_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/formatting.py
+++ b/telebot/formatting.py
@@ -397,6 +397,8 @@ def apply_html_entities(text: str, entities: Optional[List], custom_subs: Option
         "spoiler": "<span class=\"tg-spoiler\">{text}</span>",
         "custom_emoji": "<tg-emoji emoji-id=\"{custom_emoji_id}\">{text}</tg-emoji>",
         "blockquote": "<blockquote>{text}</blockquote>",
+        "expandable_blockquote": "<blockquote expandable>{text}</blockquote>",
+
     }
 
     if custom_subs:

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -989,6 +989,9 @@ class Message(JsonDeserializable):
         commands, etc. that appear in the caption
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
+    :param show_caption_above_media: Optional. True, if the caption must be shown above the message media
+    :type show_caption_above_media: :obj:`bool`
+
     :param has_media_spoiler: Optional. True, if the message media is covered by a spoiler animation
     :type has_media_spoiler: :obj:`bool`
 
@@ -1375,6 +1378,8 @@ class Message(JsonDeserializable):
             opts['is_from_offline'] = obj['is_from_offline']
         if 'effect_id' in obj:
             opts['effect_id'] = obj['effect_id']
+        if 'show_caption_above_media' in obj:
+            opts['show_caption_above_media'] = obj['show_caption_above_media']
 
 
 
@@ -1485,6 +1490,7 @@ class Message(JsonDeserializable):
         self.business_connection_id: Optional[str] = None
         self.is_from_offline: Optional[bool] = None
         self.effect_id: Optional[str] = None
+        self.show_caption_above_media: Optional[bool] = None
 
         for key in options:
             setattr(self, key, options[key])
@@ -4454,11 +4460,15 @@ class InlineQueryResultPhoto(InlineQueryResultBase):
     :param input_message_content: Optional. Content of the message to be sent instead of the photo
     :type input_message_content: :class:`telebot.types.InputMessageContent`
 
+    :param show_caption_above_media: Optional. If true, a caption is shown over the photo or video
+    :type show_caption_above_media: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.InlineQueryResultPhoto`
     """
     def __init__(self, id, photo_url, thumbnail_url, photo_width=None, photo_height=None, title=None,
-                 description=None, caption=None, caption_entities=None, parse_mode=None, reply_markup=None, input_message_content=None):
+                 description=None, caption=None, caption_entities=None, parse_mode=None, reply_markup=None, input_message_content=None,
+                 show_caption_above_media=None):
         super().__init__('photo', id, title = title, caption = caption,
                          input_message_content = input_message_content, reply_markup = reply_markup,
                          parse_mode = parse_mode, caption_entities = caption_entities)
@@ -4467,6 +4477,7 @@ class InlineQueryResultPhoto(InlineQueryResultBase):
         self.photo_width = photo_width
         self.photo_height = photo_height
         self.description = description
+        self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
     @property
     def thumb_url(self):
@@ -4483,6 +4494,8 @@ class InlineQueryResultPhoto(InlineQueryResultBase):
             json_dict['photo_height'] = self.photo_height
         if self.description:
             json_dict['description'] = self.description
+        if self.show_caption_above_media:
+            json_dict['show_caption_above_media'] = self.show_caption_above_media
         return json_dict
 
 
@@ -4537,13 +4550,16 @@ class InlineQueryResultGif(InlineQueryResultBase):
     :param input_message_content: Optional. Content of the message to be sent instead of the GIF animation
     :type input_message_content: :class:`telebot.types.InputMessageContent`
 
+    :param show_caption_above_media: Optional. If true, a caption is shown over the photo or video
+    :type show_caption_above_media: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.InlineQueryResultGif`
     """
     def __init__(self, id, gif_url, thumbnail_url, gif_width=None, gif_height=None,
                  title=None, caption=None, caption_entities=None,
                  reply_markup=None, input_message_content=None, gif_duration=None, parse_mode=None,
-                 thumbnail_mime_type=None):
+                 thumbnail_mime_type=None, show_caption_above_media=None):
         super().__init__('gif', id, title = title, caption = caption,
                          input_message_content = input_message_content, reply_markup = reply_markup,
                          parse_mode = parse_mode, caption_entities = caption_entities)
@@ -4553,6 +4569,7 @@ class InlineQueryResultGif(InlineQueryResultBase):
         self.thumbnail_url = thumbnail_url
         self.gif_duration = gif_duration
         self.thumbnail_mime_type = thumbnail_mime_type
+        self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
     @property
     def thumb_url(self):
@@ -4576,6 +4593,8 @@ class InlineQueryResultGif(InlineQueryResultBase):
             json_dict['gif_duration'] = self.gif_duration
         if self.thumbnail_mime_type:
             json_dict['thumbnail_mime_type'] = self.thumbnail_mime_type
+        if self.show_caption_above_media:
+            json_dict['show_caption_above_media'] = self.show_caption_above_media
         return json_dict
 
 
@@ -4630,13 +4649,16 @@ class InlineQueryResultMpeg4Gif(InlineQueryResultBase):
     :param input_message_content: Optional. Content of the message to be sent instead of the video animation
     :type input_message_content: :class:`telebot.types.InputMessageContent`
 
+    :param show_caption_above_media: Optional. If true, a caption is shown over the photo or video
+    :type show_caption_above_media: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.InlineQueryResultMpeg4Gif`
     """
     def __init__(self, id, mpeg4_url, thumbnail_url, mpeg4_width=None, mpeg4_height=None,
                  title=None, caption=None, caption_entities=None,
                  parse_mode=None, reply_markup=None, input_message_content=None, mpeg4_duration=None,
-                 thumbnail_mime_type=None):
+                 thumbnail_mime_type=None, show_caption_above_media=None):
         super().__init__('mpeg4_gif', id, title = title, caption = caption,
                          input_message_content = input_message_content, reply_markup = reply_markup,
                          parse_mode = parse_mode, caption_entities = caption_entities)
@@ -4646,6 +4668,7 @@ class InlineQueryResultMpeg4Gif(InlineQueryResultBase):
         self.thumbnail_url = thumbnail_url
         self.mpeg4_duration = mpeg4_duration
         self.thumbnail_mime_type = thumbnail_mime_type
+        self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
     @property
     def thumb_url(self):
@@ -4669,6 +4692,8 @@ class InlineQueryResultMpeg4Gif(InlineQueryResultBase):
             json_dict['mpeg4_duration '] = self.mpeg4_duration
         if self.thumbnail_mime_type:
             json_dict['thumbnail_mime_type'] = self.thumbnail_mime_type
+        if self.show_caption_above_media:
+            json_dict['show_caption_above_media'] = self.show_caption_above_media
         return json_dict
 
 
@@ -4727,13 +4752,16 @@ class InlineQueryResultVideo(InlineQueryResultBase):
         required if InlineQueryResultVideo is used to send an HTML-page as a result (e.g., a YouTube video).
     :type input_message_content: :class:`telebot.types.InputMessageContent`
 
+    :param show_caption_above_media: Optional. If true, a caption is shown over the video
+    :type show_caption_above_media: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.InlineQueryResultVideo`
     """
     def __init__(self, id, video_url, mime_type, thumbnail_url,
                  title, caption=None, caption_entities=None, parse_mode=None,
                  video_width=None, video_height=None, video_duration=None,
-                 description=None, reply_markup=None, input_message_content=None):
+                 description=None, reply_markup=None, input_message_content=None, show_caption_above_media=None):
         super().__init__('video', id, title = title, caption = caption,
                          input_message_content = input_message_content, reply_markup = reply_markup,
                          parse_mode = parse_mode, caption_entities = caption_entities)
@@ -4744,6 +4772,7 @@ class InlineQueryResultVideo(InlineQueryResultBase):
         self.video_height = video_height
         self.video_duration = video_duration
         self.description = description
+        self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
     @property
     def thumb_url(self):
@@ -4761,6 +4790,8 @@ class InlineQueryResultVideo(InlineQueryResultBase):
             json_dict['video_duration'] = self.video_duration
         if self.description:
             json_dict['description'] = self.description
+        if self.show_caption_above_media:
+            json_dict['show_caption_above_media'] = self.show_caption_above_media
         return json_dict
 
 
@@ -5330,6 +5361,7 @@ class InlineQueryResultCachedBase(ABC, JsonSerializable):
         self.parse_mode = None
         self.caption_entities = None
         self.payload_dic = {}
+        self.show_caption_above_media = None
 
     def to_json(self):
         json_dict = self.payload_dic
@@ -5349,6 +5381,8 @@ class InlineQueryResultCachedBase(ABC, JsonSerializable):
             json_dict['parse_mode'] = self.parse_mode
         if self.caption_entities:
             json_dict['caption_entities'] = MessageEntity.to_list_of_dicts(self.caption_entities)
+        if self.show_caption_above_media:
+            json_dict['show_caption_above_media'] = self.show_caption_above_media
         return json.dumps(json_dict)
 
 
@@ -5391,12 +5425,15 @@ class InlineQueryResultCachedPhoto(InlineQueryResultCachedBase):
     :param input_message_content: Optional. Content of the message to be sent instead of the photo
     :type input_message_content: :class:`telebot.types.InputMessageContent`
 
+    :param show_caption_above_media: Optional. Pass True, if a caption is not required for the media
+    :type show_caption_above_media: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.InlineQueryResultCachedPhoto`
     """
     def __init__(self, id, photo_file_id, title=None, description=None,
                  caption=None, caption_entities = None, parse_mode=None,
-                 reply_markup=None, input_message_content=None):
+                 reply_markup=None, input_message_content=None, show_caption_above_media=None):
         InlineQueryResultCachedBase.__init__(self)
         self.type = 'photo'
         self.id = id
@@ -5409,6 +5446,7 @@ class InlineQueryResultCachedPhoto(InlineQueryResultCachedBase):
         self.input_message_content = input_message_content
         self.parse_mode = parse_mode
         self.payload_dic['photo_file_id'] = photo_file_id
+        self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
 
 # noinspection PyUnresolvedReferences,PyShadowingBuiltins
@@ -5446,12 +5484,15 @@ class InlineQueryResultCachedGif(InlineQueryResultCachedBase):
     :param input_message_content: Optional. Content of the message to be sent instead of the GIF animation
     :type input_message_content: :class:`telebot.types.InputMessageContent`
 
+    :param show_caption_above_media: Optional. Pass True, if a caption is not required for the media
+    :type show_caption_above_media: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.InlineQueryResultCachedGif`
     """
     def __init__(self, id, gif_file_id, title=None, description=None,
                  caption=None, caption_entities = None, parse_mode=None,
-                 reply_markup=None, input_message_content=None):
+                 reply_markup=None, input_message_content=None, show_caption_above_media=None):
         InlineQueryResultCachedBase.__init__(self)
         self.type = 'gif'
         self.id = id
@@ -5464,6 +5505,7 @@ class InlineQueryResultCachedGif(InlineQueryResultCachedBase):
         self.input_message_content = input_message_content
         self.parse_mode = parse_mode
         self.payload_dic['gif_file_id'] = gif_file_id
+        self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
 
 # noinspection PyUnresolvedReferences,PyShadowingBuiltins
@@ -5501,12 +5543,15 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResultCachedBase):
     :param input_message_content: Optional. Content of the message to be sent instead of the video animation
     :type input_message_content: :class:`telebot.types.InputMessageContent`
 
+    :param show_caption_above_media: Optional. Pass True, if caption should be shown above the media
+    :type show_caption_above_media: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.InlineQueryResultCachedMpeg4Gif`
     """
     def __init__(self, id, mpeg4_file_id, title=None, description=None,
                  caption=None, caption_entities = None, parse_mode=None,
-                 reply_markup=None, input_message_content=None):
+                 reply_markup=None, input_message_content=None, show_caption_above_media=None):
         InlineQueryResultCachedBase.__init__(self)
         self.type = 'mpeg4_gif'
         self.id = id
@@ -5519,7 +5564,7 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResultCachedBase):
         self.input_message_content = input_message_content
         self.parse_mode = parse_mode
         self.payload_dic['mpeg4_file_id'] = mpeg4_file_id
-
+        self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
 # noinspection PyUnresolvedReferences,PyShadowingBuiltins
 class InlineQueryResultCachedSticker(InlineQueryResultCachedBase):
@@ -5654,13 +5699,16 @@ class InlineQueryResultCachedVideo(InlineQueryResultCachedBase):
     :param input_message_content: Optional. Content of the message to be sent instead of the video
     :type input_message_content: :class:`telebot.types.InputMessageContent`
 
+    :param show_caption_above_media: Optional. Pass True, if a caption is not required for the media
+    :type show_caption_above_media: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.InlineQueryResultCachedVideo`
     """
     def __init__(self, id, video_file_id, title, description=None,
                  caption=None, caption_entities = None, parse_mode=None,
                  reply_markup=None,
-                 input_message_content=None):
+                 input_message_content=None, show_caption_above_media=None):
         InlineQueryResultCachedBase.__init__(self)
         self.type = 'video'
         self.id = id
@@ -5673,6 +5721,7 @@ class InlineQueryResultCachedVideo(InlineQueryResultCachedBase):
         self.input_message_content = input_message_content
         self.parse_mode = parse_mode
         self.payload_dic['video_file_id'] = video_file_id
+        self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
 
 # noinspection PyUnresolvedReferences,PyShadowingBuiltins
@@ -6575,10 +6624,13 @@ class InputMediaPhoto(InputMedia):
     :param has_spoiler: Optional. True, if the uploaded photo is a spoiler
     :type has_spoiler: :obj:`bool`
 
+    :param show_caption_above_media: Optional. True, if the caption should be shown above the photo
+    :type show_caption_above_media: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.InputMediaPhoto`
     """
-    def __init__(self, media, caption=None, parse_mode=None, caption_entities=None, has_spoiler=None):
+    def __init__(self, media, caption=None, parse_mode=None, caption_entities=None, has_spoiler=None, show_caption_above_media=None):
         if service_utils.is_pil_image(media):
             media = service_utils.pil_image_to_file(media)
     
@@ -6586,11 +6638,14 @@ class InputMediaPhoto(InputMedia):
             type="photo", media=media, caption=caption, parse_mode=parse_mode, caption_entities=caption_entities)
 
         self.has_spoiler: Optional[bool] = has_spoiler
+        self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
     def to_dict(self):
         ret = super(InputMediaPhoto, self).to_dict()
         if self.has_spoiler is not None:
             ret['has_spoiler'] = self.has_spoiler
+        if self.show_caption_above_media is not None:
+            ret['show_caption_above_media'] = self.show_caption_above_media
         return ret
 
 
@@ -6638,11 +6693,14 @@ class InputMediaVideo(InputMedia):
     :param has_spoiler: Optional. True, if the uploaded video is a spoiler
     :type has_spoiler: :obj:`bool`
 
+    :param show_caption_above_media: Optional. True, if the caption should be shown above the video
+    :type show_caption_above_media: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.InputMediaVideo`
     """
     def __init__(self, media, thumbnail=None, caption=None, parse_mode=None, caption_entities=None,
-                 width=None, height=None, duration=None, supports_streaming=None, has_spoiler=None):
+                 width=None, height=None, duration=None, supports_streaming=None, has_spoiler=None, show_caption_above_media=None):
         super(InputMediaVideo, self).__init__(
             type="video", media=media, caption=caption, parse_mode=parse_mode, caption_entities=caption_entities)
         self.thumbnail = thumbnail
@@ -6651,6 +6709,7 @@ class InputMediaVideo(InputMedia):
         self.duration = duration
         self.supports_streaming = supports_streaming
         self.has_spoiler: Optional[bool] = has_spoiler
+        self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
     @property
     def thumb(self):
@@ -6671,6 +6730,8 @@ class InputMediaVideo(InputMedia):
             ret['supports_streaming'] = self.supports_streaming
         if self.has_spoiler is not None:
             ret['has_spoiler'] = self.has_spoiler
+        if self.show_caption_above_media is not None:
+            ret['show_caption_above_media'] = self.show_caption_above_media
         return ret
 
 
@@ -6715,11 +6776,14 @@ class InputMediaAnimation(InputMedia):
     :param has_spoiler: Optional. True, if the uploaded animation is a spoiler
     :type has_spoiler: :obj:`bool`
 
+    :param show_caption_above_media: Optional. True, if the caption should be shown above the animation
+    :type show_caption_above_media: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.InputMediaAnimation`
     """
     def __init__(self, media, thumbnail=None, caption=None, parse_mode=None, caption_entities=None,
-                 width=None, height=None, duration=None, has_spoiler=None):
+                 width=None, height=None, duration=None, has_spoiler=None, show_caption_above_media=None):
         super(InputMediaAnimation, self).__init__(
             type="animation", media=media, caption=caption, parse_mode=parse_mode, caption_entities=caption_entities)
         self.thumbnail = thumbnail
@@ -6727,6 +6791,7 @@ class InputMediaAnimation(InputMedia):
         self.height = height
         self.duration = duration
         self.has_spoiler: Optional[bool] = has_spoiler
+        self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
     @property
     def thumb(self):
@@ -6745,6 +6810,8 @@ class InputMediaAnimation(InputMedia):
             ret['duration'] = self.duration
         if self.has_spoiler is not None:
             ret['has_spoiler'] = self.has_spoiler
+        if self.show_caption_above_media is not None:
+            ret['show_caption_above_media'] = self.show_caption_above_media
         return ret
 
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -951,6 +951,9 @@ class Message(JsonDeserializable):
         if it is a text message and link preview options were changed
     :type link_preview_options: :class:`telebot.types.LinkPreviewOptions`
 
+    :param effect_id: Optional. Unique identifier of the message effect added to the message
+    :type effect_id: :obj:`str`
+
     :param animation: Optional. Message is an animation, information about the animation. For backward
         compatibility, when this field is set, the document field will also be set
     :type animation: :class:`telebot.types.Animation`
@@ -1370,6 +1373,8 @@ class Message(JsonDeserializable):
             opts['business_connection_id'] = obj['business_connection_id']
         if 'is_from_offline' in obj:
             opts['is_from_offline'] = obj['is_from_offline']
+        if 'effect_id' in obj:
+            opts['effect_id'] = obj['effect_id']
 
 
 
@@ -1479,6 +1484,7 @@ class Message(JsonDeserializable):
         self.sender_business_bot: Optional[User] = None
         self.business_connection_id: Optional[str] = None
         self.is_from_offline: Optional[bool] = None
+        self.effect_id: Optional[str] = None
 
         for key in options:
             setattr(self, key, options[key])

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1598,12 +1598,12 @@ class MessageEntity(Dictionaryable, JsonSerializable, JsonDeserializable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#messageentity
 
-    :param type: Type of the entity. Currently, can be “mention” (@username), “hashtag” (#hashtag), “cashtag” 
-        ($USD), “bot_command” (/start@jobs_bot), “url” (https://telegram.org), “email” 
-        (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), 
-        “underline” (underlined text), “strikethrough” (strikethrough text), “spoiler” (spoiler message), “code” 
-        (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users 
-        without usernames), “custom_emoji” (for inline custom emoji stickers)
+    :param type: Type of the entity. Currently, can be “mention” (@username), “hashtag” (#hashtag), “cashtag” ($USD),
+        “bot_command” (/start@jobs_bot),“url” (https://telegram.org), “email” (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123),
+        “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text),
+        “spoiler” (spoiler message), “blockquote” (block quotation), “expandable_blockquote” (collapsed-by-default block quotation),
+        “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs),
+        “text_mention” (for users without usernames), “custom_emoji” (for inline custom emoji stickers)
     :type type: :obj:`str`
 
     :param offset: Offset in UTF-16 code units to the start of the entity

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -4494,7 +4494,7 @@ class InlineQueryResultPhoto(InlineQueryResultBase):
             json_dict['photo_height'] = self.photo_height
         if self.description:
             json_dict['description'] = self.description
-        if self.show_caption_above_media:
+        if self.show_caption_above_media is not None:
             json_dict['show_caption_above_media'] = self.show_caption_above_media
         return json_dict
 
@@ -4593,7 +4593,7 @@ class InlineQueryResultGif(InlineQueryResultBase):
             json_dict['gif_duration'] = self.gif_duration
         if self.thumbnail_mime_type:
             json_dict['thumbnail_mime_type'] = self.thumbnail_mime_type
-        if self.show_caption_above_media:
+        if self.show_caption_above_media is not None:
             json_dict['show_caption_above_media'] = self.show_caption_above_media
         return json_dict
 
@@ -4692,7 +4692,7 @@ class InlineQueryResultMpeg4Gif(InlineQueryResultBase):
             json_dict['mpeg4_duration '] = self.mpeg4_duration
         if self.thumbnail_mime_type:
             json_dict['thumbnail_mime_type'] = self.thumbnail_mime_type
-        if self.show_caption_above_media:
+        if self.show_caption_above_media is not None:
             json_dict['show_caption_above_media'] = self.show_caption_above_media
         return json_dict
 
@@ -4790,7 +4790,7 @@ class InlineQueryResultVideo(InlineQueryResultBase):
             json_dict['video_duration'] = self.video_duration
         if self.description:
             json_dict['description'] = self.description
-        if self.show_caption_above_media:
+        if self.show_caption_above_media is not None:
             json_dict['show_caption_above_media'] = self.show_caption_above_media
         return json_dict
 
@@ -5381,7 +5381,7 @@ class InlineQueryResultCachedBase(ABC, JsonSerializable):
             json_dict['parse_mode'] = self.parse_mode
         if self.caption_entities:
             json_dict['caption_entities'] = MessageEntity.to_list_of_dicts(self.caption_entities)
-        if self.show_caption_above_media:
+        if self.show_caption_above_media is not None:
             json_dict['show_caption_above_media'] = self.show_caption_above_media
         return json.dumps(json_dict)
 


### PR DESCRIPTION
May 28, 2024
Bot API 7.4

- [x] Added support for payments in [Telegram Stars](https://t.me/BotNews/90) by introducing the new currency “XTR”.
- [ ] The parameter provider_token of the methods [sendInvoice](https://core.telegram.org/bots/api#sendinvoice) and [createInvoiceLink](https://core.telegram.org/bots/api#createinvoicelink) must be omitted for payments in [Telegram Stars](https://t.me/BotNews/90).
- [ ] The field provider_token in the class [InputInvoiceMessageContent](https://core.telegram.org/bots/api#inputinvoicemessagecontent) must be omitted for payments in [Telegram Stars](https://t.me/BotNews/90).
- [x] Added the method [refundStarPayment](https://core.telegram.org/bots/api#refundstarpayment).
- [x] Added the field effect_id to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the parameter message_effect_id to the methods [sendMessage](https://core.telegram.org/bots/api#sendmessage), [sendPhoto](https://core.telegram.org/bots/api#sendphoto), [sendVideo](https://core.telegram.org/bots/api#sendvideo), [sendAnimation](https://core.telegram.org/bots/api#sendanimation), [sendAudio](https://core.telegram.org/bots/api#sendaudio), [sendDocument](https://core.telegram.org/bots/api#senddocument), [sendSticker](https://core.telegram.org/bots/api#sendsticker), [sendVideoNote](https://core.telegram.org/bots/api#sendvideonote), [sendVoice](https://core.telegram.org/bots/api#sendvoice), [sendLocation](https://core.telegram.org/bots/api#sendlocation), [sendVenue](https://core.telegram.org/bots/api#sendvenue), [sendContact](https://core.telegram.org/bots/api#sendcontact), [sendPoll](https://core.telegram.org/bots/api#sendpoll), [sendDice](https://core.telegram.org/bots/api#senddice), [sendInvoice](https://core.telegram.org/bots/api#sendinvoice), [sendGame](https://core.telegram.org/bots/api#sendgame), and [sendMediaGroup](https://core.telegram.org/bots/api#sendmediagroup).
- [x] Added the field show_caption_above_media to the classes [Message](https://core.telegram.org/bots/api#message), [InputMediaAnimation](https://core.telegram.org/bots/api#inputmediaanimation), [InputMediaPhoto](https://core.telegram.org/bots/api#inputmediaphoto), [InputMediaVideo](https://core.telegram.org/bots/api#inputmediavideo), [InlineQueryResultGif](https://core.telegram.org/bots/api#inlinequeryresultgif), [InlineQueryResultMpeg4Gif](https://core.telegram.org/bots/api#inlinequeryresultmpeg4gif), [InlineQueryResultPhoto](https://core.telegram.org/bots/api#inlinequeryresultphoto), [InlineQueryResultVideo](https://core.telegram.org/bots/api#inlinequeryresultvideo), [InlineQueryResultCachedGif](https://core.telegram.org/bots/api#inlinequeryresultcachedgif), [InlineQueryResultCachedMpeg4Gif](https://core.telegram.org/bots/api#inlinequeryresultcachedmpeg4gif), [InlineQueryResultCachedPhoto](https://core.telegram.org/bots/api#inlinequeryresultcachedphoto), and [InlineQueryResultCachedVideo](https://core.telegram.org/bots/api#inlinequeryresultcachedvideo).
- [x] Added the parameter show_caption_above_media to the methods [sendAnimation](https://core.telegram.org/bots/api#sendanimation), [sendPhoto](https://core.telegram.org/bots/api#sendphoto), [sendVideo](https://core.telegram.org/bots/api#sendvideo), [copyMessage](https://core.telegram.org/bots/api#copymessage), and [editMessageCaption](https://core.telegram.org/bots/api#editmessagecaption).
- [x] Added support for “expandable_blockquote” entities in received messages.
- [x] Added support for “expandable_blockquote” entity parsing in “MarkdownV2” and “HTML” parse modes.
- [x] Allowed to explicitly specify “expandable_blockquote” entities in formatted texts.