### PR TITLE
Bot api 7.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">A simple, but extensible Python implementation for the <a href="https://core.telegram.org/bots/api">Telegram Bot API</a>.</p>
 <p align="center">Both synchronous and asynchronous.</p>
 
-## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#july-7-2024">7.7</a>!
+## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api-changelog#july-31-2024">7.8</a>!
 
 <h2><a href='https://pytba.readthedocs.io/en/latest/index.html'>Official documentation</a></h2>
 <h2><a href='https://pytba.readthedocs.io/ru/latest/index.html'>Official ru documentation</a></h2>

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -4640,7 +4640,7 @@ class TeleBot:
 
     def pin_chat_message(
             self, chat_id: Union[int, str], message_id: int, 
-            disable_notification: Optional[bool]=False) -> bool:
+            disable_notification: Optional[bool]=False, business_connection_id: Optional[str]=None) -> bool:
         """
         Use this method to pin a message in a supergroup.
         The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
@@ -4659,15 +4659,19 @@ class TeleBot:
             to all group members about the new pinned message
         :type disable_notification: :obj:`bool`
 
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
         :return: True on success.
         :rtype: :obj:`bool`
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
 
-        return apihelper.pin_chat_message(self.token, chat_id, message_id, disable_notification=disable_notification)
+        return apihelper.pin_chat_message(self.token, chat_id, message_id, disable_notification=disable_notification,
+                                            business_connection_id=business_connection_id)
 
 
-    def unpin_chat_message(self, chat_id: Union[int, str], message_id: Optional[int]=None) -> bool:
+    def unpin_chat_message(self, chat_id: Union[int, str], message_id: Optional[int]=None, business_connection_id: Optional[str]=None) -> bool:
         """
         Use this method to unpin specific pinned message in a supergroup chat.
         The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
@@ -4682,10 +4686,13 @@ class TeleBot:
         :param message_id: Int: Identifier of a message to unpin
         :type message_id: :obj:`int`
 
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
         :return: True on success.
         :rtype: :obj:`bool`
         """
-        return apihelper.unpin_chat_message(self.token, chat_id, message_id)
+        return apihelper.unpin_chat_message(self.token, chat_id, message_id, business_connection_id=business_connection_id)
 
 
     def unpin_all_chat_messages(self, chat_id: Union[int, str]) -> bool:

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1386,19 +1386,23 @@ def set_chat_description(token, chat_id, description):
     return _make_request(token, method_url, params=payload, method='post')
 
 
-def pin_chat_message(token, chat_id, message_id, disable_notification=None):
+def pin_chat_message(token, chat_id, message_id, disable_notification=None, business_connection_id=None):
     method_url = 'pinChatMessage'
     payload = {'chat_id': chat_id, 'message_id': message_id}
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload, method='post')
 
 
-def unpin_chat_message(token, chat_id, message_id):
+def unpin_chat_message(token, chat_id, message_id, business_connection_id=None):
     method_url = 'unpinChatMessage'
     payload = {'chat_id': chat_id}
     if message_id:
         payload['message_id'] = message_id
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6023,7 +6023,7 @@ class AsyncTeleBot:
 
     async def pin_chat_message(
             self, chat_id: Union[int, str], message_id: int, 
-            disable_notification: Optional[bool]=False) -> bool:
+            disable_notification: Optional[bool]=False, business_connection_id: Optional[str]=None) -> bool:
         """
         Use this method to pin a message in a supergroup.
         The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
@@ -6042,14 +6042,17 @@ class AsyncTeleBot:
             to all group members about the new pinned message
         :type disable_notification: :obj:`bool`
 
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
         :return: True on success.
         :rtype: :obj:`bool`
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
 
-        return await asyncio_helper.pin_chat_message(self.token, chat_id, message_id, disable_notification)
+        return await asyncio_helper.pin_chat_message(self.token, chat_id, message_id, disable_notification, business_connection_id)
 
-    async def unpin_chat_message(self, chat_id: Union[int, str], message_id: Optional[int]=None) -> bool:
+    async def unpin_chat_message(self, chat_id: Union[int, str], message_id: Optional[int]=None, business_connection_id: Optional[str]=None) -> bool:
         """
         Use this method to unpin specific pinned message in a supergroup chat.
         The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
@@ -6064,10 +6067,13 @@ class AsyncTeleBot:
         :param message_id: Int: Identifier of a message to unpin
         :type message_id: :obj:`int`
 
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
         :return: True on success.
         :rtype: :obj:`bool`
         """
-        return await asyncio_helper.unpin_chat_message(self.token, chat_id, message_id)
+        return await asyncio_helper.unpin_chat_message(self.token, chat_id, message_id, business_connection_id)
 
     async def unpin_all_chat_messages(self, chat_id: Union[int, str]) -> bool:
         """

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1365,19 +1365,23 @@ async def set_chat_description(token, chat_id, description):
     return await _process_request(token, method_url, params=payload, method='post')
 
 
-async def pin_chat_message(token, chat_id, message_id, disable_notification=None):
+async def pin_chat_message(token, chat_id, message_id, disable_notification=None, business_connection_id=None):
     method_url = 'pinChatMessage'
     payload = {'chat_id': chat_id, 'message_id': message_id}
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload, method='post')
 
 
-async def unpin_chat_message(token, chat_id, message_id):
+async def unpin_chat_message(token, chat_id, message_id, business_connection_id=None):
     method_url = 'unpinChatMessage'
     payload = {'chat_id': chat_id}
     if message_id:
         payload['message_id'] = message_id
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -494,6 +494,9 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
     :param can_connect_to_business: Optional. True, if the bot can be connected to a Telegram Business account to receive its messages. Returned only in getMe.
     :type can_connect_to_business: :obj:`bool`
 
+    :param has_main_web_app: Optional. True, if the bot has a main Web App. Returned only in getMe.
+    :type has_main_web_app: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.User`
     """
@@ -506,7 +509,8 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
     # noinspection PyShadowingBuiltins
     def __init__(self, id, is_bot, first_name, last_name=None, username=None, language_code=None,
                  can_join_groups=None, can_read_all_group_messages=None, supports_inline_queries=None, 
-                 is_premium=None, added_to_attachment_menu=None, can_connect_to_business=None, **kwargs):
+                 is_premium=None, added_to_attachment_menu=None, can_connect_to_business=None, 
+                 has_main_web_app=None, **kwargs):
         self.id: int = id
         self.is_bot: bool = is_bot
         self.first_name: str = first_name
@@ -519,6 +523,7 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
         self.is_premium: bool = is_premium
         self.added_to_attachment_menu: bool = added_to_attachment_menu
         self.can_connect_to_business: bool = can_connect_to_business
+        self.has_main_web_app: bool = has_main_web_app
 
     @property
     def full_name(self):
@@ -545,7 +550,8 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
                 'supports_inline_queries': self.supports_inline_queries,
                 'is_premium': self.is_premium,
                 'added_to_attachment_menu': self.added_to_attachment_menu,
-                'can_connect_to_business': self.can_connect_to_business}
+                'can_connect_to_business': self.can_connect_to_business,
+                'has_main_web_app': self.has_main_web_app}
 
 
 # noinspection PyShadowingBuiltins


### PR DESCRIPTION
- [x] Added the option for bots to set a [Main Mini App](https://core.telegram.org/bots/webapps#launching-the-main-mini-app), which can be previewed and launched directly from a button in the bot's profile or a link.
- [x] Added the method shareToStory to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).
- [x] Added the field has_main_web_app to the class [User](https://core.telegram.org/bots/api#user), which is returned in the response to [getMe](https://core.telegram.org/bots/api#getme).
- [x] Added the parameter business_connection_id to the methods [pinChatMessage](https://core.telegram.org/bots/api#pinchatmessage) and [unpinChatMessage](https://core.telegram.org/bots/api#unpinchatmessage), allowing bots to manage pinned messages on behalf of a business account.