### PR TITLE
full traceback for async_telebot

### DIFF
--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -575,7 +575,7 @@ class AsyncTeleBot:
                 handler_error = e
                 handled = await self._handle_exception(e)
                 if not handled:
-                    logger.error(str(e))
+                    logger.exception(e)
                     logger.debug("Exception traceback:\n%s", traceback.format_exc())
 
         if middlewares:


### PR DESCRIPTION
`AsyncTelebot` is only showing the error message in handlers.., after using `logger.exception()` instead of `logger.error()`, it's showing full trackback totally like `TeleBot`.

- Before:
```shell
2024-07-13 14:00:05,724 (async_telebot.py:564 MainThread) ERROR - TeleBot: "A request to the Telegram API was unsuccessful. Error code: 400. Description: Bad Request: chat not found"
```

- After:
```shell
Traceback (most recent call last):
  File "/home/zaid/.local/lib/python3.12/site-packages/telebot/async_telebot.py", line 537, in _run_middlewares_and_handlers
    result = await handler['function'](message)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zaid/Desktop/a/main.py", line 10, in on_start
    return await bot.send_message(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zaid/.local/lib/python3.12/site-packages/telebot/async_telebot.py", line 3174, in send_message
    await asyncio_helper.send_message(
  File "/home/zaid/.local/lib/python3.12/site-packages/telebot/asyncio_helper.py", line 310, in send_message
    return await _process_request(token, method_name, params=params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zaid/.local/lib/python3.12/site-packages/telebot/asyncio_helper.py", line 99, in _process_request
    raise e
  File "/home/zaid/.local/lib/python3.12/site-packages/telebot/asyncio_helper.py", line 95, in _process_request
    json_result = await _check_result(url, resp)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zaid/.local/lib/python3.12/site-packages/telebot/asyncio_helper.py", line 274, in _check_result
    raise ApiTelegramException(method_name, result, result_json)
telebot.asyncio_helper.ApiTelegramException: A request to the Telegram API was unsuccessful. Error code: 400. Description: Bad Request: chat not found
```

it's better to know in which line you made mistake.