### PR TITLE
Add support for processing language parameter in message entities

### DIFF
--- a/telebot/formatting.py
+++ b/telebot/formatting.py
@@ -425,15 +425,14 @@ def apply_html_entities(text: str, entities: Optional[List], custom_subs: Option
             url = "tg://user?id={0}".format(user.id)
         elif subst_type == "mention":
             url = "https://t.me/{0}".format(upd_text[1:])
-        elif subst_type == "pre":
-            if language is not None:
-                return '<pre><code class="language-{0}">{1}</code></pre>'.format(language, upd_text)
         upd_text = upd_text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
         if not subst_type or not _subs.get(subst_type):
             return upd_text
         subs = _subs.get(subst_type)
         if subst_type == "custom_emoji":
             return subs.format(text=upd_text, custom_emoji_id=custom_emoji_id)
+        elif (subst_type == "pre") and language:
+            return "<pre><code class=\"language-{0}\">{1}</code></pre>".format(language, upd_text)
         return subs.format(text=upd_text, url=url)
 
     offset = 0

--- a/telebot/formatting.py
+++ b/telebot/formatting.py
@@ -418,13 +418,16 @@ def apply_html_entities(text: str, entities: Optional[List], custom_subs: Option
     utf16_text = text.encode("utf-16-le")
     html_text = ""
 
-    def func(upd_text, subst_type=None, url=None, user=None, custom_emoji_id=None):
+    def func(upd_text, subst_type=None, url=None, user=None, custom_emoji_id=None, language=None):
         upd_text = upd_text.decode("utf-16-le")
         if subst_type == "text_mention":
             subst_type = "text_link"
             url = "tg://user?id={0}".format(user.id)
         elif subst_type == "mention":
             url = "https://t.me/{0}".format(upd_text[1:])
+        elif subst_type == "pre":
+            if language is not None:
+                return '<pre><code class="language-{0}">{1}</code></pre>'.format(language, upd_text)
         upd_text = upd_text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
         if not subst_type or not _subs.get(subst_type):
             return upd_text
@@ -444,14 +447,16 @@ def apply_html_entities(text: str, entities: Optional[List], custom_subs: Option
             offset = entity.offset
 
             new_string = func(utf16_text[offset * 2: (offset + entity.length) * 2], subst_type=entity.type,
-                              url=entity.url, user=entity.user, custom_emoji_id=entity.custom_emoji_id)
+                              url=entity.url, user=entity.user, custom_emoji_id=entity.custom_emoji_id,
+                              language=entity.language)
             start_index = len(html_text)
             html_text += new_string
             offset += entity.length
             end_index = len(html_text)
         elif entity.offset == offset:
             new_string = func(utf16_text[offset * 2: (offset + entity.length) * 2], subst_type=entity.type,
-                              url=entity.url, user=entity.user, custom_emoji_id=entity.custom_emoji_id)
+                              url=entity.url, user=entity.user, custom_emoji_id=entity.custom_emoji_id,
+                              language=entity.language)
             start_index = len(html_text)
             html_text += new_string
             end_index = len(html_text)
@@ -463,7 +468,8 @@ def apply_html_entities(text: str, entities: Optional[List], custom_subs: Option
             # And we don't change it).
             entity_string = html_text[start_index: end_index].encode("utf-16-le")
             formatted_string = func(entity_string, subst_type=entity.type, url=entity.url, user=entity.user,
-                                    custom_emoji_id=entity.custom_emoji_id). \
+                                    custom_emoji_id=entity.custom_emoji_id,
+                                    language=entity.language). \
                 replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
             html_text = html_text[:start_index] + formatted_string + html_text[end_index:]
             end_index = len(html_text)

--- a/tests/test_telebot.py
+++ b/tests/test_telebot.py
@@ -716,6 +716,7 @@ let number = loop {
             "`inline code`": "<code>inline code</code>",
             "```\ncode block```": "<pre>code block</pre>",
             "```python\nprint('Hello, world!')\n```": "<pre><code class=\"language-python\">print('Hello, world!')</code></pre>",
+            "```python\nprint(1 < 2)\n```": "<pre><code class=\"language-python\">print(1 &lt; 2)</code></pre>",
             "[link](http://example.com/)": "<a href=\"http://example.com/\">link</a>",
             ">blockquote": "<blockquote>blockquote</blockquote>",
         }

--- a/tests/test_telebot.py
+++ b/tests/test_telebot.py
@@ -44,11 +44,11 @@ class TestTeleBot:
         def listener(messages):
             assert len(messages) == 100
 
-        tb = telebot.TeleBot('')
+        tb = telebot.TeleBot(TOKEN)
         tb.set_update_listener(listener)
 
     def test_message_handler(self):
-        tb = telebot.TeleBot('')
+        tb = telebot.TeleBot(TOKEN)
         msg = self.create_text_message('/help')
 
         @tb.message_handler(commands=['help', 'start'])
@@ -60,7 +60,7 @@ class TestTeleBot:
         assert msg.text == 'got'
 
     def test_message_handler_reg(self):
-        bot = telebot.TeleBot('')
+        bot = telebot.TeleBot(TOKEN)
         msg = self.create_text_message(r'https://web.telegram.org/')
 
         # noinspection PyUnusedLocal
@@ -73,7 +73,7 @@ class TestTeleBot:
         assert msg.text == 'got'
 
     def test_message_handler_lambda(self):
-        bot = telebot.TeleBot('')
+        bot = telebot.TeleBot(TOKEN)
         msg = self.create_text_message(r'lambda_text')
 
         # noinspection PyUnusedLocal
@@ -86,7 +86,7 @@ class TestTeleBot:
         assert msg.text == 'got'
 
     def test_message_handler_lambda_fail(self):
-        bot = telebot.TeleBot('')
+        bot = telebot.TeleBot(TOKEN)
         msg = self.create_text_message(r'text')
 
         # noinspection PyUnusedLocal
@@ -99,7 +99,7 @@ class TestTeleBot:
         assert not msg.text == 'got'
 
     def test_message_handler_reg_fail(self):
-        bot = telebot.TeleBot('')
+        bot = telebot.TeleBot(TOKEN)
         msg = self.create_text_message(r'web.telegram.org/')
 
         # noinspection PyUnusedLocal
@@ -147,6 +147,7 @@ class TestTeleBot:
         ret_msg = tb.send_document(CHAT_ID, file_data)
         assert ret_msg.message_id
 
+        file_data.seek(0)
         ret_msg = tb.send_document(CHAT_ID, file_data, visible_file_name="test.jpg")
         assert ret_msg.message_id
         
@@ -529,28 +530,31 @@ let number = loop {
         params = {'text': text}
         chat = types.User(11, False, 'test')
         message = types.Message(1, None, None, chat, 'text', params, "")
-        edited_message = None
-        channel_post = None
-        edited_channel_post = None
-        inline_query = None
-        chosen_inline_result = None
-        callback_query = None
-        shipping_query = None
-        pre_checkout_query = None
-        poll = None
-        poll_answer = None
-        my_chat_member = None
-        chat_member = None
-        chat_join_request = None
-        message_reaction = None
-        message_reaction_count = None
-        chat_boost = None
-        chat_boost_removed = None
-        purchased_paid_media = None
-        return types.Update(-1001234038283, message, edited_message, channel_post, edited_channel_post, inline_query,
-                            chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                            my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, chat_boost, chat_boost_removed,
-                            purchased_paid_media)
+        return types.Update(
+            update_id=-1001234038283,
+            message=message,
+            edited_message=None,
+            channel_post=None,
+            edited_channel_post=None,
+            inline_query=None,
+            chosen_inline_result=None,
+            callback_query=None,
+            shipping_query=None,
+            pre_checkout_query=None,
+            poll=None,
+            poll_answer=None,
+            my_chat_member=None,
+            chat_member=None,
+            chat_join_request=None,
+            message_reaction=None,
+            message_reaction_count=None,
+            chat_boost=None,
+            removed_chat_boost=None,
+            purchased_paid_media=None,
+            business_message=None,
+            business_connection=None,
+            edited_business_message=None,
+            deleted_business_messages=None, )
 
     def test_is_string_unicode(self):
         s1 = u'string'
@@ -657,7 +661,7 @@ let number = loop {
 
         apihelper.ENABLE_MIDDLEWARE = True
 
-        tb = telebot.TeleBot('')
+        tb = telebot.TeleBot(TOKEN)
         update = self.create_message_update('/help')
 
         # noinspection PyUnusedLocal
@@ -678,7 +682,7 @@ let number = loop {
 
         apihelper.ENABLE_MIDDLEWARE = True
 
-        tb = telebot.TeleBot('')
+        tb = telebot.TeleBot(TOKEN)
         update = self.create_message_update('/help')
 
         # noinspection PyUnusedLocal
@@ -703,3 +707,19 @@ let number = loop {
         #tb = telebot.TeleBot(TOKEN)
         #permissions = types.ChatPermissions(can_send_messages=True, can_send_polls=False)
         #msg = tb.set_chat_permissions(CHAT_ID, permissions)
+
+    def test_apply_html_entities(self):
+        text = {
+            "*bold*": "<b>bold</b>",
+            "__italic__": "<u>italic</u>",
+            "~strikethrough~": "<s>strikethrough</s>",
+            "`inline code`": "<code>inline code</code>",
+            "```\ncode block```": "<pre>code block</pre>",
+            "```python\nprint('Hello, world!')\n```": "<pre><code class=\"language-python\">print('Hello, world!')</code></pre>",
+            "[link](http://example.com/)": "<a href=\"http://example.com/\">link</a>",
+            ">blockquote": "<blockquote>blockquote</blockquote>",
+        }
+        tb = telebot.TeleBot(TOKEN)
+        for key, value in text.items():
+            ret_msg = tb.send_message(CHAT_ID, text=key, parse_mode='MarkdownV2')
+            assert telebot.formatting.apply_html_entities(ret_msg.text, ret_msg.entities, None) == value


### PR DESCRIPTION
## Description
Add support for processing code language parameter in `<pre>` tag under message entities

## Describe your tests
How did you test your change?

Python version: 3.12

OS: Windows 11

Send a message containing a code block to the bot, then see the result of the parsed HTML code.

![image](https://github.com/user-attachments/assets/3ba5aa32-4ea0-488f-b7bd-3b91bfc99c7d)
![image](https://github.com/user-attachments/assets/012d4b1a-5237-4867-b1f9-e6ac5c880fba)
## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [ ] I made changes both for sync and async
