### PR TITLE
Fix KeyboardButtonRequestChat request_title typing

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -2655,7 +2655,7 @@ class KeyboardButtonRequestChat(Dictionaryable):
                  chat_has_username: Optional[bool]=None, chat_is_created: Optional[bool]=None,
                  user_administrator_rights: Optional[ChatAdministratorRights]=None,
                  bot_administrator_rights: Optional[ChatAdministratorRights]=None, bot_is_member: Optional[bool]=None,
-                 request_title: Optional[str]=None, request_photo: Optional[bool]=None, request_username: Optional[bool]=None):
+                 request_title: Optional[bool]=None, request_photo: Optional[bool]=None, request_username: Optional[bool]=None):
         self.request_id: int = request_id
         self.chat_is_channel: bool = chat_is_channel
         self.chat_is_forum: Optional[bool] = chat_is_forum
@@ -2664,7 +2664,7 @@ class KeyboardButtonRequestChat(Dictionaryable):
         self.user_administrator_rights: Optional[ChatAdministratorRights] = user_administrator_rights
         self.bot_administrator_rights: Optional[ChatAdministratorRights] = bot_administrator_rights
         self.bot_is_member: Optional[bool] = bot_is_member
-        self.request_title: Optional[str] = request_title
+        self.request_title: Optional[bool] = request_title
         self.request_photo: Optional[bool] = request_photo
         self.request_username: Optional[bool] = request_username
 


### PR DESCRIPTION
## Description
Fix KeyboardButtonRequestChat request_title typing from str to bool

## Describe your tests
How did you test your change?
no tests needed

Python version: any

OS: any

## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async
