### PR TITLE
Bot API 8.0 - Subscription plans, Emoji Statuses, Gifts and many more

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">A simple, but extensible Python implementation for the <a href="https://core.telegram.org/bots/api">Telegram Bot API</a>.</p>
 <p align="center">Both synchronous and asynchronous.</p>
 
-## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#october-31-2024"><img src="https://img.shields.io/badge/Bot%20API-7.11-blue?logo=telegram" alt="Supported Bot API version"></a>
+## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#november-17-2024"><img src="https://img.shields.io/badge/Bot%20API-8.0-blue?logo=telegram" alt="Supported Bot API version"></a>
 
 <h2><a href='https://pytba.readthedocs.io/en/latest/index.html'>Official documentation</a></h2>
 <h2><a href='https://pytba.readthedocs.io/ru/latest/index.html'>Official ru documentation</a></h2>

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6249,7 +6249,19 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.delete_sticker_set(self.token, name)
+    
+    def get_available_gifts(self) -> types.Gifts:
+        """
+        Returns the list of gifts that can be sent by the bot to users. Requires no parameters. Returns a Gifts object.
 
+        Telegram documentation: https://core.telegram.org/bots/api#getavailablegifts
+
+        :return: On success, a Gifts object is returned.
+        :rtype: :class:`telebot.types.Gifts`
+        """
+        return types.Gifts.de_json(
+            apihelper.get_available_gifts(self.token)
+        )
 
     def replace_sticker_in_set(self, user_id: int, name: str, old_sticker: str, sticker: types.InputSticker) -> bool:
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5418,7 +5418,9 @@ class TeleBot:
             need_shipping_address: Optional[bool]=None,
             send_phone_number_to_provider: Optional[bool]=None,
             send_email_to_provider: Optional[bool]=None,
-            is_flexible: Optional[bool]=None) -> str:
+            is_flexible: Optional[bool]=None,
+            subscription_period: Optional[int]=None,
+            business_connection_id: Optional[str]=None) -> str:
             
         """
         Use this method to create a link for an invoice. 
@@ -5426,6 +5428,9 @@ class TeleBot:
 
         Telegram documentation:
         https://core.telegram.org/bots/api#createinvoicelink
+
+        :param business_connection_id: Unique identifier of the business connection on behalf of which the link will be created
+        :type business_connection_id: :obj:`str`
 
         :param title: Product name, 1-32 characters
         :type title: :obj:`str`
@@ -5448,6 +5453,11 @@ class TeleBot:
         :param prices: Price breakdown, a list of components
             (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)
         :type prices: :obj:`list` of :obj:`types.LabeledPrice`
+
+        :subscription_period: 	The number of seconds the subscription will be active for before the next payment.
+            The currency must be set to “XTR” (Telegram Stars) if the parameter is used. Currently, it must always
+            be 2592000 (30 days) if specified.
+        :type subscription_period: :obj:`int`
 
         :param max_tip_amount: The maximum accepted amount for tips in the smallest units of the currency
         :type max_tip_amount: :obj:`int`
@@ -5505,7 +5515,8 @@ class TeleBot:
             photo_width=photo_width, photo_height=photo_height, need_name=need_name,
             need_phone_number=need_phone_number, need_email=need_email,
             need_shipping_address=need_shipping_address, send_phone_number_to_provider=send_phone_number_to_provider,
-            send_email_to_provider=send_email_to_provider, is_flexible=is_flexible)
+            send_email_to_provider=send_email_to_provider, is_flexible=is_flexible ,subscription_period=subscription_period,
+            business_connection_id=business_connection_id)
 
 
     # noinspection PyShadowingBuiltins

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6769,6 +6769,42 @@ class TeleBot:
         """
         return apihelper.answer_web_app_query(self.token, web_app_query_id, result)
 
+    def save_prepared_inline_message(
+            self, user_id: int, result: types.InlineQueryResultBase, allow_user_chats: Optional[bool]=None,
+            allow_bot_chats: Optional[bool]=None, allow_group_chats: Optional[bool]=None,
+            allow_channel_chats: Optional[bool]=None) -> types.PreparedInlineMessage:
+        """
+        Use this method to store a message that can be sent by a user of a Mini App.
+        Returns a PreparedInlineMessage object.
+
+        Telegram Documentation: https://core.telegram.org/bots/api#savepreparedinlinemessage
+
+        :param user_id: Unique identifier of the target user that can use the prepared message
+        :type user_id: :obj:`int`
+
+        :param result: A JSON-serialized object describing the message to be sent
+        :type result: :class:`telebot.types.InlineQueryResultBase`
+
+        :param allow_user_chats: Pass True if the message can be sent to private chats with users
+        :type allow_user_chats: :obj:`bool`
+
+        :param allow_bot_chats: Pass True if the message can be sent to private chats with bots
+        :type allow_bot_chats: :obj:`bool`
+
+        :param allow_group_chats: Pass True if the message can be sent to group and supergroup chats
+        :type allow_group_chats: :obj:`bool`
+
+        :param allow_channel_chats: Pass True if the message can be sent to channel chats
+        :type allow_channel_chats: :obj:`bool`
+
+        :return: On success, a PreparedInlineMessage object is returned.
+        :rtype: :class:`telebot.types.PreparedInlineMessage`
+        """
+        return types.PreparedInlineMessage.de_json(
+            apihelper.save_prepared_inline_message(
+                self.token, user_id, result, allow_user_chats=allow_user_chats, allow_bot_chats=allow_bot_chats,
+                allow_group_chats=allow_group_chats, allow_channel_chats=allow_channel_chats)
+        )
 
     def register_for_reply(self, message: types.Message, callback: Callable, *args, **kwargs) -> None:
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6249,6 +6249,32 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.delete_sticker_set(self.token, name)
+
+    def send_gift(self, user_id: int, gift_id: str, text: Optional[str]=None, text_parse_mode: Optional[str]=None, text_entities: Optional[List[types.MessageEntity]]=None) -> bool:
+        """
+        Sends a gift to the given user. The gift can't be converted to Telegram Stars by the user. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#sendgift
+
+        :param user_id: Unique identifier of the target user that will receive the gift
+        :type user_id: :obj:`int`
+
+        :param gift_id: Identifier of the gift
+        :type gift_id: :obj:`str`
+
+        :param text: Text that will be shown along with the gift; 0-255 characters
+        :type text: :obj:`str`
+
+        :param text_parse_mode: Mode for parsing entities in the text. See formatting options for more details. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored.
+        :type text_parse_mode: :obj:`str`
+
+        :param text_entities: A JSON-serialized list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored.
+        :type text_entities: :obj:`list` of :obj:`types.MessageEntity`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.send_gift(self.token, user_id, gift_id, text=text, text_parse_mode=text_parse_mode, text_entities=text_entities)
     
     def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5814,6 +5814,26 @@ class TeleBot:
         """
         return apihelper.refund_star_payment(self.token, user_id, telegram_payment_charge_id)
 
+    def edit_user_star_subscription(self, user_id: int, telegram_payment_charge_id: str, is_canceled: bool) -> bool:
+        """
+        Allows the bot to cancel or re-enable extension of a subscription paid in Telegram Stars. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#edituserstarsubscription
+
+        :param user_id: Identifier of the user whose subscription will be edited
+        :type user_id: :obj:`int`
+
+        :param telegram_payment_charge_id: Telegram payment identifier for the subscription
+        :type telegram_payment_charge_id: :obj:`str`
+
+        :param is_canceled: Pass True to cancel extension of the user subscription; the subscription must be active up to the end of the current subscription period. Pass False to allow the user to re-enable a subscription that was previously canceled by the bot.
+        :type is_canceled: :obj:`bool`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.edit_user_star_subscription(self.token, user_id, telegram_payment_charge_id, is_canceled)
+
     def edit_message_caption(
             self, caption: str, chat_id: Optional[Union[int, str]]=None, 
             message_id: Optional[int]=None, 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1512,6 +1512,26 @@ class TeleBot:
             apihelper.get_user_profile_photos(self.token, user_id, offset=offset, limit=limit)
         )
 
+    def set_user_emoji_status(self, user_id: int, emoji_status_custom_emoji_id: Optional[str]=None, emoji_status_expiration_date: Optional[int]=None) -> bool:
+        """
+        Changes the emoji status for a given user that previously allowed the bot to manage their emoji status via the Mini App method requestEmojiStatusAccess. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setuseremojistatus
+
+        :param user_id: Unique identifier of the target user
+        :type user_id: :obj:`int`
+
+        :param emoji_status_custom_emoji_id: Custom emoji identifier of the emoji status to set. Pass an empty string to remove the status.
+        :type emoji_status_custom_emoji_id: :obj:`str`
+
+        :param emoji_status_expiration_date: Expiration date of the emoji status, if any
+        :type emoji_status_expiration_date: :obj:`int`
+
+        :return: :obj:`bool`
+        """
+        return apihelper.set_user_emoji_status(
+            self.token, user_id, emoji_status_custom_emoji_id=emoji_status_custom_emoji_id, emoji_status_expiration_date=emoji_status_expiration_date)
+    
 
     def get_chat(self, chat_id: Union[int, str]) -> types.ChatFullInfo:
         """

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1970,7 +1970,7 @@ def create_invoice_link(token, title, description, payload, provider_token,
             currency, prices, max_tip_amount=None, suggested_tip_amounts=None, provider_data=None,
             photo_url=None, photo_size=None, photo_width=None, photo_height=None, need_name=None, need_phone_number=None,
             need_email=None, need_shipping_address=None, send_phone_number_to_provider=None,
-            send_email_to_provider=None, is_flexible=None):
+            send_email_to_provider=None, is_flexible=None, subscription_period=None, business_connection_id=None):
     method_url = r'createInvoiceLink'
     payload = {'title': title, 'description': description, 'payload': payload,
                 'currency': currency, 'prices': _convert_list_json_serializable(prices)}
@@ -2004,6 +2004,10 @@ def create_invoice_link(token, title, description, payload, provider_token,
         payload['is_flexible'] = is_flexible
     if provider_token is not None:
         payload['provider_token'] = provider_token
+    if subscription_period:
+        payload['subscription_period'] = subscription_period
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1929,6 +1929,17 @@ def get_available_gifts(token):
     return _make_request(token, method_url)
 
 
+def send_gift(token, user_id, gift_id, text=None, text_parse_mode=None, text_entities=None):
+    method_url = 'sendGift'
+    payload = {'user_id': user_id, 'gift_id': gift_id}
+    if text:
+        payload['text'] = text
+    if text_parse_mode:
+        payload['text_parse_mode'] = text_parse_mode
+    if text_entities:
+        payload['text_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(text_entities))
+    return _make_request(token, method_url, params=payload, method='post')
+
 def set_sticker_emoji_list(token, sticker, emoji_list):
     method_url = 'setStickerEmojiList'
     payload = {'sticker': sticker, 'emoji_list': json.dumps(emoji_list)}

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1924,6 +1924,11 @@ def delete_sticker_set(token, name):
     return _make_request(token, method_url, params=payload, method='post')
 
 
+def get_available_gifts(token):
+    method_url = 'getAvailableGifts'
+    return _make_request(token, method_url)
+
+
 def set_sticker_emoji_list(token, sticker, emoji_list):
     method_url = 'setStickerEmojiList'
     payload = {'sticker': sticker, 'emoji_list': json.dumps(emoji_list)}

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1981,6 +1981,21 @@ def answer_web_app_query(token, web_app_query_id, result: types.InlineQueryResul
     return _make_request(token, method_url, params=payload, method='post')
 
 
+def save_prepared_inline_message(token, user_id, result: types.InlineQueryResultBase, allow_user_chats=None,
+                                    allow_bot_chats=None, allow_group_chats=None, allow_channel_chats=None):
+        method_url = 'savePreparedInlineMessage'
+        payload = {'user_id': user_id, 'result': result.to_json()}
+        if allow_user_chats is not None:
+            payload['allow_user_chats'] = allow_user_chats
+        if allow_bot_chats is not None:
+            payload['allow_bot_chats'] = allow_bot_chats
+        if allow_group_chats is not None:
+            payload['allow_group_chats'] = allow_group_chats
+        if allow_channel_chats is not None:
+            payload['allow_channel_chats'] = allow_channel_chats
+        return _make_request(token, method_url, params=payload, method='post')
+
+
 def create_invoice_link(token, title, description, payload, provider_token,
             currency, prices, max_tip_amount=None, suggested_tip_amounts=None, provider_data=None,
             photo_url=None, photo_size=None, photo_width=None, photo_height=None, need_name=None, need_phone_number=None,

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -341,6 +341,16 @@ def get_user_profile_photos(token, user_id, offset=None, limit=None):
         payload['limit'] = limit
     return _make_request(token, method_url, params=payload)
 
+
+def set_user_emoji_status(token, user_id, emoji_status_custom_emoji_id=None, emoji_status_expiration_date=None):
+    method_url = r'setUserEmojiStatus'
+    payload = {'user_id': user_id}
+    if emoji_status_custom_emoji_id:
+        payload['emoji_status_custom_emoji_id'] = emoji_status_custom_emoji_id
+    if emoji_status_expiration_date:
+        payload['emoji_status_expiration_date'] = emoji_status_expiration_date
+    return _make_request(token, method_url, params=payload)
+
 def set_message_reaction(token, chat_id, message_id, reaction=None, is_big=None):
     method_url = r'setMessageReaction'
     payload = {'chat_id': chat_id, 'message_id': message_id}

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1805,6 +1805,11 @@ def refund_star_payment(token, user_id, telegram_payment_charge_id):
     payload = {'user_id': user_id, 'telegram_payment_charge_id': telegram_payment_charge_id}
     return _make_request(token, method_url, params=payload)
 
+def edit_user_star_subscription(token, user_id, telegram_payment_charge_id, is_canceled):
+    method_url = 'editUserStarSubscription'
+    payload = {'user_id': user_id, 'telegram_payment_charge_id': telegram_payment_charge_id, 'is_canceled': is_canceled}
+    return _make_request(token, method_url, params=payload)
+
 
 def unpin_all_general_forum_topic_messages(token, chat_id):
     method_url = 'unpinAllGeneralForumTopicMessages'

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7707,6 +7707,18 @@ class AsyncTeleBot:
 
         return await asyncio_helper.delete_sticker_set(self.token, name)
     
+    async def get_available_gifts(self) -> types.Gifts:
+        """
+        Returns the list of gifts that can be sent by the bot to users. Requires no parameters. Returns a Gifts object.
+
+        Telegram documentation: https://core.telegram.org/bots/api#getavailablegifts
+
+        :return: On success, a Gifts object is returned.
+        :rtype: :class:`telebot.types.Gifts`
+        """
+
+        return types.Gifts.de_json(await asyncio_helper.get_available_gifts(self.token))
+    
     async def replace_sticker_in_set(self, user_id: int, name: str, old_sticker: str, sticker: types.InputSticker) -> bool:
         """
         Use this method to replace an existing sticker in a sticker set with a new one. The method is equivalent to calling deleteStickerFromSet, then addStickerToSet,

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7706,6 +7706,32 @@ class AsyncTeleBot:
         """
 
         return await asyncio_helper.delete_sticker_set(self.token, name)
+
+    async def send_gift(self, user_id: int, gift_id: str, text: Optional[str]=None, text_parse_mode: Optional[str]=None, text_entities: Optional[List[types.MessageEntity]]=None) -> bool:
+        """
+        Sends a gift to the given user. The gift can't be converted to Telegram Stars by the user. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#sendgift
+
+        :param user_id: Unique identifier of the target user that will receive the gift
+        :type user_id: :obj:`int`
+
+        :param gift_id: Identifier of the gift
+        :type gift_id: :obj:`str`
+
+        :param text: Text that will be shown along with the gift; 0-255 characters
+        :type text: :obj:`str`
+
+        :param text_parse_mode: Mode for parsing entities in the text. See formatting options for more details. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored.
+        :type text_parse_mode: :obj:`str`
+
+        :param text_entities: A JSON-serialized list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored.
+        :type text_entities: :obj:`list` of :obj:`types.MessageEntity`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.send_gift(self.token, user_id, gift_id, text, text_parse_mode, text_entities)
     
     async def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6836,7 +6836,9 @@ class AsyncTeleBot:
             need_shipping_address: Optional[bool]=None,
             send_phone_number_to_provider: Optional[bool]=None,
             send_email_to_provider: Optional[bool]=None,
-            is_flexible: Optional[bool]=None) -> str:
+            is_flexible: Optional[bool]=None,
+            subscription_period: Optional[int]=None,
+            business_connection_id: Optional[str]=None) -> str:
             
         """
         Use this method to create a link for an invoice. 
@@ -6844,6 +6846,9 @@ class AsyncTeleBot:
 
         Telegram documentation:
         https://core.telegram.org/bots/api#createinvoicelink
+    
+        :param business_connection_id: Unique identifier of the business connection on behalf of which the link will be created
+        :type business_connection_id: :obj:`str`
 
         :param title: Product name, 1-32 characters
         :type title: :obj:`str`
@@ -6866,6 +6871,11 @@ class AsyncTeleBot:
         :param prices: Price breakdown, a list of components
             (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)
         :type prices: :obj:`list` of :obj:`types.LabeledPrice`
+
+        :subscription_period: 	The number of seconds the subscription will be active for before the next payment.
+            The currency must be set to “XTR” (Telegram Stars) if the parameter is used. Currently, it must always
+            be 2592000 (30 days) if specified.
+        :type subscription_period: :obj:`int`
 
         :param max_tip_amount: The maximum accepted amount for tips in the smallest units of the currency
         :type max_tip_amount: :obj:`int`
@@ -6921,7 +6931,7 @@ class AsyncTeleBot:
             currency, prices, max_tip_amount, suggested_tip_amounts, provider_data,
             photo_url, photo_size, photo_width, photo_height, need_name, need_phone_number,
             need_email, need_shipping_address, send_phone_number_to_provider,
-            send_email_to_provider, is_flexible)
+            send_email_to_provider, is_flexible, subscription_period=subscription_period, business_connection_id=business_connection_id)
         return result
 
     # noinspection PyShadowingBuiltins

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -2987,6 +2987,26 @@ class AsyncTeleBot:
         """
         result = await asyncio_helper.get_user_profile_photos(self.token, user_id, offset, limit)
         return types.UserProfilePhotos.de_json(result)
+    
+    async def set_user_emoji_status(self, user_id: int, emoji_status_custom_emoji_id: Optional[str]=None, emoji_status_expiration_date: Optional[int]=None) -> bool:
+        """
+        Use this method to change the emoji status for a given user that previously allowed the bot to manage their emoji status via the Mini App method requestEmojiStatusAccess.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setuseremojistatus
+
+        :param user_id: Unique identifier of the target user
+        :type user_id: :obj:`int`
+
+        :param emoji_status_custom_emoji_id: Custom emoji identifier of the emoji status to set. Pass an empty string to remove the status.
+        :type emoji_status_custom_emoji_id: :obj:`str`, optional
+
+        :param emoji_status_expiration_date: Expiration date of the emoji status, if any
+        :type emoji_status_expiration_date: :obj:`int`, optional
+
+        :return: :obj:`bool`
+        """
+        result = await asyncio_helper.set_user_emoji_status(self.token, user_id, emoji_status_custom_emoji_id, emoji_status_expiration_date)
+        return result
 
     async def get_chat(self, chat_id: Union[int, str]) -> types.ChatFullInfo:
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -3148,6 +3148,36 @@ class AsyncTeleBot:
 
         return await asyncio_helper.answer_web_app_query(self.token, web_app_query_id, result)
 
+    async def save_prepared_inline_message(self, user_id: int, result: types.InlineQueryResultBase, allow_user_chats: Optional[bool]=None,
+            allow_bot_chats: Optional[bool]=None, allow_group_chats: Optional[bool]=None, allow_channel_chats: Optional[bool]=None) -> types.PreparedInlineMessage:
+        """
+        Stores a message that can be sent by a user of a Mini App. Returns a PreparedInlineMessage object.
+
+        Telegram Documentation: https://core.telegram.org/bots/api#savepreparedinlinemessage
+
+        :param user_id: Unique identifier of the target user that can use the prepared message
+        :type user_id: :obj:`int`
+
+        :param result: A JSON-serialized object describing the message to be sent
+        :type result: :class:`telebot.types.InlineQueryResultBase`
+
+        :param allow_user_chats: Pass True if the message can be sent to private chats with users
+        :type allow_user_chats: :obj:`bool`, optional
+
+        :param allow_bot_chats: Pass True if the message can be sent to private chats with bots
+        :type allow_bot_chats: :obj:`bool`, optional
+
+        :param allow_group_chats: Pass True if the message can be sent to group and supergroup chats
+        :type allow_group_chats: :obj:`bool`, optional
+
+        :param allow_channel_chats: Pass True if the message can be sent to channel chats
+        :type allow_channel_chats: :obj:`bool`, optional
+
+        :return: :class:`telebot.types.PreparedInlineMessage`
+        """
+        result = await asyncio_helper.save_prepared_inline_message(self.token, user_id, result, allow_user_chats, allow_bot_chats, allow_group_chats, allow_channel_chats)
+        return types.PreparedInlineMessage.de_json(result)
+
     async def get_chat_member(self, chat_id: Union[int, str], user_id: int) -> types.ChatMember:
         """
         Use this method to get information about a member of a chat. Returns a ChatMember object on success.

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7220,6 +7220,26 @@ class AsyncTeleBot:
         """
         return await asyncio_helper.refund_star_payment(self.token, user_id, telegram_payment_charge_id)
 
+    async def edit_user_star_subscription(self, user_id: int, telegram_payment_charge_id: str, is_canceled: bool) -> bool:
+        """
+        Allows the bot to cancel or re-enable extension of a subscription paid in Telegram Stars. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#edituserstarsubscription
+
+        :param user_id: Identifier of the user whose subscription will be edited
+        :type user_id: :obj:`int`
+
+        :param telegram_payment_charge_id: Telegram payment identifier for the subscription
+        :type telegram_payment_charge_id: :obj:`str`
+
+        :param is_canceled: Pass True to cancel extension of the user subscription; the subscription must be active up to the end of the current subscription period. Pass False to allow the user to re-enable a subscription that was previously canceled by the bot.
+        :type is_canceled: :obj:`bool`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.edit_user_star_subscription(self.token, user_id, telegram_payment_charge_id, is_canceled)
+
     async def edit_message_caption(
             self, caption: str, chat_id: Optional[Union[int, str]]=None, 
             message_id: Optional[int]=None, 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1793,6 +1793,12 @@ async def refund_star_payment(token, user_id, telegram_payment_charge_id):
     return await _process_request(token, method_url, params=payload)
 
 
+async def edit_user_star_subscription(token, user_id, telegram_payment_charge_id, is_canceled):
+    method_url = 'editUserStarSubscription'
+    payload = {'user_id': user_id, 'telegram_payment_charge_id': telegram_payment_charge_id, 'is_canceled': is_canceled}
+    return await _process_request(token, method_url, params=payload)
+
+
 async def unpin_all_general_forum_topic_messages(token, chat_id):
     method_url = 'unpinAllGeneralForumTopicMessages'
     payload = {'chat_id': chat_id}

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1916,6 +1916,17 @@ async def delete_sticker_set(token, name):
     payload = {'name': name}
     return await _process_request(token, method_url, params=payload, method='post')
 
+async def send_gift(token, user_id, gift_id, text=None, text_parse_mode=None, text_entities=None):
+    method_url = 'sendGift'
+    payload = {'user_id': user_id, 'gift_id': gift_id}
+    if text:
+        payload['text'] = text
+    if text_parse_mode:
+        payload['text_parse_mode'] = text_parse_mode
+    if text_entities:
+        payload['text_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(text_entities))
+    return await _process_request(token, method_url, params=payload, method='post')
+
 async def get_available_gifts(token):
     method_url = 'getAvailableGifts'
     return await _process_request(token, method_url)

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1952,7 +1952,7 @@ async def create_invoice_link(token, title, description, payload, provider_token
             currency, prices, max_tip_amount=None, suggested_tip_amounts=None, provider_data=None,
             photo_url=None, photo_size=None, photo_width=None, photo_height=None, need_name=None, need_phone_number=None,
             need_email=None, need_shipping_address=None, send_phone_number_to_provider=None,
-            send_email_to_provider=None, is_flexible=None):
+            send_email_to_provider=None, is_flexible=None, subscription_period=None, business_connection_id=None):
     method_url = r'createInvoiceLink'
     payload = {'title': title, 'description': description, 'payload': payload,
                 'currency': currency, 'prices': await _convert_list_json_serializable(prices)}
@@ -1986,6 +1986,10 @@ async def create_invoice_link(token, title, description, payload, provider_token
         payload['is_flexible'] = is_flexible
     if provider_token is not None:
         payload['provider_token'] = provider_token
+    if subscription_period:
+        payload['subscription_period'] = subscription_period
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -406,6 +406,20 @@ async def answer_web_app_query(token, web_app_query_id, result: types.InlineQuer
     return await _process_request(token, method_url, params=payload, method='post')
 
 
+async def save_prepared_inline_message(token, user_id, result: types.InlineQueryResultBase, allow_user_chats=None, allow_bot_chats=None, allow_group_chats=None, allow_channel_chats=None):
+    method_url = r'savePreparedInlineMessage'
+    payload = {'user_id': user_id, 'result': result.to_json()}
+    if allow_user_chats is not None:
+        payload['allow_user_chats'] = allow_user_chats
+    if allow_bot_chats is not None:
+        payload['allow_bot_chats'] = allow_bot_chats
+    if allow_group_chats is not None:
+        payload['allow_group_chats'] = allow_group_chats
+    if allow_channel_chats is not None:
+        payload['allow_channel_chats'] = allow_channel_chats
+    return await _process_request(token, method_url, params=payload)
+
+
 async def get_chat_member(token, chat_id, user_id):
     method_url = r'getChatMember'
     payload = {'chat_id': chat_id, 'user_id': user_id}

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1916,6 +1916,10 @@ async def delete_sticker_set(token, name):
     payload = {'name': name}
     return await _process_request(token, method_url, params=payload, method='post')
 
+async def get_available_gifts(token):
+    method_url = 'getAvailableGifts'
+    return await _process_request(token, method_url)
+
 async def set_custom_emoji_sticker_set_thumbnail(token, name, custom_emoji_id=None):
     method_url = 'setCustomEmojiStickerSetThumbnail'
     payload = {'name': name}

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -325,6 +325,16 @@ async def get_user_profile_photos(token, user_id, offset=None, limit=None):
         payload['limit'] = limit
     return await _process_request(token, method_url, params=payload)
 
+
+async def set_user_emoji_status(token, user_id, emoji_status_custom_emoji_id=None, emoji_status_expiration_date=None):
+    method_url = r'setUserEmojiStatus'
+    payload = {'user_id': user_id}
+    if emoji_status_custom_emoji_id:
+        payload['emoji_status_custom_emoji_id'] = emoji_status_custom_emoji_id
+    if emoji_status_expiration_date:
+        payload['emoji_status_expiration_date'] = emoji_status_expiration_date
+    return await _process_request(token, method_url, params=payload)
+
 async def set_message_reaction(token, chat_id, message_id, reaction=None, is_big=None):
     method_url = r'setMessageReaction'
     payload = {'chat_id': chat_id, 'message_id': message_id}

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -6318,6 +6318,15 @@ class SuccessfulPayment(JsonDeserializable):
     :param invoice_payload: Bot specified invoice payload
     :type invoice_payload: :obj:`str`
 
+    :param subscription_expiration_date: Optional. Expiration date of the subscription, in Unix time; for recurring payments only
+    :type subscription_expiration_date: :obj:`int`
+
+    :param is_recurring: Optional. True, if the payment is a recurring payment, false otherwise
+    :type is_recurring: :obj:`bool`
+
+    :param is_first_recurring: Optional. True, if the payment is the first payment for a subscription
+    :type is_first_recurring: :obj:`bool`
+
     :param shipping_option_id: Optional. Identifier of the shipping option chosen by the user
     :type shipping_option_id: :obj:`str`
 
@@ -6341,7 +6350,8 @@ class SuccessfulPayment(JsonDeserializable):
         return cls(**obj)
 
     def __init__(self, currency, total_amount, invoice_payload, shipping_option_id=None, order_info=None,
-                 telegram_payment_charge_id=None, provider_payment_charge_id=None, **kwargs):
+                 telegram_payment_charge_id=None, provider_payment_charge_id=None, 
+                    subscription_expiration_date=None, is_recurring=None, is_first_recurring=None, **kwargs):
         self.currency: str = currency
         self.total_amount: int = total_amount
         self.invoice_payload: str = invoice_payload
@@ -6349,6 +6359,9 @@ class SuccessfulPayment(JsonDeserializable):
         self.order_info: OrderInfo = order_info
         self.telegram_payment_charge_id: str = telegram_payment_charge_id
         self.provider_payment_charge_id: str = provider_payment_charge_id
+        self.subscription_expiration_date: Optional[int] = subscription_expiration_date
+        self.is_recurring: Optional[bool] = is_recurring
+        self.is_first_recurring: Optional[bool] = is_first_recurring
 
 
 # noinspection PyShadowingBuiltins

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -11025,3 +11025,66 @@ class PreparedInlineMessage(JsonDeserializable):
         obj = cls.check_json(json_string)
         return cls(**obj)
     
+    
+class Gift(JsonDeserializable):
+    """
+    This object represents a gift that can be sent by the bot.
+
+    Telegram documentation: https://core.telegram.org/bots/api#gift
+
+    :param id: Unique identifier of the gift
+    :type id: :obj:`str`
+
+    :param sticker: The sticker that represents the gift
+    :type sticker: :class:`Sticker`
+
+    :param star_count: The number of Telegram Stars that must be paid to send the sticker
+    :type star_count: :obj:`int`
+
+    :param total_count: Optional. The total number of the gifts of this type that can be sent; for limited gifts only
+    :type total_count: :obj:`int`
+
+    :param remaining_count: Optional. The number of remaining gifts of this type that can be sent; for limited gifts only
+    :type remaining_count: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`Gift`
+    """
+
+    def __init__(self, id, sticker, star_count, total_count=None, remaining_count=None, **kwargs):
+        self.id: str = id
+        self.sticker: Sticker = sticker
+        self.star_count: int = star_count
+        self.total_count: Optional[int] = total_count
+        self.remaining_count: Optional[int] = remaining_count
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['sticker'] = Sticker.de_json(obj['sticker'])
+        return cls(**obj)
+    
+class Gifts(JsonDeserializable):
+    """
+    This object represent a list of gifts.
+
+    Telegram documentation: https://core.telegram.org/bots/api#gifts
+
+    :param gifts: The list of gifts
+    :type gifts: :obj:`list` of :class:`Gift`
+
+    :return: Instance of the class
+    :rtype: :class:`Gifts`
+    """
+
+    def __init__(self, gifts, **kwargs):
+        self.gifts: List[Gift] = gifts
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['gifts'] = [Gift.de_json(gift) for gift in obj['gifts']]
+        return cls(**obj)
+    

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -10997,3 +10997,31 @@ class CopyTextButton(JsonSerializable, JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         return cls(**obj)
+
+
+class PreparedInlineMessage(JsonDeserializable):
+    """
+    Describes an inline message to be sent by a user of a Mini App.
+
+    Telegram documentation: https://core.telegram.org/bots/api#preparedinlinemessage
+
+    :param id: Unique identifier of the prepared message
+    :type id: :obj:`str`
+
+    :param expiration_date: Expiration date of the prepared message, in Unix time. Expired prepared messages can no longer be used
+    :type expiration_date: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`PreparedInlineMessage`
+    """
+
+    def __init__(self, id, expiration_date, **kwargs):
+        self.id: str = id
+        self.expiration_date: int = expiration_date
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+    

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -10495,17 +10495,21 @@ class TransactionPartnerUser(TransactionPartner):
     :param paid_media: Optional. Information about the paid media bought by the user
     :type paid_media: :obj:`list` of :class:`PaidMedia`
 
+    :param gift: Optional. The gift sent to the user by the bot
+    :type gift: :class:`Gift`
+
     :return: Instance of the class
     :rtype: :class:`TransactionPartnerUser`
     """
 
     def __init__(self, type, user, invoice_payload=None, paid_media: Optional[List[PaidMedia]] = None, 
-                    subscription_period=None, **kwargs):
+                    subscription_period=None, gift: Optional[Gift] = None, **kwargs):
         self.type: str = type
         self.user: User = user
         self.invoice_payload: Optional[str] = invoice_payload
         self.paid_media: Optional[List[PaidMedia]] = paid_media
         self.subscription_period: Optional[int] = subscription_period
+        self.gift: Optional[Gift] = gift
 
     @classmethod
     def de_json(cls, json_string):
@@ -10514,6 +10518,8 @@ class TransactionPartnerUser(TransactionPartner):
         obj['user'] = User.de_json(obj['user'])
         if 'paid_media' in obj:
             obj['paid_media'] = [PaidMedia.de_json(media) for media in obj['paid_media']]
+        if 'gift' in obj:
+            obj['gift'] = Gift.de_json(obj['gift'])
         return cls(**obj)
 
 
@@ -11025,7 +11031,7 @@ class PreparedInlineMessage(JsonDeserializable):
         obj = cls.check_json(json_string)
         return cls(**obj)
     
-    
+
 class Gift(JsonDeserializable):
     """
     This object represents a gift that can be sent by the bot.

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -10489,6 +10489,9 @@ class TransactionPartnerUser(TransactionPartner):
     :param invoice_payload: Optional, Bot-specified invoice payload
     :type invoice_payload: :obj:`str`
 
+    :param subscription_period: Optional. The duration of the paid subscription
+    :type subscription_period: :obj:`int`
+
     :param paid_media: Optional. Information about the paid media bought by the user
     :type paid_media: :obj:`list` of :class:`PaidMedia`
 
@@ -10496,11 +10499,13 @@ class TransactionPartnerUser(TransactionPartner):
     :rtype: :class:`TransactionPartnerUser`
     """
 
-    def __init__(self, type, user, invoice_payload=None, paid_media: Optional[List[PaidMedia]] = None, **kwargs):
+    def __init__(self, type, user, invoice_payload=None, paid_media: Optional[List[PaidMedia]] = None, 
+                    subscription_period=None, **kwargs):
         self.type: str = type
         self.user: User = user
         self.invoice_payload: Optional[str] = invoice_payload
         self.paid_media: Optional[List[PaidMedia]] = paid_media
+        self.subscription_period: Optional[int] = subscription_period
 
     @classmethod
     def de_json(cls, json_string):


### PR DESCRIPTION
**Star Subscriptions**

- [x] Bots now support paid subscriptions powered by [Telegram Stars](https://telegram.org/blog/telegram-stars) - monetizing their efforts with multiple tiers of content and features.
- [x] Added the parameter subscription_period to the method [createInvoiceLink](https://core.telegram.org/bots/api#createinvoicelink) to support the creation of links that are billed periodically.
- [x] Added the parameter business_connection_id to the method [createInvoiceLink](https://core.telegram.org/bots/api#createinvoicelink) to support the creation of invoice links on behalf of business accounts.
- [x] Added the fields subscription_expiration_date, is_recurring and is_first_recurring to the class [SuccessfulPayment](https://core.telegram.org/bots/api#successfulpayment).
- [x] Added the method [editUserStarSubscription](https://core.telegram.org/bots/api#edituserstarsubscription).
- [x] Added the field subscription_period to the class [TransactionPartnerUser](https://core.telegram.org/bots/api#transactionpartneruser).

**Full-screen Mode**

- [ ] Mini Apps are now able to [become full-screen](https://telegram.org/blog/fullscreen-miniapps-and-more#full-screen-mode) in both portrait and landscape mode - allowing them to host more games, play widescreen media and support immersive user experiences.
- [ ] Added the methods requestFullscreen and exitFullscreen to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps) to toggle full-screen mode.
- [ ] Added the fields safeAreaInset and contentSafeAreaInset to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps), allowing Mini Apps to ensure that their content properly respects the device's safe area margins.
- [ ] Further added the fields isActive and isFullscreen to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).
- [ ] Added the [events](https://core.telegram.org/bots/webapps#events-available-for-mini-apps) activated, deactivated, safeAreaChanged, contentSafeAreaChanged, fullscreenChanged and fullscreenFailed for Mini Apps.

**Homescreen Shortcuts**

- [ ] Mini Apps can now be accessed via [direct shortcuts](https://telegram.org/blog/fullscreen-miniapps-and-more#home-screen-shortcuts) added to the home screen of mobile devices.
- [ ] Added the method addToHomeScreen to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps) to create a shortcut for users to add to their home screens.
- [ ] Added the method checkHomeScreenStatus to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps) to determine the status and support of the home screen shortcut for the Mini App on the current device.
- [ ] Added the [events](https://core.telegram.org/bots/webapps#events-available-for-mini-apps) homeScreenAdded and homeScreenChecked for Mini Apps.

**Emoji Status**

- [ ] Mini Apps can now prompt users to set their [emoji status](https://telegram.org/blog/fullscreen-miniapps-and-more#emoji-status) - or request access to later sync it automatically with in-game badges, third-party APIs and more.
- [x] Added the method [setUserEmojiStatus](https://core.telegram.org/bots/api#setuseremojistatus). The user must allow the bot to manage their emoji status.
- [ ] Added the method setEmojiStatus to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps) to let users manually confirm a custom emoji as their new status via a native dialog.
- [ ] Added the method requestEmojiStatusAccess to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps) for obtaining permission to later update a user's emoji status via the Bot API method [setUserEmojiStatus](https://core.telegram.org/bots/api#setuseremojistatus).
- [ ] Added the [events](https://core.telegram.org/bots/webapps#events-available-for-mini-apps) emojiStatusSet, emojiStatusFailed and emojiStatusAccessRequested for Mini Apps.

**Media Sharing and File Downloads**

- [ ] Users can now [share media](https://telegram.org/blog/fullscreen-miniapps-and-more#media-sharing) directly from Mini Apps - sending referral codes, custom memes, artwork and more to any chat or posting them [as a story](https://telegram.org/blog/w3-browser-mini-app-store#sharing-from-mini-apps-to-stories).
- [ ] Added the class [PreparedInlineMessage](https://core.telegram.org/bots/api#preparedinlinemessage) and the method [savePreparedInlineMessage](https://core.telegram.org/bots/api#savepreparedinlinemessage), allowing bots to suggest users to send a specific message from a Mini App via the method [shareMessage](https://core.telegram.org/bots/webapps#initializing-mini-apps).
- [ ] Added the method shareMessage to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps) to share media from Mini Apps to Telegram chats.
- [ ] Added the method downloadFile to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps), introducing support for a native popup that prompts users to download files from the Mini App.
- [ ] Added the [events](https://core.telegram.org/bots/webapps#events-available-for-mini-apps) shareMessageSent, shareMessageFailed and fileDownloadRequested for Mini Apps.

**Geolocation Access**

- [ ] Mini Apps can now request [geolocation access](https://telegram.org/blog/fullscreen-miniapps-and-more#geolocation-access) to users, allowing them to build virtually any location-based service, from games with dynamic points of interest to interactive maps for events.
- [ ] Added the field LocationManager to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).
- [ ] Added the [events](https://core.telegram.org/bots/webapps#events-available-for-mini-apps) locationManagerUpdated and locationRequested for Mini Apps.

**Device Motion Tracking**

- [ ] Mini Apps can now track detailed [device motion data](https://telegram.org/blog/fullscreen-miniapps-and-more#device-motion-tracking), allowing them to implement better productivity tools, immersive VR experiences and more.
- [ ] Added the fields isOrientationLocked, Accelerometer, DeviceOrientation and Gyroscope to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).
- [ ] Added the methods lockOrientation and unlockOrientation to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps) to control the screen orientation.
- [ ] Added the [events](https://core.telegram.org/bots/webapps#events-available-for-mini-apps) accelerometerStarted, accelerometerStopped, accelerometerChanged, accelerometerFailed, deviceOrientationStarted, deviceOrientationStopped, deviceOrientationChanged, deviceOrientationFailed, gyroscopeStarted, gyroscopeStopped, gyroscopeChanged, gyroscopeFailed for Mini Apps.

**Gifts**

- [x] Bots can now send [Paid Gifts](https://telegram.org/blog/gifts-verification-platform#gifts) to users in exchange for Telegram Stars.
- [x] Added the classes [Gift](https://core.telegram.org/bots/api#gift) and [Gifts](https://core.telegram.org/bots/api#gifts) and the method [getAvailableGifts](https://core.telegram.org/bots/api#getavailablegifts), allowing bots to get all gifts available for sending.
- [x] Added the method [sendGift](https://core.telegram.org/bots/api#sendgift), allowing bots to send gifts to users.
- [x] Added the field gift to the class [TransactionPartnerUser](https://core.telegram.org/bots/api#transactionpartneruser).

**Loading Screen Customization**

- [ ] Mini Apps can customize their loading screen, adding their own icon and specific colors for light and dark themes.
- [ ] You can access these customization settings in [@BotFather](https://t.me/botfather) via /mybots > Select Bot > Bot Settings > Configure Mini App > Enable Mini App

**Hardware-specific Optimizations**

- [ ] Mini Apps running on Android can now receive [basic information](https://core.telegram.org/bots/webapps#additional-data-in-user-agent) about a device's processing hardware, allowing them to optimize user experience based on the device's capabilities.
- [ ] This information includes the OS, App and SDK's respective versions as well as the device's model and performance class.

**General**

- [ ] Added the field photo_url to the class [WebAppUser](https://core.telegram.org/bots/webapps#webappuser) for all bots, allowing Mini Apps to access a user's profile photo if their privacy settings allow for it.
- [ ] Third parties (e.g., Mini App builders) that receive or process data on behalf of Mini Apps are now able to [validate it](https://core.telegram.org/bots/webapps#validating-data-for-third-party-use) without knowing the App's [bot token](https://core.telegram.org/bots/tutorial#obtain-your-bot-token).
- [ ] Debugging [options](https://core.telegram.org/bots/webapps#debug-mode-for-mini-apps) have been expanded to include full support for iOS devices. You can use these tools to find app-specific issues in your Mini App.