### PR TITLE
chg: allow callback_query_handler to do not have func arg.

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -7700,7 +7700,7 @@ class TeleBot:
         self.add_chosen_inline_handler(handler_dict)
 
 
-    def callback_query_handler(self, func, **kwargs):
+    def callback_query_handler(self, func=None, **kwargs):
         """
         Handles new incoming callback query.
         As a parameter to the decorator function, it passes :class:`telebot.types.CallbackQuery` object.

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -1700,7 +1700,7 @@ class AsyncTeleBot:
         handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
         self.add_chosen_inline_handler(handler_dict)
 
-    def callback_query_handler(self, func, **kwargs):
+    def callback_query_handler(self, func=None, **kwargs):
         """
         Handles new incoming callback query.
         As a parameter to the decorator function, it passes :class:`telebot.types.CallbackQuery` object.


### PR DESCRIPTION
## Description
when we have a custom filter forcing using func is not acceptable in callback_query_handler so i have removed it

## Describe your tests
How did you test your change?

Python version:

OS:

## Checklist:
- [*] I added/edited example on new feature/change (if exists)
- [*] My changes won't break backward compatibility
- [*] I made changes both for sync and async
