### PR TITLE
Fix: change code for non-escape mode - return url

### DIFF
--- a/telebot/formatting.py
+++ b/telebot/formatting.py
@@ -240,7 +240,7 @@ def mlink(content: str, url: str, escape: Optional[bool]=True) -> str:
     :return: The formatted string.
     :rtype: :obj:`str`
     """
-    return '[{}]({})'.format(escape_markdown(content), escape_markdown(url) if escape else content)
+    return '[{}]({})'.format(escape_markdown(content), escape_markdown(url) if escape else url)
 
 
 def hlink(content: str, url: str, escape: Optional[bool]=True) -> str:


### PR DESCRIPTION
## Description
The correction ensures that when escape is False, url is used instead of content in the formatted string.
[Issue#2425](https://github.com/eternnoir/pyTelegramBotAPI/issues/2425#issue-2705365214)

## Describe your tests
How did you test your change?
```python
from formatting import mlink

print(mlink("content", "http://example.com/test", escape=False))
#[content](http://example.com/test)

print(mlink("content", "http://example.com/test", escape=True))
#[content](http://example\.com/test)

```
Python version:
3.10
OS:
Windows 11

## Checklist:
- [] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async
