### PR TITLE
Replaced deprecated reply_to_message_id with reply_parameters in custom_states examples

### DIFF
--- a/examples/asynchronous_telebot/custom_states.py
+++ b/examples/asynchronous_telebot/custom_states.py
@@ -2,6 +2,7 @@ from telebot import async_telebot, asyncio_filters, types
 from telebot.asyncio_storage import StateMemoryStorage
 from telebot.states import State, StatesGroup
 from telebot.states.asyncio.context import StateContext
+from telebot.types import ReplyParameters
 
 # Initialize the bot
 state_storage = StateMemoryStorage()  # don't use this in production; switch to redis
@@ -23,7 +24,7 @@ async def start_ex(message: types.Message, state: StateContext):
     await bot.send_message(
         message.chat.id,
         "Hello! What is your first name?",
-        reply_to_message_id=message.message_id,
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
 
 
@@ -34,7 +35,7 @@ async def any_state(message: types.Message, state: StateContext):
     await bot.send_message(
         message.chat.id,
         "Your information has been cleared. Type /start to begin again.",
-        reply_to_message_id=message.message_id,
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
 
 
@@ -43,7 +44,8 @@ async def any_state(message: types.Message, state: StateContext):
 async def name_get(message: types.Message, state: StateContext):
     await state.set(MyStates.age)
     await bot.send_message(
-        message.chat.id, "How old are you?", reply_to_message_id=message.message_id
+        message.chat.id, "How old are you?",
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
     await state.add_data(name=message.text)
 
@@ -64,7 +66,7 @@ async def ask_color(message: types.Message, state: StateContext):
         message.chat.id,
         "What is your favorite color? Choose from the options below.",
         reply_markup=keyboard,
-        reply_to_message_id=message.message_id,
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
 
 
@@ -84,7 +86,7 @@ async def ask_hobby(message: types.Message, state: StateContext):
         message.chat.id,
         "What is one of your hobbies? Choose from the options below.",
         reply_markup=keyboard,
-        reply_to_message_id=message.message_id,
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
 
 
@@ -123,7 +125,8 @@ async def finish(message: types.Message, state: StateContext):
         )
 
     await bot.send_message(
-        message.chat.id, msg, parse_mode="html", reply_to_message_id=message.message_id
+        message.chat.id, msg, parse_mode="html",
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
     await state.delete()
 
@@ -134,7 +137,7 @@ async def age_incorrect(message: types.Message):
     await bot.send_message(
         message.chat.id,
         "Please enter a valid number for age.",
-        reply_to_message_id=message.message_id,
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
 
 

--- a/examples/custom_states.py
+++ b/examples/custom_states.py
@@ -3,6 +3,7 @@ from telebot import custom_filters, types
 from telebot.states import State, StatesGroup
 from telebot.states.sync.context import StateContext
 from telebot.storage import StateMemoryStorage
+from telebot.types import ReplyParameters
 
 # Initialize the bot
 state_storage = StateMemoryStorage()  # don't use this in production; switch to redis
@@ -24,7 +25,7 @@ def start_ex(message: types.Message, state: StateContext):
     bot.send_message(
         message.chat.id,
         "Hello! What is your first name?",
-        reply_to_message_id=message.message_id,
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
 
 
@@ -35,7 +36,7 @@ def any_state(message: types.Message, state: StateContext):
     bot.send_message(
         message.chat.id,
         "Your information has been cleared. Type /start to begin again.",
-        reply_to_message_id=message.message_id,
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
 
 
@@ -44,7 +45,8 @@ def any_state(message: types.Message, state: StateContext):
 def name_get(message: types.Message, state: StateContext):
     state.set(MyStates.age)
     bot.send_message(
-        message.chat.id, "How old are you?", reply_to_message_id=message.message_id
+        message.chat.id, "How old are you?",
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
     state.add_data(name=message.text)
 
@@ -65,7 +67,7 @@ def ask_color(message: types.Message, state: StateContext):
         message.chat.id,
         "What is your favorite color? Choose from the options below.",
         reply_markup=keyboard,
-        reply_to_message_id=message.message_id,
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
 
 
@@ -85,7 +87,7 @@ def ask_hobby(message: types.Message, state: StateContext):
         message.chat.id,
         "What is one of your hobbies? Choose from the options below.",
         reply_markup=keyboard,
-        reply_to_message_id=message.message_id,
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
 
 
@@ -124,7 +126,8 @@ def finish(message: types.Message, state: StateContext):
         )
 
     bot.send_message(
-        message.chat.id, msg, parse_mode="html", reply_to_message_id=message.message_id
+        message.chat.id, msg, parse_mode="html",
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
     state.delete()
 
@@ -135,7 +138,7 @@ def age_incorrect(message: types.Message):
     bot.send_message(
         message.chat.id,
         "Please enter a valid number for age.",
-        reply_to_message_id=message.message_id,
+        reply_parameters=ReplyParameters(message_id=message.message_id),
     )
 
 


### PR DESCRIPTION
## Description
I've replaced the deprecated `reply_to_message_id` with `reply_parameters` in the custom_states examples. I did that after noticing a deprecation message in the logs but couldn't see an example of usage of the new method.


On Telegram I saw this so I used it:

```python
bot.send_message(
    <CHAT_ID>,
    <TEXT>,
    reply_parameters=telebot.types.ReplyParameters(
        message_id=<QUOTED_MESSAGE_ID>,
        chat_id=<QUOTED_CHAT_ID>,
        quote=<QUOTED_TEXT>
    )
)
```


## Describe your tests
I've tested the example code after modification and it seems to have behaved as expected. 


Python version: 3.10


## Checklist:
- [ x] I added/edited example on new feature/change (if exists)
- [ x] My changes won't break backward compatibility
- [x ] I made changes both for sync and async
