### PR TITLE
Set answer_pre_checkout_query query_id argument type to str

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5627,7 +5627,7 @@ class TeleBot:
 
 
     def answer_pre_checkout_query(
-            self, pre_checkout_query_id: int, ok: bool, 
+            self, pre_checkout_query_id: str, ok: bool, 
             error_message: Optional[str]=None) -> bool:
         """
         Once the user has confirmed their payment and shipping details, the Bot API sends the final confirmation in the form of an Update with the


### PR DESCRIPTION
Hi! 
Noticed a typing mistake, it should be fairly easy to fix :)

As per the documentation, in `answer_pre_checkout_query` method, `pre_checkout_query_id` should be str, not int - https://core.telegram.org/bots/api#answerprecheckoutquery

## Description
Correct type in answer_pre_checkout_query() method signature  

## Describe your tests
Pycharm does not show type warning anymore :)

Python version: 3.12

OS: MacOS, Debian

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [ ] I made changes both for sync and async
