### PR TITLE
Revert changes to middlewares

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -20,7 +20,6 @@ from telebot.storage import StatePickleStorage, StateMemoryStorage, StateStorage
 # random module to generate random string
 import random
 import string
-import copy
 
 import ssl
 
@@ -8750,7 +8749,7 @@ class TeleBot:
                             logger.error("It is not allowed to pass data and values inside data to the handler. Check your handler: {}".format(handler['function']))
                             return
                     else:
-                        data_copy = copy.deepcopy(data)
+                        data_copy = data.copy()
                         for key in list(data_copy):
                             # remove data from data_copy if handler does not accept it
                             if key not in params:

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -32,7 +32,7 @@ REPLY_MARKUP_TYPES = Union[
 import string
 import random
 import ssl
-import copy
+
 
 """
 Module : telebot
@@ -558,7 +558,7 @@ class AsyncTeleBot:
                             logger.error("It is not allowed to pass data and values inside data to the handler. Check your handler: {}".format(handler['function']))
                             return
                     else:
-                        data_copy = copy.deepcopy(data)
+                        data_copy = data.copy()
                         for key in list(data_copy):
                             # remove data from data_copy if handler does not accept it
                             if key not in params:


### PR DESCRIPTION
Decided to revert the changes to middlewares.

To change data in handler, the user will need to have a dict parameter, which will obtain original dict, not a shallow copy.
Values are still passed to post_process regardless of handler.

Sorry for the inconvenience. 