### PR TITLE
Create send_release_message script and action

### DIFF
--- a/.github/workflows/action_release_message.yml
+++ b/.github/workflows/action_release_message.yml
@@ -1,0 +1,27 @@
+---
+name: Send Release message
+on:
+  release:
+    types:
+    - created
+
+jobs:
+  send-message:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install Requirements
+      run: pip install pyTelegramBotAPI
+    - name: Send Message
+      run: python send_release_message.py
+      env:
+        TOKEN: ${{ secrets.TOKEN }}
+        CHAT_ID: ${{ vars.CHAT_ID }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+        RELEASE_TITLE: ${{ github.event.release.name }}
+        RELEASE_BODY: ${{ github.event.release.body }}

--- a/.github/workflows/action_release_message.yml
+++ b/.github/workflows/action_release_message.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Requirements
       run: pip install pyTelegramBotAPI
     - name: Send Message
-      run: python send_release_message.py
+      run: python examples/send_release_message.py
       env:
         TOKEN: ${{ secrets.TOKEN }}
         CHAT_ID: ${{ vars.CHAT_ID }}

--- a/examples/send_release_message.py
+++ b/examples/send_release_message.py
@@ -1,3 +1,8 @@
+#!/usr/bin/python
+
+# This is a simple script that sends a message to a defined chat_id using GitHub Actions.
+# It was created alongside action_release_message.yml
+
 import telebot
 import os
 

--- a/send_release_message.py
+++ b/send_release_message.py
@@ -1,0 +1,22 @@
+import telebot
+import os
+
+bot = telebot.TeleBot(os.environ.get('TOKEN'))
+chat_id = os.environ.get('CHAT_ID')
+release_tag = os.environ.get('RELEASE_TAG')
+release_title = os.environ.get('RELEASE_TITLE')
+release_body = os.environ.get('RELEASE_BODY')
+
+message = (
+    f'🎉 <b>{release_tag} - {release_title}</b>\n\n'
+    f'🛠 Changes:\n'
+    f'<b>{release_body}</b>\n\n'
+    f'<a href="https://github.com/eternnoir/pyTelegramBotAPI/releases/tag/{release_tag}">Release</a>'
+)
+
+bot.send_message(
+    chat_id,
+    message,
+    parse_mode='HTML',
+    link_preview_options=telebot.types.LinkPreviewOptions(is_disabled=True)
+)


### PR DESCRIPTION
## Description

Creates a GitHub Action and a small script that automatically sends a message to a specified chat_id whenever a new release is created.

To set this up:
- In this repository, go to **Settings** → **Secrets and variables** → **Actions**.
- Click on **New repository secret**, then create a new secret with the name `TOKEN` and provide the bot token as its value. Save it.
- Navigate to the **Variables** tab, click **New repository variable**, and create one named `CHAT_ID` with the destination chat ID for the release message. Save it.
> The channel @pytelegrambotapi corresponds to -1001006970192.

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [ ] I made changes both for sync and async
