### PR TITLE
Fixed "subscription_period" docstring

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5474,7 +5474,7 @@ class TeleBot:
             (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)
         :type prices: :obj:`list` of :obj:`types.LabeledPrice`
 
-        :subscription_period: 	The number of seconds the subscription will be active for before the next payment.
+        :param subscription_period: The number of seconds the subscription will be active for before the next payment.
             The currency must be set to “XTR” (Telegram Stars) if the parameter is used. Currently, it must always
             be 2592000 (30 days) if specified.
         :type subscription_period: :obj:`int`

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6922,7 +6922,7 @@ class AsyncTeleBot:
             (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)
         :type prices: :obj:`list` of :obj:`types.LabeledPrice`
 
-        :subscription_period: 	The number of seconds the subscription will be active for before the next payment.
+        :param subscription_period: The number of seconds the subscription will be active for before the next payment.
             The currency must be set to “XTR” (Telegram Stars) if the parameter is used. Currently, it must always
             be 2592000 (30 days) if specified.
         :type subscription_period: :obj:`int`


### PR DESCRIPTION
## Description
Fixed method docstring for "subscription_period"

Python version: 3.10

OS: macOS Sonoma 14.7

## Checklist:
- Just minor change of param docstring
