### PR TITLE
Update pickle_storage.py

### DIFF
--- a/telebot/storage/pickle_storage.py
+++ b/telebot/storage/pickle_storage.py
@@ -254,9 +254,9 @@ class StatePickleStorage(StateStorageBase):
             message_thread_id,
             bot_id,
         )
-        data = self._read_from_file()
-        data[_key]["data"] = data
-        self._write_to_file(data)
+        file_data = self._read_from_file()
+        file_data[_key]["data"] = data
+        self._write_to_file(file_data)
         return True
 
     def __str__(self) -> str:


### PR DESCRIPTION
fixed typo in StatePickleStorage.save, which didn't allow to save user state, but instead copied the whole content of state file inside "data"

## Description
Include changes, new features and etc:
fixed typo

## Describe your tests
How did you test your change?
my one year old bot started working again

Python version: any

OS: any

## Checklist:
- [ no ] I added/edited example on new feature/change (if exists)
- [ yes ] My changes won't break backward compatibility
- [ no ] I made changes both for sync and async
