### PR TITLE
Resolve the issue with inline queries

### DIFF
--- a/examples/inline_example.py
+++ b/examples/inline_example.py
@@ -61,7 +61,7 @@ def default_query(inline_query):
 
 
 def main_loop():
-    bot.infinity_polling()
+    bot.infinity_polling(allowed_updates=[])
     while 1:
         time.sleep(3)
 


### PR DESCRIPTION
## Description
When the 'allowed_updates' parameter is not specified, it just uses some settings that does not allow updating the inline queries. So based on the docstring from the 'infinity_polling' method, we have to specify an empty list for it to allow any update, including the 'inline_queries' update.

## Describe your tests
Just tested the example file.

Python version:
3.11
OS:
Windows 10
## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [ ] My changes won't break backward compatibility
- [ ] I made changes both for sync and async
