### PR TITLE
Pypy 3.8 removed from tests

### DIFF
--- a/.github/workflows/setup_python.yml
+++ b/.github/workflows/setup_python.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.9', 'pypy-3.10']
     name: ${{ matrix.python-version }} and tests
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Pypy 3.8 removed from tests
Since 7.3.12 they discontinued Pypy 3.8: https://www.pypy.org/posts/2023/06/pypy-v7312-release.html