### PR TITLE
Bot API 9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">A simple, but extensible Python implementation for the <a href="https://core.telegram.org/bots/api">Telegram Bot API</a>.</p>
 <p align="center">Both synchronous and asynchronous.</p>
 
-## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#february-12-2025"><img src="https://img.shields.io/badge/Bot%20API-8.3-blue?logo=telegram" alt="Supported Bot API version"></a>
+## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#april-11-2025"><img src="https://img.shields.io/badge/Bot%20API-9.0-blue?logo=telegram" alt="Supported Bot API version"></a>
 
 <h2><a href='https://pytba.readthedocs.io/en/latest/index.html'>Official documentation</a></h2>
 <h2><a href='https://pytba.readthedocs.io/ru/latest/index.html'>Official ru documentation</a></h2>

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -9651,3 +9651,4 @@ class TeleBot:
                 handlers=handlers,
                 middlewares=middlewares,
                 update_type=update_type)
+

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6524,6 +6524,65 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.transfer_business_account_stars(self.token, business_connection_id, star_count)
+    
+    def get_business_account_gifts(
+            self, business_connection_id: str,
+            exclude_unsaved: Optional[bool]=None,
+            exclude_saved: Optional[bool]=None,
+            exclude_unlimited: Optional[bool]=None,
+            exclude_limited: Optional[bool]=None,
+            exclude_unique: Optional[bool]=None,
+            sort_by_price: Optional[bool]=None,
+            offset: Optional[str]=None,
+            limit: Optional[int]=None) -> types.OwnedGifts:
+        """
+        Returns the gifts received and owned by a managed business account. Requires the can_view_gifts_and_stars business bot right. Returns OwnedGifts on success.
+        
+        Telegram documentation: https://core.telegram.org/bots/api#getbusinessaccountgifts
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param exclude_unsaved: Pass True to exclude gifts that aren't saved to the account's profile page
+        :type exclude_unsaved: :obj:`bool`
+
+        :param exclude_saved: Pass True to exclude gifts that are saved to the account's profile page
+        :type exclude_saved: :obj:`bool`
+
+        :param exclude_unlimited: Pass True to exclude gifts that can be purchased an unlimited number of times
+        :type exclude_unlimited: :obj:`bool`
+
+        :param exclude_limited: Pass True to exclude gifts that can be purchased a limited number of times
+        :type exclude_limited: :obj:`bool`
+
+        :param exclude_unique: Pass True to exclude unique gifts
+        :type exclude_unique: :obj:`bool`
+
+        :param sort_by_price: Pass True to sort results by gift price instead of send date. Sorting is applied before pagination.
+        :type sort_by_price: :obj:`bool`
+
+        :param offset: Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results
+        :type offset: :obj:`str`
+
+        :param limit: The maximum number of gifts to be returned; 1-100. Defaults to 100
+        :type limit: :obj:`int`
+
+        :return: On success, a OwnedGifts object is returned.
+        :rtype: :class:`telebot.types.OwnedGifts`
+        """
+        return types.OwnedGifts.de_json(
+            apihelper.get_business_account_gifts(
+                self.token, business_connection_id,
+                exclude_unsaved=exclude_unsaved,
+                exclude_saved=exclude_saved,
+                exclude_unlimited=exclude_unlimited,
+                exclude_limited=exclude_limited,
+                exclude_unique=exclude_unique,
+                sort_by_price=sort_by_price,
+                offset=offset,
+                limit=limit
+            )
+        )
 
     def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6364,7 +6364,7 @@ class TeleBot:
 
         return apihelper.remove_user_verification(self.token, user_id)
 
-    def remove_chat_verification(self, chat_id: Union[int, str]) -> bool:
+    def remove_chat_verification(self, chat_id: int) -> bool:
         """
         Removes verification from a chat that is currently verified on behalf of the organization represented by the bot. Returns True on success.
 
@@ -6433,7 +6433,7 @@ class TeleBot:
         :return: Returns True on success.
         :rtype: :obj:`bool`
         """
-        return apihelper.set_business_account_name(self.token, business_connection_id, first_name, last_name)
+        return apihelper.set_business_account_name(self.token, business_connection_id, first_name, last_name=last_name)
 
     def set_business_account_username(self, business_connection_id: str, username: Optional[str]=None) -> bool:
         """
@@ -6451,7 +6451,7 @@ class TeleBot:
         :rtype: :obj:`bool`
 
         """
-        return apihelper.set_business_account_username(self.token, business_connection_id, username)
+        return apihelper.set_business_account_username(self.token, business_connection_id, username=username)
 
     def set_business_account_bio(self, business_connection_id: str, bio: Optional[str]=None) -> bool:
         """
@@ -6468,7 +6468,7 @@ class TeleBot:
         :return: Returns True on success.
         :rtype: :obj:`bool`
         """
-        return apihelper.set_business_account_bio(self.token, business_connection_id, bio)
+        return apihelper.set_business_account_bio(self.token, business_connection_id, bio=bio)
 
     def set_business_account_gift_settings(
             self, business_connection_id: str, show_gift_button: bool, accepted_gift_types: types.AcceptedGiftTypes) -> bool:
@@ -6635,7 +6635,7 @@ class TeleBot:
 
     def transfer_gift(
             self, business_connection_id: str, owned_gift_id: str,
-            new_owner_chat_id: Union[int, str],
+            new_owner_chat_id: int,
             star_count: Optional[int]=None) -> bool:
         """
         Transfers an owned unique gift to another user. Requires the can_transfer_and_upgrade_gifts business bot right.
@@ -6650,7 +6650,7 @@ class TeleBot:
         :type owned_gift_id: :obj:`str`
 
         :param new_owner_chat_id: Unique identifier of the chat which will own the gift. The chat must be active in the last 24 hours.
-        :type new_owner_chat_id: :obj:`int` | :obj:`str`
+        :type new_owner_chat_id: :obj:`int`
 
         :param star_count: The amount of Telegram Stars that will be paid for the transfer from the business account balance.
             If positive, then the can_transfer_stars business bot right is required.
@@ -6661,7 +6661,7 @@ class TeleBot:
         """
         return apihelper.transfer_gift(
             self.token, business_connection_id, owned_gift_id,
-            new_owner_chat_id=new_owner_chat_id,
+            new_owner_chat_id,
             star_count=star_count
         )
     

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6820,6 +6820,48 @@ class TeleBot:
             text=text, text_parse_mode=text_parse_mode,
             text_entities=text_entities
         )
+    
+    def set_business_account_profile_photo(
+            self, business_connection_id: str, photo: types.InputProfilePhoto,
+            is_public: Optional[bool]=None) -> bool:
+        """
+        Changes the profile photo of a managed business account. Requires the can_edit_profile_photo business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountprofilephoto
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param photo: The new profile photo to set
+        :type photo: :class:`telebot.types.InputProfilePhoto`
+
+        :param is_public: Pass True to set the public photo, which will be visible even if the main photo is hidden by the business account's privacy settings. An account can have only one public photo.
+        :type is_public: :obj:`bool`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.set_business_account_profile_photo(self.token, business_connection_id, photo, is_public=is_public)
+
+
+    def remove_business_account_profile_photo(
+            self, business_connection_id: str,
+            is_public: Optional[bool]=None) -> bool:
+        """
+        Removes the current profile photo of a managed business account. Requires the can_edit_profile_photo business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#removebusinessaccountprofilephoto
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param is_public: Pass True to remove the public photo, which is visible even if the main photo is hidden by the business account's privacy settings. After the main photo is removed, the previous profile photo (if present) becomes the main photo.
+        :type is_public: :obj:`bool`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.remove_business_account_profile_photo(self.token, business_connection_id, is_public=is_public)
 
     def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6600,6 +6600,71 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.convert_gift_to_stars(self.token, business_connection_id, owned_gift_id)
+    
+    def upgrade_gift(
+            self, business_connection_id: str, owned_gift_id: str,
+            keep_original_details: Optional[bool]=None,
+            star_count: Optional[int]=None) -> bool:
+        """
+        Upgrades a given regular gift to a unique gift. Requires the can_transfer_and_upgrade_gifts business bot right.
+        Additionally requires the can_transfer_stars business bot right if the upgrade is paid. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#upgradegift
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param owned_gift_id: Unique identifier of the regular gift that should be upgraded to a unique one
+        :type owned_gift_id: :obj:`str`
+
+        :param keep_original_details: Pass True to keep the original gift text, sender and receiver in the upgraded gift
+        :type keep_original_details: :obj:`bool`
+
+        :param star_count: The amount of Telegram Stars that will be paid for the upgrade from the business account balance.
+            If gift.prepaid_upgrade_star_count > 0, then pass 0, otherwise, the can_transfer_stars business bot right is required and gift.upgrade_star_count must be passed.
+        :type star_count: :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.upgrade_gift(
+            self.token, business_connection_id, owned_gift_id,
+            keep_original_details=keep_original_details,
+            star_count=star_count
+        )
+
+    def transfer_gift(
+            self, business_connection_id: str, owned_gift_id: str,
+            new_owner_chat_id: Union[int, str],
+            star_count: Optional[int]=None) -> bool:
+        """
+        Transfers an owned unique gift to another user. Requires the can_transfer_and_upgrade_gifts business bot right.
+        Requires can_transfer_stars business bot right if the transfer is paid. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#transfergift
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param owned_gift_id: Unique identifier of the regular gift that should be transferred
+        :type owned_gift_id: :obj:`str`
+
+        :param new_owner_chat_id: Unique identifier of the chat which will own the gift. The chat must be active in the last 24 hours.
+        :type new_owner_chat_id: :obj:`int` | :obj:`str`
+
+        :param star_count: The amount of Telegram Stars that will be paid for the transfer from the business account balance.
+            If positive, then the can_transfer_stars business bot right is required.
+        :type star_count: :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.transfer_gift(
+            self.token, business_connection_id, owned_gift_id,
+            new_owner_chat_id=new_owner_chat_id,
+            star_count=star_count
+        )
+
 
     def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6785,6 +6785,42 @@ class TeleBot:
         """
         return apihelper.delete_story(self.token, business_connection_id, story_id)
 
+    def gift_premium_subscription(
+            self, user_id: int, month_count: int, star_count: int,
+            text: Optional[str]=None, text_parse_mode: Optional[str]=None,
+            text_entities: Optional[List[types.MessageEntity]]=None) -> bool:
+        """
+        Gifts a Telegram Premium subscription to the given user. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#giftpremiumsubscription
+
+        :param user_id: Unique identifier of the target user who will receive a Telegram Premium subscription
+        :type user_id: :obj:`int`
+
+        :param month_count: Number of months the Telegram Premium subscription will be active for the user; must be one of 3, 6, or 12
+        :type month_count: :obj:`int`
+
+        :param star_count: Number of Telegram Stars to pay for the Telegram Premium subscription; must be 1000 for 3 months, 1500 for 6 months, and 2500 for 12 months
+        :type star_count: :obj:`int`
+
+        :param text: Text that will be shown along with the service message about the subscription; 0-128 characters
+        :type text: :obj:`str`
+
+        :param text_parse_mode: Mode for parsing entities in the text. See formatting options for more details. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored.
+        :type text_parse_mode: :obj:`str`
+
+        :param text_entities: A JSON-serialized list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored.
+        :type text_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.gift_premium_subscription(
+            self.token, user_id, month_count, star_count,
+            text=text, text_parse_mode=text_parse_mode,
+            text_entities=text_entities
+        )
+
     def get_available_gifts(self) -> types.Gifts:
         """
         Returns the list of gifts that can be sent by the bot to users. Requires no parameters. Returns a Gifts object.

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6584,6 +6584,23 @@ class TeleBot:
             )
         )
 
+    def convert_gift_to_stars(self, business_connection_id: str, owned_gift_id: str) -> bool:
+        """
+        Converts a given regular gift to Telegram Stars. Requires the can_convert_gifts_to_stars business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#convertgifttostars
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param owned_gift_id: Unique identifier of the regular gift that should be converted to Telegram Stars
+        :type owned_gift_id: :obj:`str`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.convert_gift_to_stars(self.token, business_connection_id, owned_gift_id)
+
     def get_available_gifts(self) -> types.Gifts:
         """
         Returns the list of gifts that can be sent by the bot to users. Requires no parameters. Returns a Gifts object.

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6664,7 +6664,126 @@ class TeleBot:
             new_owner_chat_id=new_owner_chat_id,
             star_count=star_count
         )
+    
+    def post_story(
+            self, business_connection_id: str, content: types.InputStoryContent,
+            active_period: int, caption: Optional[str]=None,
+            parse_mode: Optional[str]=None,
+            caption_entities: Optional[List[types.MessageEntity]]=None,
+            areas: Optional[List[types.StoryArea]]=None,
+            post_to_chat_page: Optional[bool]=None,
+            protect_content: Optional[bool]=None) -> types.Story:
 
+        """
+        Posts a story on behalf of a managed business account. Requires the can_manage_stories business bot right. Returns Story on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#poststory
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param content: Content of the story
+        :type content: :class:`telebot.types.InputStoryContent`
+
+        :param active_period: Period after which the story is moved to the archive, in seconds; must be one of 6 * 3600, 12 * 3600, 86400, or 2 * 86400
+        :type active_period: :obj:`int`
+
+        :param caption: Caption of the story, 0-2048 characters after entities parsing
+        :type caption: :obj:`str`
+
+        :param parse_mode: Mode for parsing entities in the story caption. See formatting options for more details.
+        :type parse_mode: :obj:`str`
+
+        :param caption_entities: A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
+        :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
+
+        :param areas: A JSON-serialized list of clickable areas to be shown on the story
+        :type areas: :obj:`list` of :class:`telebot.types.StoryArea`
+
+        :param post_to_chat_page: Pass True to keep the story accessible after it expires
+        :type post_to_chat_page: :obj:`bool`
+
+        :param protect_content: Pass True if the content of the story must be protected from forwarding and screenshotting
+        :type protect_content: :obj:`bool`
+
+        :return: On success, a Story object is returned.
+        :rtype: :class:`telebot.types.Story`
+        """
+        return types.Story.de_json(
+            apihelper.post_story(
+                self.token, business_connection_id, content,
+                active_period, caption=caption,
+                parse_mode=parse_mode,
+                caption_entities=caption_entities,
+                areas=areas,
+                post_to_chat_page=post_to_chat_page,
+                protect_content=protect_content
+            )
+        )
+
+    def edit_story(
+            self, business_connection_id: str, story_id: int,
+            content: types.InputStoryContent,
+            caption: Optional[str]=None,
+            parse_mode: Optional[str]=None,
+            caption_entities: Optional[List[types.MessageEntity]]=None,
+            areas: Optional[List[types.StoryArea]]=None) -> types.Story:
+        """
+        Edits a story previously posted by the bot on behalf of a managed business account. Requires the can_manage_stories business bot right. Returns Story on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#editstory
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param story_id: Unique identifier of the story to edit
+        :type story_id: :obj:`int`
+
+        :param content: Content of the story
+        :type content: :class:`telebot.types.InputStoryContent`
+
+        :param caption: Caption of the story, 0-2048 characters after entities parsing
+        :type caption: :obj:`str`
+
+        :param parse_mode: Mode for parsing entities in the story caption. See formatting options for more details.
+        :type parse_mode: :obj:`str`
+
+        :param caption_entities: A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
+        :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
+
+        :param areas: A JSON-serialized list of clickable areas to be shown on the story
+        :type areas: :obj:`list` of :class:`telebot.types.StoryArea`
+
+        :return: On success, a Story object is returned.
+        :rtype: :class:`telebot.types.Story`
+
+        """
+        return types.Story.de_json(
+            apihelper.edit_story(
+                self.token, business_connection_id, story_id,
+                content, caption=caption,
+                parse_mode=parse_mode,
+                caption_entities=caption_entities,
+                areas=areas
+            )
+    )
+
+    def delete_story(self, business_connection_id: str, story_id: int) -> bool:
+        """
+        Deletes a story previously posted by the bot on behalf of a managed business account. Requires the can_manage_stories business bot right. Returns True on success.
+        
+        Telegram documentation: https://core.telegram.org/bots/api#deletestory
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param story_id: Unique identifier of the story to delete
+        :type story_id: :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.delete_story(self.token, business_connection_id, story_id)
 
     def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6469,6 +6469,28 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.set_business_account_bio(self.token, business_connection_id, bio)
+
+    def set_business_account_gift_settings(
+            self, business_connection_id: str, show_gift_button: bool, accepted_gift_types: types.AcceptedGiftTypes) -> bool:
+        """
+        Changes the privacy settings pertaining to incoming gifts in a managed business account. Requires the can_change_gift_settings business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountgiftsettings
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param show_gift_button: Pass True, if a button for sending a gift to the user or by the business account must always be shown in the input field
+        :type show_gift_button: :obj:`bool`
+
+        :param accepted_gift_types: Types of gifts accepted by the business account
+        :type accepted_gift_types: :class:`telebot.types.AcceptedGiftTypes`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.set_business_account_gift_settings(self.token, business_connection_id, show_gift_button, accepted_gift_types)
+    
     
     def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6491,7 +6491,23 @@ class TeleBot:
         """
         return apihelper.set_business_account_gift_settings(self.token, business_connection_id, show_gift_button, accepted_gift_types)
     
-    
+
+    def get_business_account_star_balance(self, business_connection_id: str) -> types.StarAmount:
+        """
+        Returns the amount of Telegram Stars owned by a managed business account. Requires the can_view_gifts_and_stars business bot right. Returns StarAmount on success.
+        
+        Telegram documentation: https://core.telegram.org/bots/api#getbusinessaccountstarbalance
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :return: On success, a StarAmount object is returned.
+        :rtype: :class:`telebot.types.StarAmount`
+        """
+        return types.StarAmount.de_json(
+            apihelper.get_business_account_star_balance(self.token, business_connection_id)
+        )
+
     def get_available_gifts(self) -> types.Gifts:
         """
         Returns the list of gifts that can be sent by the bot to users. Requires no parameters. Returns a Gifts object.

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6377,6 +6377,98 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.remove_chat_verification(self.token, chat_id)
+
+    def read_business_message(self, business_connection_id: str, chat_id: Union[int, str], message_id: int) -> bool:
+        """
+        Marks incoming message as read on behalf of a business account. Requires the can_read_messages business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#readbusinessmessage
+
+        :param business_connection_id: Unique identifier of the business connection on behalf of which to read the message
+        :type business_connection_id: :obj:`str`
+
+        :param chat_id: Unique identifier of the chat in which the message was received. The chat must have been active in the last 24 hours.
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param message_id: Unique identifier of the message to mark as read
+        :type message_id: :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.read_business_message(self.token, business_connection_id, chat_id, message_id)
+
+    def delete_business_messages(self, business_connection_id: str, message_ids: List[int]) -> bool:
+        """
+        Delete messages on behalf of a business account. Requires the can_delete_outgoing_messages business bot right to delete messages sent by the bot itself, or the can_delete_all_messages business bot right to delete any message. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#deletebusinessmessages
+
+        :param business_connection_id: Unique identifier of the business connection on behalf of which to delete the messages
+        :type business_connection_id: :obj:`str`
+
+        :param message_ids: A JSON-serialized list of 1-100 identifiers of messages to delete. All messages must be from the same chat. See deleteMessage for limitations on which messages can be deleted
+        :type message_ids: :obj:`list` of :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.delete_business_messages(self.token, business_connection_id, message_ids)
+
+    def set_business_account_name(self, business_connection_id: str, first_name: str, last_name: Optional[str]=None) -> bool:
+        """
+        Changes the first and last name of a managed business account. Requires the can_change_name business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountname
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param first_name: The new value of the first name for the business account; 1-64 characters
+        :type first_name: :obj:`str`
+
+        :param last_name: The new value of the last name for the business account; 0-64 characters
+        :type last_name: :obj:`str`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.set_business_account_name(self.token, business_connection_id, first_name, last_name)
+
+    def set_business_account_username(self, business_connection_id: str, username: Optional[str]=None) -> bool:
+        """
+        Changes the username of a managed business account. Requires the can_change_username business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountusername
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param username: The new value of the username for the business account; 0-32 characters
+        :type username: :obj:`str`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+
+        """
+        return apihelper.set_business_account_username(self.token, business_connection_id, username)
+
+    def set_business_account_bio(self, business_connection_id: str, bio: Optional[str]=None) -> bool:
+        """
+        Changes the bio of a managed business account. Requires the can_change_bio business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountbio
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param bio: The new value of the bio for the business account; 0-140 characters
+        :type bio: :obj:`str`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.set_business_account_bio(self.token, business_connection_id, bio)
     
     def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6507,6 +6507,23 @@ class TeleBot:
         return types.StarAmount.de_json(
             apihelper.get_business_account_star_balance(self.token, business_connection_id)
         )
+    
+    def transfer_business_account_stars(self, business_connection_id: str, star_count: int) -> bool:
+        """
+        Transfers Telegram Stars from the business account balance to the bot's balance. Requires the can_transfer_stars business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#transferbusinessaccountstars
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param star_count: Number of Telegram Stars to transfer; 1-10000
+        :type star_count: :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.transfer_business_account_stars(self.token, business_connection_id, star_count)
 
     def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -2135,6 +2135,18 @@ def delete_story(token, business_connection_id, story_id):
     payload = {'business_connection_id': business_connection_id, 'story_id': story_id}
     return _make_request(token, method_url, params=payload, method='post')
 
+def gift_premium_subscription(token, user_id, month_count, star_count, text=None, text_parse_mode=None,
+                            text_entities=None):
+    method_url = 'giftPremiumSubscription'
+    payload = {'user_id': user_id, 'month_count': month_count, 'star_count': star_count}
+    if text:
+        payload['text'] = text
+    if text_parse_mode:
+        payload['text_parse_mode'] = text_parse_mode
+    if text_entities:
+        payload['text_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(text_entities))
+    return _make_request(token, method_url, params=payload, method='post')
+
 def create_new_sticker_set(
         token, user_id, name, title, stickers, sticker_type=None, needs_repainting=None):
     method_url = 'createNewStickerSet'

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1992,6 +1992,39 @@ def remove_chat_verification(token, chat_id):
     payload = {'chat_id': chat_id}
     return _make_request(token, method_url, params=payload, method='post')
 
+
+def read_business_message(token, business_connection_id, chat_id, message_id):
+    method_url = 'readBusinessMessage'
+    payload = {'business_connection_id': business_connection_id, 'chat_id': chat_id, 'message_id': message_id}
+    return _make_request(token, method_url, params=payload, method='post')
+
+
+def delete_business_messages(token, business_connection_id, message_ids):
+    method_url = 'deleteBusinessMessages'
+    payload = {'business_connection_id': business_connection_id, 'message_ids': json.dumps(message_ids)}
+    return _make_request(token, method_url, params=payload, method='post')
+
+
+def set_business_account_name(token, business_connection_id, first_name, last_name=None):
+    method_url = 'setBusinessAccountName'
+    payload = {'business_connection_id': business_connection_id, 'first_name': first_name}
+    if last_name:
+        payload['last_name'] = last_name
+    return _make_request(token, method_url, params=payload, method='post')
+
+
+def set_business_account_username(token, business_connection_id, username):
+    method_url = 'setBusinessAccountUsername'
+    payload = {'business_connection_id': business_connection_id, 'username': username}
+    return _make_request(token, method_url, params=payload, method='post')
+
+
+def set_business_account_bio(token, business_connection_id, bio):
+    method_url = 'setBusinessAccountBio'
+    payload = {'business_connection_id': business_connection_id, 'bio': bio}
+    return _make_request(token, method_url, params=payload, method='post')
+
+
 def set_sticker_emoji_list(token, sticker, emoji_list):
     method_url = 'setStickerEmojiList'
     payload = {'sticker': sticker, 'emoji_list': json.dumps(emoji_list)}

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -2147,6 +2147,22 @@ def gift_premium_subscription(token, user_id, month_count, star_count, text=None
         payload['text_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(text_entities))
     return _make_request(token, method_url, params=payload, method='post')
 
+def set_business_account_profile_photo(token, business_connection_id, photo, is_public=None):
+    method_url = 'setBusinessAccountProfilePhoto'
+    payload = {'business_connection_id': business_connection_id}
+    photo_json, files = photo.convert_input_profile_photo()
+    payload['photo'] = photo_json
+    if is_public is not None:
+        payload['is_public'] = is_public
+    return _make_request(token, method_url, params=payload, files=files, method='post')
+
+def remove_business_account_profile_photo(token, business_connection_id, is_public=None):
+    method_url = 'removeBusinessAccountProfilePhoto'
+    payload = {'business_connection_id': business_connection_id}
+    if is_public is not None:
+        payload['is_public'] = is_public
+    return _make_request(token, method_url, params=payload, method='post')
+
 def create_new_sticker_set(
         token, user_id, name, title, stickers, sticker_type=None, needs_repainting=None):
     method_url = 'createNewStickerSet'

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -2013,21 +2013,26 @@ def set_business_account_name(token, business_connection_id, first_name, last_na
     return _make_request(token, method_url, params=payload, method='post')
 
 
-def set_business_account_username(token, business_connection_id, username):
+def set_business_account_username(token, business_connection_id, username=None):
     method_url = 'setBusinessAccountUsername'
-    payload = {'business_connection_id': business_connection_id, 'username': username}
+    payload = {'business_connection_id': business_connection_id}
+    if username:
+        payload['username'] = username
     return _make_request(token, method_url, params=payload, method='post')
 
 
-def set_business_account_bio(token, business_connection_id, bio):
+def set_business_account_bio(token, business_connection_id, bio=None):
     method_url = 'setBusinessAccountBio'
-    payload = {'business_connection_id': business_connection_id, 'bio': bio}
+    payload = {'business_connection_id': business_connection_id}
+    if bio:
+        payload['bio'] = bio
     return _make_request(token, method_url, params=payload, method='post')
 
 
 def set_business_account_gift_settings(token, business_connection_id, show_gift_button, accepted_gift_types):
     method_url = 'setBusinessAccountGiftSettings'
-    payload = {'business_connection_id': business_connection_id, 'show_gift_button': show_gift_button, 'accepted_gift_types': json.dumps(accepted_gift_types)}
+    payload = {'business_connection_id': business_connection_id, 'show_gift_button': show_gift_button,
+                'accepted_gift_types': accepted_gift_types.to_json()}
     return _make_request(token, method_url, params=payload, method='post')
 
 def set_sticker_emoji_list(token, sticker, emoji_list):

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -2090,6 +2090,51 @@ def transfer_gift(token, business_connection_id, owned_gift_id, new_owner_chat_i
         payload['star_count'] = star_count
     return _make_request(token, method_url, params=payload, method='post')
 
+def post_story(token, business_connection_id, content, active_period, caption=None, parse_mode=None,
+             caption_entities=None, areas=None, post_to_chat_page=None, protect_content=None):
+    method_url = 'postStory'
+    payload = {'business_connection_id': business_connection_id, 'active_period': active_period}
+    
+    content_json, files = content.convert_input_story()
+    payload['content'] = content_json
+    
+    if caption:
+        payload['caption'] = caption
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
+    if caption_entities:
+        payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
+    if areas:
+        payload['areas'] = json.dumps([area.to_json() for area in areas])
+    if post_to_chat_page is not None:
+        payload['post_to_chat_page'] = post_to_chat_page
+    if protect_content is not None:
+        payload['protect_content'] = protect_content
+    return _make_request(token, method_url, params=payload, files=files, method='post')
+
+def edit_story(token, business_connection_id, story_id, content, caption=None, parse_mode=None,
+                caption_entities=None, areas=None):
+    method_url = 'editStory'
+    payload = {'business_connection_id': business_connection_id, 'story_id': story_id}
+    
+    content_json, files = content.convert_input_story()
+    payload['content'] = content_json
+    
+    if caption:
+        payload['caption'] = caption
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
+    if caption_entities:
+        payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
+    if areas:
+        payload['areas'] = json.dumps([area.to_json() for area in areas])
+    return _make_request(token, method_url, params=payload, files=files, method='post')
+
+def delete_story(token, business_connection_id, story_id):
+    method_url = 'deleteStory'
+    payload = {'business_connection_id': business_connection_id, 'story_id': story_id}
+    return _make_request(token, method_url, params=payload, method='post')
+
 def create_new_sticker_set(
         token, user_id, name, title, stickers, sticker_type=None, needs_repainting=None):
     method_url = 'createNewStickerSet'

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -2035,6 +2035,10 @@ def set_sticker_emoji_list(token, sticker, emoji_list):
     payload = {'sticker': sticker, 'emoji_list': json.dumps(emoji_list)}
     return _make_request(token, method_url, params=payload, method='post')
 
+def get_business_account_star_balance(token, business_connection_id):
+    method_url = 'getBusinessAccountStarBalance'
+    payload = {'business_connection_id': business_connection_id}
+    return _make_request(token, method_url, params=payload)
 
 def create_new_sticker_set(
         token, user_id, name, title, stickers, sticker_type=None, needs_repainting=None):

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -2074,6 +2074,22 @@ def convert_gift_to_stars(token, business_connection_id, owned_gift_id):
     payload = {'business_connection_id': business_connection_id, 'owned_gift_id': owned_gift_id}
     return _make_request(token, method_url, params=payload, method='post')
 
+def upgrade_gift(token, business_connection_id, owned_gift_id, keep_original_details=None, star_count=None):
+    method_url = 'upgradeGift'
+    payload = {'business_connection_id': business_connection_id, 'owned_gift_id': owned_gift_id}
+    if keep_original_details is not None:
+        payload['keep_original_details'] = keep_original_details
+    if star_count is not None:
+        payload['star_count'] = star_count
+    return _make_request(token, method_url, params=payload, method='post')
+
+def transfer_gift(token, business_connection_id, owned_gift_id, new_owner_chat_id, star_count=None):
+    method_url = 'transferGift'
+    payload = {'business_connection_id': business_connection_id, 'owned_gift_id': owned_gift_id, 'new_owner_chat_id': new_owner_chat_id}
+    if star_count is not None:
+        payload['star_count'] = star_count
+    return _make_request(token, method_url, params=payload, method='post')
+
 def create_new_sticker_set(
         token, user_id, name, title, stickers, sticker_type=None, needs_repainting=None):
     method_url = 'createNewStickerSet'

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -2040,6 +2040,11 @@ def get_business_account_star_balance(token, business_connection_id):
     payload = {'business_connection_id': business_connection_id}
     return _make_request(token, method_url, params=payload)
 
+def transfer_business_account_stars(token, business_connection_id, star_count):
+    method_url = 'transferBusinessAccountStars'
+    payload = {'business_connection_id': business_connection_id, 'star_count': star_count}
+    return _make_request(token, method_url, params=payload, method='post')
+
 def create_new_sticker_set(
         token, user_id, name, title, stickers, sticker_type=None, needs_repainting=None):
     method_url = 'createNewStickerSet'

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -2068,6 +2068,12 @@ def get_business_account_gifts(token, business_connection_id, exclude_unsaved=No
           payload['limit'] = limit
      return _make_request(token, method_url, params=payload)
 
+
+def convert_gift_to_stars(token, business_connection_id, owned_gift_id):
+    method_url = 'convertGiftToStars'
+    payload = {'business_connection_id': business_connection_id, 'owned_gift_id': owned_gift_id}
+    return _make_request(token, method_url, params=payload, method='post')
+
 def create_new_sticker_set(
         token, user_id, name, title, stickers, sticker_type=None, needs_repainting=None):
     method_url = 'createNewStickerSet'

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -2105,7 +2105,7 @@ def post_story(token, business_connection_id, content, active_period, caption=No
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
     if areas:
-        payload['areas'] = json.dumps([area.to_json() for area in areas])
+        payload['areas'] = json.dumps([area.to_dict() for area in areas])
     if post_to_chat_page is not None:
         payload['post_to_chat_page'] = post_to_chat_page
     if protect_content is not None:
@@ -2127,7 +2127,7 @@ def edit_story(token, business_connection_id, story_id, content, caption=None, p
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
     if areas:
-        payload['areas'] = json.dumps([area.to_json() for area in areas])
+        payload['areas'] = json.dumps([area.to_dict() for area in areas])
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 def delete_story(token, business_connection_id, story_id):

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -2025,6 +2025,11 @@ def set_business_account_bio(token, business_connection_id, bio):
     return _make_request(token, method_url, params=payload, method='post')
 
 
+def set_business_account_gift_settings(token, business_connection_id, show_gift_button, accepted_gift_types):
+    method_url = 'setBusinessAccountGiftSettings'
+    payload = {'business_connection_id': business_connection_id, 'show_gift_button': show_gift_button, 'accepted_gift_types': json.dumps(accepted_gift_types)}
+    return _make_request(token, method_url, params=payload, method='post')
+
 def set_sticker_emoji_list(token, sticker, emoji_list):
     method_url = 'setStickerEmojiList'
     payload = {'sticker': sticker, 'emoji_list': json.dumps(emoji_list)}

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -2045,6 +2045,29 @@ def transfer_business_account_stars(token, business_connection_id, star_count):
     payload = {'business_connection_id': business_connection_id, 'star_count': star_count}
     return _make_request(token, method_url, params=payload, method='post')
 
+def get_business_account_gifts(token, business_connection_id, exclude_unsaved=None, exclude_saved=None,
+                                 exclude_unlimited=None, exclude_limited=None, exclude_unique=None,
+                                 sort_by_price=None, offset=None, limit=None):
+     method_url = 'getBusinessAccountGifts'
+     payload = {'business_connection_id': business_connection_id}
+     if exclude_unsaved is not None:
+          payload['exclude_unsaved'] = exclude_unsaved
+     if exclude_saved is not None:
+          payload['exclude_saved'] = exclude_saved
+     if exclude_unlimited is not None:
+          payload['exclude_unlimited'] = exclude_unlimited
+     if exclude_limited is not None:
+          payload['exclude_limited'] = exclude_limited
+     if exclude_unique is not None:
+          payload['exclude_unique'] = exclude_unique
+     if sort_by_price is not None:
+          payload['sort_by_price'] = sort_by_price
+     if offset is not None:
+          payload['offset'] = offset
+     if limit is not None:
+          payload['limit'] = limit
+     return _make_request(token, method_url, params=payload)
+
 def create_new_sticker_set(
         token, user_id, name, title, stickers, sticker_type=None, needs_repainting=None):
     method_url = 'createNewStickerSet'

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7821,7 +7821,7 @@ class AsyncTeleBot:
         """
         return await asyncio_helper.remove_user_verification(self.token, user_id)
 
-    async def remove_chat_verification(self, chat_id: Union[int, str]) -> bool:
+    async def remove_chat_verification(self, chat_id: int) -> bool:
         """
         Removes verification from a chat that is currently verified on behalf of the organization represented by the bot. Returns True on success.
 
@@ -7890,7 +7890,7 @@ class AsyncTeleBot:
         :return: Returns True on success.
         :rtype: :obj:`bool`
         """
-        return await asyncio_helper.set_business_account_name(self.token, business_connection_id, first_name, last_name)
+        return await asyncio_helper.set_business_account_name(self.token, business_connection_id, first_name, last_name=last_name)
 
     async def set_business_account_username(self, business_connection_id: str, username: Optional[str]=None) -> bool:
         """
@@ -7908,7 +7908,7 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
 
         """
-        return await asyncio_helper.set_business_account_username(self.token, business_connection_id, username)
+        return await asyncio_helper.set_business_account_username(self.token, business_connection_id, username=username)
 
     async def set_business_account_bio(self, business_connection_id: str, bio: Optional[str]=None) -> bool:
         """
@@ -7925,7 +7925,7 @@ class AsyncTeleBot:
         :return: Returns True on success.
         :rtype: :obj:`bool`
         """
-        return await asyncio_helper.set_business_account_bio(self.token, business_connection_id, bio)
+        return await asyncio_helper.set_business_account_bio(self.token, business_connection_id, bio=bio)
     
     async def set_business_account_gift_settings(
             self, business_connection_id: str, show_gift_button: bool, accepted_gift_types: types.AcceptedGiftTypes) -> bool:
@@ -8091,7 +8091,7 @@ class AsyncTeleBot:
 
     async def transfer_gift(
             self, business_connection_id: str, owned_gift_id: str,
-            new_owner_chat_id: Union[int, str],
+            new_owner_chat_id: int,
             star_count: Optional[int]=None) -> bool:
         """
         Transfers an owned unique gift to another user. Requires the can_transfer_and_upgrade_gifts business bot right.
@@ -8106,7 +8106,7 @@ class AsyncTeleBot:
         :type owned_gift_id: :obj:`str`
 
         :param new_owner_chat_id: Unique identifier of the chat which will own the gift. The chat must be active in the last 24 hours.
-        :type new_owner_chat_id: :obj:`int` | :obj:`str`
+        :type new_owner_chat_id: :obj:`int`
 
         :param star_count: The amount of Telegram Stars that will be paid for the transfer from the business account balance.
             If positive, then the can_transfer_stars business bot right is required.
@@ -8117,7 +8117,7 @@ class AsyncTeleBot:
         """
         return await asyncio_helper.transfer_gift(
             self.token, business_connection_id, owned_gift_id,
-            new_owner_chat_id=new_owner_chat_id,
+            new_owner_chat_id,
             star_count=star_count
         )
     

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7980,7 +7980,65 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.transfer_business_account_stars(self.token, business_connection_id, star_count)
+    
+    async def get_business_account_gifts(
+            self, business_connection_id: str,
+            exclude_unsaved: Optional[bool]=None,
+            exclude_saved: Optional[bool]=None,
+            exclude_unlimited: Optional[bool]=None,
+            exclude_limited: Optional[bool]=None,
+            exclude_unique: Optional[bool]=None,
+            sort_by_price: Optional[bool]=None,
+            offset: Optional[str]=None,
+            limit: Optional[int]=None) -> types.OwnedGifts:
+        """
+        Returns the gifts received and owned by a managed business account. Requires the can_view_gifts_and_stars business bot right. Returns OwnedGifts on success.
+        
+        Telegram documentation: https://core.telegram.org/bots/api#getbusinessaccountgifts
 
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param exclude_unsaved: Pass True to exclude gifts that aren't saved to the account's profile page
+        :type exclude_unsaved: :obj:`bool`
+
+        :param exclude_saved: Pass True to exclude gifts that are saved to the account's profile page
+        :type exclude_saved: :obj:`bool`
+
+        :param exclude_unlimited: Pass True to exclude gifts that can be purchased an unlimited number of times
+        :type exclude_unlimited: :obj:`bool`
+
+        :param exclude_limited: Pass True to exclude gifts that can be purchased a limited number of times
+        :type exclude_limited: :obj:`bool`
+
+        :param exclude_unique: Pass True to exclude unique gifts
+        :type exclude_unique: :obj:`bool`
+
+        :param sort_by_price: Pass True to sort results by gift price instead of send date. Sorting is applied before pagination.
+        :type sort_by_price: :obj:`bool`
+
+        :param offset: Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results
+        :type offset: :obj:`str`
+
+        :param limit: The maximum number of gifts to be returned; 1-100. Defaults to 100
+        :type limit: :obj:`int`
+
+        :return: On success, a OwnedGifts object is returned.
+        :rtype: :class:`telebot.types.OwnedGifts`
+        """
+        return types.OwnedGifts.de_json(
+            await asyncio_helper.get_business_account_gifts(
+                self.token, business_connection_id,
+                exclude_unsaved=exclude_unsaved,
+                exclude_saved=exclude_saved,
+                exclude_unlimited=exclude_unlimited,
+                exclude_limited=exclude_limited,
+                exclude_unique=exclude_unique,
+                sort_by_price=sort_by_price,
+                offset=offset,
+                limit=limit
+            )
+        )
 
     async def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7963,6 +7963,24 @@ class AsyncTeleBot:
         return types.StarAmount.de_json(
             await asyncio_helper.get_business_account_star_balance(self.token, business_connection_id)
         )
+    
+    async def transfer_business_account_stars(self, business_connection_id: str, star_count: int) -> bool:
+        """
+        Transfers Telegram Stars from the business account balance to the bot's balance. Requires the can_transfer_stars business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#transferbusinessaccountstars
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param star_count: Number of Telegram Stars to transfer; 1-10000
+        :type star_count: :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.transfer_business_account_stars(self.token, business_connection_id, star_count)
+
 
     async def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -8241,6 +8241,48 @@ class AsyncTeleBot:
         """
         return await asyncio_helper.delete_story(self.token, business_connection_id, story_id)
     
+    async def set_business_account_profile_photo(
+            self, business_connection_id: str, photo: types.InputProfilePhoto,
+            is_public: Optional[bool]=None) -> bool:
+        """
+        Changes the profile photo of a managed business account. Requires the can_edit_profile_photo business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountprofilephoto
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param photo: The new profile photo to set
+        :type photo: :class:`telebot.types.InputProfilePhoto`
+
+        :param is_public: Pass True to set the public photo, which will be visible even if the main photo is hidden by the business account's privacy settings. An account can have only one public photo.
+        :type is_public: :obj:`bool`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.set_business_account_profile_photo(self.token, business_connection_id, photo, is_public=is_public)
+
+
+    async def remove_business_account_profile_photo(
+            self, business_connection_id: str,
+            is_public: Optional[bool]=None) -> bool:
+        """
+        Removes the current profile photo of a managed business account. Requires the can_edit_profile_photo business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#removebusinessaccountprofilephoto
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param is_public: Pass True to remove the public photo, which is visible even if the main photo is hidden by the business account's privacy settings. After the main photo is removed, the previous profile photo (if present) becomes the main photo.
+        :type is_public: :obj:`bool`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.remove_business_account_profile_photo(self.token, business_connection_id, is_public=is_public)
+    
     async def gift_premium_subscription(
             self, user_id: int, month_count: int, star_count: int,
             text: Optional[str]=None, text_parse_mode: Optional[str]=None,

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7835,6 +7835,98 @@ class AsyncTeleBot:
         """
         return await asyncio_helper.remove_chat_verification(self.token, chat_id)
     
+    async def read_business_message(self, business_connection_id: str, chat_id: Union[int, str], message_id: int) -> bool:
+        """
+        Marks incoming message as read on behalf of a business account. Requires the can_read_messages business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#readbusinessmessage
+
+        :param business_connection_id: Unique identifier of the business connection on behalf of which to read the message
+        :type business_connection_id: :obj:`str`
+
+        :param chat_id: Unique identifier of the chat in which the message was received. The chat must have been active in the last 24 hours.
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param message_id: Unique identifier of the message to mark as read
+        :type message_id: :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.read_business_message(self.token, business_connection_id, chat_id, message_id)
+
+    async def delete_business_messages(self, business_connection_id: str, message_ids: List[int]) -> bool:
+        """
+        Delete messages on behalf of a business account. Requires the can_delete_outgoing_messages business bot right to delete messages sent by the bot itself, or the can_delete_all_messages business bot right to delete any message. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#deletebusinessmessages
+
+        :param business_connection_id: Unique identifier of the business connection on behalf of which to delete the messages
+        :type business_connection_id: :obj:`str`
+
+        :param message_ids: A JSON-serialized list of 1-100 identifiers of messages to delete. All messages must be from the same chat. See deleteMessage for limitations on which messages can be deleted
+        :type message_ids: :obj:`list` of :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.delete_business_messages(self.token, business_connection_id, message_ids)
+
+    async def set_business_account_name(self, business_connection_id: str, first_name: str, last_name: Optional[str]=None) -> bool:
+        """
+        Changes the first and last name of a managed business account. Requires the can_change_name business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountname
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param first_name: The new value of the first name for the business account; 1-64 characters
+        :type first_name: :obj:`str`
+
+        :param last_name: The new value of the last name for the business account; 0-64 characters
+        :type last_name: :obj:`str`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.set_business_account_name(self.token, business_connection_id, first_name, last_name)
+
+    async def set_business_account_username(self, business_connection_id: str, username: Optional[str]=None) -> bool:
+        """
+        Changes the username of a managed business account. Requires the can_change_username business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountusername
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param username: The new value of the username for the business account; 0-32 characters
+        :type username: :obj:`str`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+
+        """
+        return await asyncio_helper.set_business_account_username(self.token, business_connection_id, username)
+
+    async def set_business_account_bio(self, business_connection_id: str, bio: Optional[str]=None) -> bool:
+        """
+        Changes the bio of a managed business account. Requires the can_change_bio business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountbio
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param bio: The new value of the bio for the business account; 0-140 characters
+        :type bio: :obj:`str`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.set_business_account_bio(self.token, business_connection_id, bio)
+    
     async def get_available_gifts(self) -> types.Gifts:
         """
         Returns the list of gifts that can be sent by the bot to users. Requires no parameters. Returns a Gifts object.

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -8240,6 +8240,42 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.delete_story(self.token, business_connection_id, story_id)
+    
+    async def gift_premium_subscription(
+            self, user_id: int, month_count: int, star_count: int,
+            text: Optional[str]=None, text_parse_mode: Optional[str]=None,
+            text_entities: Optional[List[types.MessageEntity]]=None) -> bool:
+        """
+        Gifts a Telegram Premium subscription to the given user. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#giftpremiumsubscription
+
+        :param user_id: Unique identifier of the target user who will receive a Telegram Premium subscription
+        :type user_id: :obj:`int`
+
+        :param month_count: Number of months the Telegram Premium subscription will be active for the user; must be one of 3, 6, or 12
+        :type month_count: :obj:`int`
+
+        :param star_count: Number of Telegram Stars to pay for the Telegram Premium subscription; must be 1000 for 3 months, 1500 for 6 months, and 2500 for 12 months
+        :type star_count: :obj:`int`
+
+        :param text: Text that will be shown along with the service message about the subscription; 0-128 characters
+        :type text: :obj:`str`
+
+        :param text_parse_mode: Mode for parsing entities in the text. See formatting options for more details. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored.
+        :type text_parse_mode: :obj:`str`
+
+        :param text_entities: A JSON-serialized list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored.
+        :type text_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.gift_premium_subscription(
+            self.token, user_id, month_count, star_count,
+            text=text, text_parse_mode=text_parse_mode,
+            text_entities=text_entities
+        )
 
     async def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7948,6 +7948,22 @@ class AsyncTeleBot:
         """
         return await asyncio_helper.set_business_account_gift_settings(self.token, business_connection_id, show_gift_button, accepted_gift_types)
     
+    async def get_business_account_star_balance(self, business_connection_id: str) -> types.StarAmount:
+        """
+        Returns the amount of Telegram Stars owned by a managed business account. Requires the can_view_gifts_and_stars business bot right. Returns StarAmount on success.
+        
+        Telegram documentation: https://core.telegram.org/bots/api#getbusinessaccountstarbalance
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :return: On success, a StarAmount object is returned.
+        :rtype: :class:`telebot.types.StarAmount`
+        """
+        return types.StarAmount.de_json(
+            await asyncio_helper.get_business_account_star_balance(self.token, business_connection_id)
+        )
+
     async def get_available_gifts(self) -> types.Gifts:
         """
         Returns the list of gifts that can be sent by the bot to users. Requires no parameters. Returns a Gifts object.

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -8056,6 +8056,70 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.convert_gift_to_stars(self.token, business_connection_id, owned_gift_id)
+    
+    async def upgrade_gift(
+            self, business_connection_id: str, owned_gift_id: str,
+            keep_original_details: Optional[bool]=None,
+            star_count: Optional[int]=None) -> bool:
+        """
+        Upgrades a given regular gift to a unique gift. Requires the can_transfer_and_upgrade_gifts business bot right.
+        Additionally requires the can_transfer_stars business bot right if the upgrade is paid. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#upgradegift
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param owned_gift_id: Unique identifier of the regular gift that should be upgraded to a unique one
+        :type owned_gift_id: :obj:`str`
+
+        :param keep_original_details: Pass True to keep the original gift text, sender and receiver in the upgraded gift
+        :type keep_original_details: :obj:`bool`
+
+        :param star_count: The amount of Telegram Stars that will be paid for the upgrade from the business account balance.
+            If gift.prepaid_upgrade_star_count > 0, then pass 0, otherwise, the can_transfer_stars business bot right is required and gift.upgrade_star_count must be passed.
+        :type star_count: :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.upgrade_gift(
+            self.token, business_connection_id, owned_gift_id,
+            keep_original_details=keep_original_details,
+            star_count=star_count
+        )
+
+    async def transfer_gift(
+            self, business_connection_id: str, owned_gift_id: str,
+            new_owner_chat_id: Union[int, str],
+            star_count: Optional[int]=None) -> bool:
+        """
+        Transfers an owned unique gift to another user. Requires the can_transfer_and_upgrade_gifts business bot right.
+        Requires can_transfer_stars business bot right if the transfer is paid. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#transfergift
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param owned_gift_id: Unique identifier of the regular gift that should be transferred
+        :type owned_gift_id: :obj:`str`
+
+        :param new_owner_chat_id: Unique identifier of the chat which will own the gift. The chat must be active in the last 24 hours.
+        :type new_owner_chat_id: :obj:`int` | :obj:`str`
+
+        :param star_count: The amount of Telegram Stars that will be paid for the transfer from the business account balance.
+            If positive, then the can_transfer_stars business bot right is required.
+        :type star_count: :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.transfer_gift(
+            self.token, business_connection_id, owned_gift_id,
+            new_owner_chat_id=new_owner_chat_id,
+            star_count=star_count
+        )
 
     async def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7927,6 +7927,27 @@ class AsyncTeleBot:
         """
         return await asyncio_helper.set_business_account_bio(self.token, business_connection_id, bio)
     
+    async def set_business_account_gift_settings(
+            self, business_connection_id: str, show_gift_button: bool, accepted_gift_types: types.AcceptedGiftTypes) -> bool:
+        """
+        Changes the privacy settings pertaining to incoming gifts in a managed business account. Requires the can_change_gift_settings business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#setbusinessaccountgiftsettings
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param show_gift_button: Pass True, if a button for sending a gift to the user or by the business account must always be shown in the input field
+        :type show_gift_button: :obj:`bool`
+
+        :param accepted_gift_types: Types of gifts accepted by the business account
+        :type accepted_gift_types: :class:`telebot.types.AcceptedGiftTypes`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.set_business_account_gift_settings(self.token, business_connection_id, show_gift_button, accepted_gift_types)
+    
     async def get_available_gifts(self) -> types.Gifts:
         """
         Returns the list of gifts that can be sent by the bot to users. Requires no parameters. Returns a Gifts object.
@@ -7938,6 +7959,7 @@ class AsyncTeleBot:
         """
 
         return types.Gifts.de_json(await asyncio_helper.get_available_gifts(self.token))
+
     
     async def replace_sticker_in_set(self, user_id: int, name: str, old_sticker: str, sticker: types.InputSticker) -> bool:
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -8120,6 +8120,126 @@ class AsyncTeleBot:
             new_owner_chat_id=new_owner_chat_id,
             star_count=star_count
         )
+    
+    async def post_story(
+            self, business_connection_id: str, content: types.InputStoryContent,
+            active_period: int, caption: Optional[str]=None,
+            parse_mode: Optional[str]=None,
+            caption_entities: Optional[List[types.MessageEntity]]=None,
+            areas: Optional[List[types.StoryArea]]=None,
+            post_to_chat_page: Optional[bool]=None,
+            protect_content: Optional[bool]=None) -> types.Story:
+
+        """
+        Posts a story on behalf of a managed business account. Requires the can_manage_stories business bot right. Returns Story on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#poststory
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param content: Content of the story
+        :type content: :class:`telebot.types.InputStoryContent`
+
+        :param active_period: Period after which the story is moved to the archive, in seconds; must be one of 6 * 3600, 12 * 3600, 86400, or 2 * 86400
+        :type active_period: :obj:`int`
+
+        :param caption: Caption of the story, 0-2048 characters after entities parsing
+        :type caption: :obj:`str`
+
+        :param parse_mode: Mode for parsing entities in the story caption. See formatting options for more details.
+        :type parse_mode: :obj:`str`
+
+        :param caption_entities: A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
+        :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
+
+        :param areas: A JSON-serialized list of clickable areas to be shown on the story
+        :type areas: :obj:`list` of :class:`telebot.types.StoryArea`
+
+        :param post_to_chat_page: Pass True to keep the story accessible after it expires
+        :type post_to_chat_page: :obj:`bool`
+
+        :param protect_content: Pass True if the content of the story must be protected from forwarding and screenshotting
+        :type protect_content: :obj:`bool`
+
+        :return: On success, a Story object is returned.
+        :rtype: :class:`telebot.types.Story`
+        """
+        return types.Story.de_json(
+            await asyncio_helper.post_story(
+                self.token, business_connection_id, content,
+                active_period, caption=caption,
+                parse_mode=parse_mode,
+                caption_entities=caption_entities,
+                areas=areas,
+                post_to_chat_page=post_to_chat_page,
+                protect_content=protect_content
+            )
+        )
+
+    async def edit_story(
+            self, business_connection_id: str, story_id: int,
+            content: types.InputStoryContent,
+            caption: Optional[str]=None,
+            parse_mode: Optional[str]=None,
+            caption_entities: Optional[List[types.MessageEntity]]=None,
+            areas: Optional[List[types.StoryArea]]=None) -> types.Story:
+        """
+        Edits a story previously posted by the bot on behalf of a managed business account. Requires the can_manage_stories business bot right. Returns Story on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#editstory
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param story_id: Unique identifier of the story to edit
+        :type story_id: :obj:`int`
+
+        :param content: Content of the story
+        :type content: :class:`telebot.types.InputStoryContent`
+
+        :param caption: Caption of the story, 0-2048 characters after entities parsing
+        :type caption: :obj:`str`
+
+        :param parse_mode: Mode for parsing entities in the story caption. See formatting options for more details.
+        :type parse_mode: :obj:`str`
+
+        :param caption_entities: A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
+        :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
+
+        :param areas: A JSON-serialized list of clickable areas to be shown on the story
+        :type areas: :obj:`list` of :class:`telebot.types.StoryArea`
+
+        :return: On success, a Story object is returned.
+        :rtype: :class:`telebot.types.Story`
+
+        """
+        return types.Story.de_json(
+            await asyncio_helper.edit_story(
+                self.token, business_connection_id, story_id,
+                content, caption=caption,
+                parse_mode=parse_mode,
+                caption_entities=caption_entities,
+                areas=areas
+            )
+    )
+
+    async def delete_story(self, business_connection_id: str, story_id: int) -> bool:
+        """
+        Deletes a story previously posted by the bot on behalf of a managed business account. Requires the can_manage_stories business bot right. Returns True on success.
+        
+        Telegram documentation: https://core.telegram.org/bots/api#deletestory
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param story_id: Unique identifier of the story to delete
+        :type story_id: :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.delete_story(self.token, business_connection_id, story_id)
 
     async def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -8039,6 +8039,23 @@ class AsyncTeleBot:
                 limit=limit
             )
         )
+    
+    async def convert_gift_to_stars(self, business_connection_id: str, owned_gift_id: str) -> bool:
+        """
+        Converts a given regular gift to Telegram Stars. Requires the can_convert_gifts_to_stars business bot right. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#convertgifttostars
+
+        :param business_connection_id: Unique identifier of the business connection
+        :type business_connection_id: :obj:`str`
+
+        :param owned_gift_id: Unique identifier of the regular gift that should be converted to Telegram Stars
+        :type owned_gift_id: :obj:`str`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.convert_gift_to_stars(self.token, business_connection_id, owned_gift_id)
 
     async def get_available_gifts(self) -> types.Gifts:
         """

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1993,20 +1993,24 @@ async def set_business_account_name(token, business_connection_id, first_name, l
     return await _process_request(token, method_url, params=payload, method='post')
 
 
-async def set_business_account_username(token, business_connection_id, username):
+async def set_business_account_username(token, business_connection_id, username=None):
     method_url = 'setBusinessAccountUsername'
-    payload = {'business_connection_id': business_connection_id, 'username': username}
+    payload = {'business_connection_id': business_connection_id}
+    if username is not None:
+        payload['username'] = username
     return await _process_request(token, method_url, params=payload, method='post')
 
 
-async def set_business_account_bio(token, business_connection_id, bio):
+async def set_business_account_bio(token, business_connection_id, bio=None):
     method_url = 'setBusinessAccountBio'
-    payload = {'business_connection_id': business_connection_id, 'bio': bio}
+    payload = {'business_connection_id': business_connection_id}
+    if bio:
+        payload['bio'] = bio
     return await _process_request(token, method_url, params=payload, method='post')
 
 async def set_business_account_gift_settings(token, business_connection_id, show_gift_button, accepted_gift_types):
     method_url = 'setBusinessAccountGiftSettings'
-    payload = {'business_connection_id': business_connection_id, 'show_gift_button': show_gift_button, 'accepted_gift_types': json.dumps(accepted_gift_types)}
+    payload = {'business_connection_id': business_connection_id, 'show_gift_button': show_gift_button, 'accepted_gift_types': accepted_gift_types.to_json()}
     return await _process_request(token, method_url, params=payload, method='post')
 
 async def get_business_account_star_balance(token, business_connection_id):

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -2009,6 +2009,11 @@ async def set_business_account_gift_settings(token, business_connection_id, show
     payload = {'business_connection_id': business_connection_id, 'show_gift_button': show_gift_button, 'accepted_gift_types': json.dumps(accepted_gift_types)}
     return await _process_request(token, method_url, params=payload, method='post')
 
+async def get_business_account_star_balance(token, business_connection_id):
+    method_url = 'getBusinessAccountStarBalance'
+    payload = {'business_connection_id': business_connection_id}
+    return _process_request(token, method_url, params=payload)
+
 
 async def get_available_gifts(token):
     method_url = 'getAvailableGifts'

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1972,6 +1972,39 @@ async def remove_chat_verification(token, chat_id):
     payload = {'chat_id': chat_id}
     return await _process_request(token, method_url, params=payload, method='post')
 
+
+async def read_business_message(token, business_connection_id, chat_id, message_id):
+    method_url = 'readBusinessMessage'
+    payload = {'business_connection_id': business_connection_id, 'chat_id': chat_id, 'message_id': message_id}
+    return await _process_request(token, method_url, params=payload, method='post')
+
+
+async def delete_business_messages(token, business_connection_id, message_ids):
+    method_url = 'deleteBusinessMessages'
+    payload = {'business_connection_id': business_connection_id, 'message_ids': json.dumps(message_ids)}
+    return await _process_request(token, method_url, params=payload, method='post')
+
+
+async def set_business_account_name(token, business_connection_id, first_name, last_name=None):
+    method_url = 'setBusinessAccountName'
+    payload = {'business_connection_id': business_connection_id, 'first_name': first_name}
+    if last_name:
+        payload['last_name'] = last_name
+    return await _process_request(token, method_url, params=payload, method='post')
+
+
+async def set_business_account_username(token, business_connection_id, username):
+    method_url = 'setBusinessAccountUsername'
+    payload = {'business_connection_id': business_connection_id, 'username': username}
+    return await _process_request(token, method_url, params=payload, method='post')
+
+
+async def set_business_account_bio(token, business_connection_id, bio):
+    method_url = 'setBusinessAccountBio'
+    payload = {'business_connection_id': business_connection_id, 'bio': bio}
+    return await _process_request(token, method_url, params=payload, method='post')
+
+
 async def get_available_gifts(token):
     method_url = 'getAvailableGifts'
     return await _process_request(token, method_url)

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -2063,6 +2063,51 @@ async def transfer_gift(token, business_connection_id, owned_gift_id, new_owner_
         payload['star_count'] = star_count
     return await _process_request(token, method_url, params=payload, method='post')
 
+async def post_story(token, business_connection_id, content, active_period, caption=None, parse_mode=None,
+             caption_entities=None, areas=None, post_to_chat_page=None, protect_content=None):
+    method_url = 'postStory'
+    payload = {'business_connection_id': business_connection_id, 'active_period': active_period}
+    
+    content_json, files = content.convert_input_story()
+    payload['content'] = content_json
+    
+    if caption:
+        payload['caption'] = caption
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
+    if caption_entities:
+        payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
+    if areas:
+        payload['areas'] = json.dumps([area.to_json() for area in areas])
+    if post_to_chat_page is not None:
+        payload['post_to_chat_page'] = post_to_chat_page
+    if protect_content is not None:
+        payload['protect_content'] = protect_content
+    return await _process_request(token, method_url, params=payload, files=files, method='post')
+
+async def edit_story(token, business_connection_id, story_id, content, caption=None, parse_mode=None,
+                caption_entities=None, areas=None):
+    method_url = 'editStory'
+    payload = {'business_connection_id': business_connection_id, 'story_id': story_id}
+    
+    content_json, files = content.convert_input_story()
+    payload['content'] = content_json
+    
+    if caption:
+        payload['caption'] = caption
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
+    if caption_entities:
+        payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
+    if areas:
+        payload['areas'] = json.dumps([area.to_json() for area in areas])
+    return await _process_request(token, method_url, params=payload, files=files, method='post')
+
+async def delete_story(token, business_connection_id, story_id):
+    method_url = 'deleteStory'
+    payload = {'business_connection_id': business_connection_id, 'story_id': story_id}
+    return await _process_request(token, method_url, params=payload, method='post')
+
 async def get_available_gifts(token):
     method_url = 'getAvailableGifts'
     return await _process_request(token, method_url)

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -2019,6 +2019,29 @@ async def transfer_business_account_stars(token, business_connection_id, star_co
     payload = {'business_connection_id': business_connection_id, 'star_count': star_count}
     return await _process_request(token, method_url, params=payload, method='post')
 
+async def get_business_account_gifts(token, business_connection_id, exclude_unsaved=None, exclude_saved=None,
+                                 exclude_unlimited=None, exclude_limited=None, exclude_unique=None,
+                                 sort_by_price=None, offset=None, limit=None):
+     method_url = 'getBusinessAccountGifts'
+     payload = {'business_connection_id': business_connection_id}
+     if exclude_unsaved is not None:
+          payload['exclude_unsaved'] = exclude_unsaved
+     if exclude_saved is not None:
+          payload['exclude_saved'] = exclude_saved
+     if exclude_unlimited is not None:
+          payload['exclude_unlimited'] = exclude_unlimited
+     if exclude_limited is not None:
+          payload['exclude_limited'] = exclude_limited
+     if exclude_unique is not None:
+          payload['exclude_unique'] = exclude_unique
+     if sort_by_price is not None:
+          payload['sort_by_price'] = sort_by_price
+     if offset is not None:
+          payload['offset'] = offset
+     if limit is not None:
+          payload['limit'] = limit
+     return await _process_request(token, method_url, params=payload)
+
 async def get_available_gifts(token):
     method_url = 'getAvailableGifts'
     return await _process_request(token, method_url)

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -2004,6 +2004,11 @@ async def set_business_account_bio(token, business_connection_id, bio):
     payload = {'business_connection_id': business_connection_id, 'bio': bio}
     return await _process_request(token, method_url, params=payload, method='post')
 
+async def set_business_account_gift_settings(token, business_connection_id, show_gift_button, accepted_gift_types):
+    method_url = 'setBusinessAccountGiftSettings'
+    payload = {'business_connection_id': business_connection_id, 'show_gift_button': show_gift_button, 'accepted_gift_types': json.dumps(accepted_gift_types)}
+    return await _process_request(token, method_url, params=payload, method='post')
+
 
 async def get_available_gifts(token):
     method_url = 'getAvailableGifts'

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -2120,6 +2120,22 @@ async def gift_premium_subscription(token, user_id, month_count, star_count, tex
         payload['text_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(text_entities))
     return await _process_request(token, method_url, params=payload, method='post')
 
+async def set_business_account_profile_photo(token, business_connection_id, photo, is_public=None):
+    method_url = 'setBusinessAccountProfilePhoto'
+    payload = {'business_connection_id': business_connection_id}
+    photo_json, files = photo.convert_input_profile_photo()
+    payload['photo'] = photo_json
+    if is_public is not None:
+        payload['is_public'] = is_public
+    return await _process_request(token, method_url, params=payload, files=files, method='post')
+
+async def remove_business_account_profile_photo(token, business_connection_id, is_public=None):
+    method_url = 'removeBusinessAccountProfilePhoto'
+    payload = {'business_connection_id': business_connection_id}
+    if is_public is not None:
+        payload['is_public'] = is_public
+    return await _process_request(token, method_url, params=payload, method='post')
+
 
 async def get_available_gifts(token):
     method_url = 'getAvailableGifts'

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -2078,7 +2078,7 @@ async def post_story(token, business_connection_id, content, active_period, capt
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
     if areas:
-        payload['areas'] = json.dumps([area.to_json() for area in areas])
+        payload['areas'] = json.dumps([area.to_dict() for area in areas])
     if post_to_chat_page is not None:
         payload['post_to_chat_page'] = post_to_chat_page
     if protect_content is not None:
@@ -2100,7 +2100,7 @@ async def edit_story(token, business_connection_id, story_id, content, caption=N
     if caption_entities:
         payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
     if areas:
-        payload['areas'] = json.dumps([area.to_json() for area in areas])
+        payload['areas'] = json.dumps([area.to_dict() for area in areas])
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 async def delete_story(token, business_connection_id, story_id):

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -2108,6 +2108,19 @@ async def delete_story(token, business_connection_id, story_id):
     payload = {'business_connection_id': business_connection_id, 'story_id': story_id}
     return await _process_request(token, method_url, params=payload, method='post')
 
+async def gift_premium_subscription(token, user_id, month_count, star_count, text=None, text_parse_mode=None,
+                            text_entities=None):
+    method_url = 'giftPremiumSubscription'
+    payload = {'user_id': user_id, 'month_count': month_count, 'star_count': star_count}
+    if text:
+        payload['text'] = text
+    if text_parse_mode:
+        payload['text_parse_mode'] = text_parse_mode
+    if text_entities:
+        payload['text_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(text_entities))
+    return await _process_request(token, method_url, params=payload, method='post')
+
+
 async def get_available_gifts(token):
     method_url = 'getAvailableGifts'
     return await _process_request(token, method_url)

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -2014,6 +2014,10 @@ async def get_business_account_star_balance(token, business_connection_id):
     payload = {'business_connection_id': business_connection_id}
     return _process_request(token, method_url, params=payload)
 
+async def transfer_business_account_stars(token, business_connection_id, star_count):
+    method_url = 'transferBusinessAccountStars'
+    payload = {'business_connection_id': business_connection_id, 'star_count': star_count}
+    return await _process_request(token, method_url, params=payload, method='post')
 
 async def get_available_gifts(token):
     method_url = 'getAvailableGifts'

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -2042,6 +2042,11 @@ async def get_business_account_gifts(token, business_connection_id, exclude_unsa
           payload['limit'] = limit
      return await _process_request(token, method_url, params=payload)
 
+async def convert_gift_to_stars(token, business_connection_id, owned_gift_id):
+    method_url = 'convertGiftToStars'
+    payload = {'business_connection_id': business_connection_id, 'owned_gift_id': owned_gift_id}
+    return await _process_request(token, method_url, params=payload, method='post')
+
 async def get_available_gifts(token):
     method_url = 'getAvailableGifts'
     return await _process_request(token, method_url)

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -2047,6 +2047,22 @@ async def convert_gift_to_stars(token, business_connection_id, owned_gift_id):
     payload = {'business_connection_id': business_connection_id, 'owned_gift_id': owned_gift_id}
     return await _process_request(token, method_url, params=payload, method='post')
 
+async def upgrade_gift(token, business_connection_id, owned_gift_id, keep_original_details=None, star_count=None):
+    method_url = 'upgradeGift'
+    payload = {'business_connection_id': business_connection_id, 'owned_gift_id': owned_gift_id}
+    if keep_original_details is not None:
+        payload['keep_original_details'] = keep_original_details
+    if star_count is not None:
+        payload['star_count'] = star_count
+    return await _process_request(token, method_url, params=payload, method='post')
+
+async def transfer_gift(token, business_connection_id, owned_gift_id, new_owner_chat_id, star_count=None):
+    method_url = 'transferGift'
+    payload = {'business_connection_id': business_connection_id, 'owned_gift_id': owned_gift_id, 'new_owner_chat_id': new_owner_chat_id}
+    if star_count is not None:
+        payload['star_count'] = star_count
+    return await _process_request(token, method_url, params=payload, method='post')
+
 async def get_available_gifts(token):
     method_url = 'getAvailableGifts'
     return await _process_request(token, method_url)

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -10551,6 +10551,11 @@ class TransactionPartnerUser(TransactionPartner):
     :param type: Type of the transaction partner, always “user”
     :type type: :obj:`str`
 
+    :param transaction_type: Type of the transaction, currently one of “invoice_payment” for payments via invoices,
+        “paid_media_payment” for payments for paid media, “gift_purchase” for gifts sent by the bot, “premium_purchase” for Telegram Premium subscriptions
+        gifted by the bot, “business_account_transfer” for direct transfers from managed business accounts
+    :type transaction_type: :obj:`str`
+
     :param user: Information about the user
     :type user: :class:`User`
 
@@ -10577,7 +10582,8 @@ class TransactionPartnerUser(TransactionPartner):
     """
 
     def __init__(self, type, user, affiliate=None, invoice_payload=None, paid_media: Optional[List[PaidMedia]] = None, 
-                    subscription_period=None, gift: Optional[Gift] = None, premium_subscription_duration: Optional[int] = None, **kwargs):
+                    subscription_period=None, gift: Optional[Gift] = None, premium_subscription_duration: Optional[int] = None, 
+                    transaction_type: Optional[str] = None, **kwargs):
         self.type: str = type
         self.user: User = user
         self.affiliate: Optional[AffiliateInfo] = affiliate
@@ -10586,6 +10592,7 @@ class TransactionPartnerUser(TransactionPartner):
         self.subscription_period: Optional[int] = subscription_period
         self.gift: Optional[Gift] = gift
         self.premium_subscription_duration: Optional[int] = premium_subscription_duration
+        self.transaction_type: Optional[str] = transaction_type
 
     @classmethod
     def de_json(cls, json_string):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -11773,6 +11773,96 @@ class UniqueGiftBackdrop(JsonDeserializable):
         obj = cls.check_json(json_string)
         obj['colors'] = UniqueGiftBackdropColors.de_json(obj['colors'])
         return cls(**obj)
+
+class InputStoryContent(JsonSerializable):
+    """
+    This object describes the content of a story to post. Currently, it can be one of
+    InputStoryContentPhoto
+    InputStoryContentVideo
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputstorycontent
+
+    """
+
+
+class InputStoryContentPhoto(InputStoryContent):
+    """
+    This object describes a photo to post as a story.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputstorycontentphoto
+
+    :param photo: The photo to post as a story. The photo must be of the size 1080x1920 and must not exceed 10 MB. The photo can't be reused and can only be uploaded as a new file, so you can pass “attach://<file_attach_name>” if the photo was uploaded using multipart/form-data under <file_attach_name>. More information on Sending Files
+    :type photo: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`InputStoryContentPhoto`
+    """
+    def __init__(self, photo: InputFile, **kwargs):
+        self.type: str = "photo"
+        self.photo: InputFile = photo
+        self._photo_name = service_utils.generate_random_token()
+        self._photo_dic = "attach://{}".format(self._photo_name)
+        
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    
+    def to_dict(self):
+        data = {
+            'type': self.type,
+            'photo': self._photo_dic
+        }
+        return data
+    
+    def convert_input_story(self):
+        return self.to_json(), {self._photo_name: self.photo}
     
 
+class InputStoryContentVideo(InputStoryContent):
+    """
+    This object describes a video to post as a story.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputstorycontentvideo
+
+    :param video: The video to post as a story. The video must be of the size 720x1280, streamable, encoded with H.265 codec, with key frames added each second in the MPEG4 format, and must not exceed 30 MB. The video can't be reused and can only be uploaded as a new file, so you can pass “attach://<file_attach_name>” if the video was uploaded using multipart/form-data under <file_attach_name>. More information on Sending Files
+    :type video: :obj:`str`
+
+    :param duration: Optional. Precise duration of the video in seconds; 0-60
+    :type duration: :obj:`float`
+
+    :param cover_frame_timestamp: Optional. Timestamp in seconds of the frame that will be used as the static cover for the story. Defaults to 0.0.
+    :type cover_frame_timestamp: :obj:`float`
+
+    :param is_animation: Optional. Pass True if the video has no sound
+    :type is_animation: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`InputStoryContentVideo`
+    """
+    def __init__(self, video: InputFile, duration: Optional[float] = None, cover_frame_timestamp: Optional[float] = None,
+                    is_animation: Optional[bool] = None, **kwargs):
+        self.type: str = "video"
+        self.video: InputFile = video
+        self._video_name = service_utils.generate_random_token()
+        self._video_dic = "attach://{}".format(self._video_name)
+        self.duration: Optional[float] = duration
+        self.cover_frame_timestamp: Optional[float] = cover_frame_timestamp
+        self.is_animation: Optional[bool] = is_animation
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    
+    def to_dict(self):
+        data = {
+            'type': self.type,
+            'video': self._video_dic
+        }
+        if self.duration is not None:
+            data['duration'] = self.duration
+        if self.cover_frame_timestamp is not None:
+            data['cover_frame_timestamp'] = self.cover_frame_timestamp
+        if self.is_animation is not None:
+            data['is_animation'] = self.is_animation
+        return data
+    def convert_input_story(self):
+        return self.to_json(), {self._video_name: self.video}
+    
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -9736,8 +9736,11 @@ class BusinessConnection(JsonDeserializable):
     :param date: Date the connection was established in Unix time
     :type date: :obj:`int`
 
-    :param can_reply: True, if the bot can act on behalf of the business account in chats that were active in the last 24 hours
+    :param can_reply: Deprecated, use :attr:`can_reply` instead. True, if the bot can reply to messages from the business account
     :type can_reply: :obj:`bool`
+
+    :param rights: Optional. Rights of the business bot
+    :type rights: :class:`BusinessBotRights`
 
     :param is_enabled: True, if the connection is active
     :type is_enabled: :obj:`bool`
@@ -9753,12 +9756,15 @@ class BusinessConnection(JsonDeserializable):
         obj['user'] = User.de_json(obj['user'])
         return cls(**obj)
     
-    def __init__(self, id, user, user_chat_id, date, can_reply, is_enabled, **kwargs):
+    def __init__(self, id, user, user_chat_id, date, can_reply, is_enabled,
+                    rights=None, **kwargs):
         self.id: str = id
         self.user: User = user
         self.user_chat_id: int = user_chat_id
         self.date: int = date
-        self.can_reply: bool = can_reply
+        self.rights: Optional[BusinessBotRights] = rights
+        # Deprecated, use self.rights instead
+        self.can_reply: Optional[bool] = can_reply
         self.is_enabled: bool = is_enabled
 
 
@@ -11270,5 +11276,82 @@ class TransactionPartnerChat(TransactionPartner):
         obj['chat'] = Chat.de_json(obj['chat'])
         if 'gift' in obj:
             obj['gift'] = Gift.de_json(obj['gift'])
+        return cls(**obj)
+    
+
+class BusinessBotRights(JsonDeserializable):
+    """
+    Represents the rights of a business bot.
+
+    Telegram documentation: https://core.telegram.org/bots/api#businessbotrights
+
+    :param can_reply: Optional. True, if the bot can send and edit messages in the private chats that had incoming messages in the last 24 hours
+    :type can_reply: :obj:`bool`
+
+    :param can_read_messages: Optional. True, if the bot can mark incoming private messages as read
+    :type can_read_messages: :obj:`bool`
+
+    :param can_delete_outgoing_messages: Optional. True, if the bot can delete messages sent by the bot
+    :type can_delete_outgoing_messages: :obj:`bool`
+
+    :param can_delete_all_messages: Optional. True, if the bot can delete all private messages in managed chats
+    :type can_delete_all_messages: :obj:`bool`
+
+    :param can_edit_name: Optional. True, if the bot can edit the first and last name of the business account
+    :type can_edit_name: :obj:`bool`
+
+    :param can_edit_bio: Optional. True, if the bot can edit the bio of the business account
+    :type can_edit_bio: :obj:`bool`
+
+    :param can_edit_profile_photo: Optional. True, if the bot can edit the profile photo of the business account
+    :type can_edit_profile_photo: :obj:`bool`
+
+    :param can_edit_username: Optional. True, if the bot can edit the username of the business account
+    :type can_edit_username: :obj:`bool`
+
+    :param can_change_gift_settings: Optional. True, if the bot can change the privacy settings pertaining to gifts for the business account
+    :type can_change_gift_settings: :obj:`bool`
+
+    :param can_view_gifts_and_stars: Optional. True, if the bot can view gifts and the amount of Telegram Stars owned by the business account
+    :type can_view_gifts_and_stars: :obj:`bool`
+
+    :param can_convert_gifts_to_stars: Optional. True, if the bot can convert regular gifts owned by the business account to Telegram Stars
+    :type can_convert_gifts_to_stars: :obj:`bool`
+
+    :param can_transfer_and_upgrade_gifts: Optional. True, if the bot can transfer and upgrade gifts owned by the business account
+    :type can_transfer_and_upgrade_gifts: :obj:`bool`
+
+    :param can_transfer_stars: Optional. True, if the bot can transfer Telegram Stars received by the business account to its own account, or use them to upgrade and transfer gifts
+    :type can_transfer_stars: :obj:`bool`
+
+    :param can_manage_stories: Optional. True, if the bot can post, edit and delete stories on behalf of the business account
+    :type can_manage_stories: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`BusinessBotRights` 
+    """
+    def __init__(self, can_reply=None, can_read_messages=None, can_delete_outgoing_messages=None, can_delete_all_messages=None,
+                    can_edit_name=None, can_edit_bio=None, can_edit_profile_photo=None, can_edit_username=None, 
+                    can_change_gift_settings=None, can_view_gifts_and_stars=None, can_convert_gifts_to_stars=None,
+                    can_transfer_and_upgrade_gifts=None, can_transfer_stars=None, can_manage_stories=None, **kwargs):
+        self.can_reply: Optional[bool] = can_reply
+        self.can_read_messages: Optional[bool] = can_read_messages
+        self.can_delete_outgoing_messages: Optional[bool] = can_delete_outgoing_messages
+        self.can_delete_all_messages: Optional[bool] = can_delete_all_messages
+        self.can_edit_name: Optional[bool] = can_edit_name
+        self.can_edit_bio: Optional[bool] = can_edit_bio
+        self.can_edit_profile_photo: Optional[bool] = can_edit_profile_photo
+        self.can_edit_username: Optional[bool] = can_edit_username
+        self.can_change_gift_settings: Optional[bool] = can_change_gift_settings
+        self.can_view_gifts_and_stars: Optional[bool] = can_view_gifts_and_stars
+        self.can_convert_gifts_to_stars: Optional[bool] = can_convert_gifts_to_stars
+        self.can_transfer_and_upgrade_gifts: Optional[bool] = can_transfer_and_upgrade_gifts
+        self.can_transfer_stars: Optional[bool] = can_transfer_stars
+        self.can_manage_stories: Optional[bool] = can_manage_stories
+    
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
         return cls(**obj)
     

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -12328,3 +12328,88 @@ class PaidMessagePriceChanged(JsonDeserializable):
         obj = cls.check_json(json_string)
         return cls(**obj)
     
+
+class InputProfilePhoto(JsonSerializable):
+    """
+    This object describes a profile photo to set. Currently, it can be one of
+    InputProfilePhotoStatic
+    InputProfilePhotoAnimated
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputprofilephoto
+
+    :return: Instance of the class
+    :rtype: :class:`InputProfilePhoto`
+    """
+
+class InputProfilePhotoStatic(InputProfilePhoto):
+    """
+    This object describes a static profile photo to set.
+    
+    Telegram documentation: https://core.telegram.org/bots/api#inputprofilephotostatic
+
+    :param type: Type of the profile photo, must be static
+    :type type: :obj:`str`
+
+    :param photo: The static profile photo. Profile photos can't be reused and can only be uploaded as a new file, so you can pass “attach://<file_attach_name>” if the photo was uploaded using multipart/form-data under <file_attach_name>. More information on Sending Files
+    :type photo: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`InputProfilePhotoStatic`
+
+    """
+    def __init__(self, photo: InputFile, **kwargs):
+        self.type: str = "static"
+        self.photo: InputFile = photo
+
+        self._photo_name = service_utils.generate_random_token()
+        self._photo_dic = "attach://{}".format(self._photo_name)
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    
+    def to_dict(self):
+        data = {
+            'type': self.type,
+            'photo': self._photo_dic
+        }
+        return data
+    def convert_input_profile_photo(self):
+        return self.to_json(), {self._photo_name: self.photo}
+
+
+class InputProfilePhotoAnimated(InputProfilePhoto):
+    """
+    This object describes an animated profile photo to set.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputprofilephotoanimated
+
+    :param type: Type of the profile photo, must be animated
+    :type type: :obj:`str`
+
+    :param animation: The animated profile photo. Profile photos can't be reused and can only be uploaded as a new file, so you can pass “attach://<file_attach_name>” if the photo was uploaded using multipart/form-data under <file_attach_name>. More information on Sending Files
+    :type animation: :obj:`str`
+
+    :param main_frame_timestamp: Optional. Timestamp in seconds of the frame that will be used as the static profile photo. Defaults to 0.0.
+    :type main_frame_timestamp: :obj:`float`
+
+    :return: Instance of the class
+    :rtype: :class:`InputProfilePhotoAnimated`
+
+    """
+    def __init__(self, animation: InputFile, main_frame_timestamp: Optional[float] = None, **kwargs):
+        self.type: str = "animated"
+        self.animation: InputFile = animation
+        self._animation_name = service_utils.generate_random_token()
+        self._animation_dic = "attach://{}".format(self._animation_name)
+        self.main_frame_timestamp: Optional[float] = main_frame_timestamp
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    def to_dict(self):
+        data = {
+            'type': self.type,
+            'animation': self._animation_dic
+        }
+        if self.main_frame_timestamp is not None:
+            data['main_frame_timestamp'] = self.main_frame_timestamp
+        return data
+    def convert_input_profile_photo(self):
+        return self.to_json(), {self._animation_name: self.animation}

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -12054,7 +12054,7 @@ class StoryAreaTypeLocation(StoryAreaType):
             'type': self.type,
             'latitude': self.latitude,
             'longitude': self.longitude,
-            'address': self.address.to_json()
+            'address': self.address.to_dict()
         }
         return data
     
@@ -12090,7 +12090,7 @@ class StoryAreaTypeSuggestedReaction(StoryAreaType):
     def to_dict(self):
         data = {
             'type': self.type,
-            'reaction_type': self.reaction_type.to_json()
+            'reaction_type': self.reaction_type.to_dict()
         }
         if self.is_dark is not None:
             data['is_dark'] = self.is_dark
@@ -12213,8 +12213,8 @@ class StoryArea(JsonSerializable):
         return json.dumps(self.to_dict())
     def to_dict(self):
         data = {
-            'position': self.position.to_json(),
-            'type': self.type.to_json()
+            'position': self.position.to_dict(),
+            'type': self.type.to_dict()
         }
         return data
     

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -981,6 +981,9 @@ class Message(JsonDeserializable):
         anonymous group administrator
     :type author_signature: :obj:`str`
 
+    :param paid_star_count: Optional. The number of Telegram Stars that were paid by the sender of the message to send it
+    :type paid_star_count: :obj:`int`
+
     :param text: Optional. For text messages, the actual UTF-8 text of the message
     :type text: :obj:`str`
 
@@ -1449,6 +1452,9 @@ class Message(JsonDeserializable):
         if 'paid_message_price_changed' in obj:
             opts['paid_message_price_changed'] = PaidMessagePriceChanged.de_json(obj['paid_message_price_changed'])
             content_type = 'paid_message_price_changed'
+        if 'paid_star_count' in obj:
+            opts['paid_star_count'] = obj['paid_star_count']
+            
 
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
@@ -1570,6 +1576,7 @@ class Message(JsonDeserializable):
         self.gift : Optional[GiftInfo] = None
         self.unique_gift : Optional[UniqueGiftInfo] = None
         self.paid_message_price_changed: Optional[PaidMessagePriceChanged] = None
+        self.paid_star_count: Optional[int] = None
         
 
         for key in options:

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -11866,3 +11866,308 @@ class InputStoryContentVideo(InputStoryContent):
         return self.to_json(), {self._video_name: self.video}
     
 
+class StoryAreaPosition(JsonSerializable):
+    """
+    Describes the position of a clickable area within a story.
+
+    Telegram documentation: https://core.telegram.org/bots/api#storyareaposition
+
+    :param x_percentage: The abscissa of the area's center, as a percentage of the media width
+    :type x_percentage: :obj:`float`
+
+    :param y_percentage: The ordinate of the area's center, as a percentage of the media height
+    :type y_percentage: :obj:`float`
+
+    :param width_percentage: The width of the area's rectangle, as a percentage of the media width
+    :type width_percentage: :obj:`float`
+
+    :param height_percentage: The height of the area's rectangle, as a percentage of the media height
+    :type height_percentage: :obj:`float`
+
+    :param rotation_angle: The clockwise rotation angle of the rectangle, in degrees; 0-360
+    :type rotation_angle: :obj:`float`
+
+    :param corner_radius_percentage: The radius of the rectangle corner rounding, as a percentage of the media width
+    :type corner_radius_percentage: :obj:`float`
+
+    :return: Instance of the class
+    :rtype: :class:`StoryAreaPosition`
+    """
+    def __init__(self, x_percentage: float, y_percentage: float, width_percentage: float,
+                    height_percentage: float, rotation_angle: float, corner_radius_percentage: float, **kwargs):
+        self.x_percentage: float = x_percentage
+        self.y_percentage: float = y_percentage
+        self.width_percentage: float = width_percentage
+        self.height_percentage: float = height_percentage
+        self.rotation_angle: float = rotation_angle
+        self.corner_radius_percentage: float = corner_radius_percentage
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    def to_dict(self):
+        data = {
+            'x_percentage': self.x_percentage,
+            'y_percentage': self.y_percentage,
+            'width_percentage': self.width_percentage,
+            'height_percentage': self.height_percentage,
+            'rotation_angle': self.rotation_angle,
+            'corner_radius_percentage': self.corner_radius_percentage
+        }
+        return data
+    
+
+class LocationAddress(JsonSerializable):
+    """
+    Describes the physical address of a location.
+
+    Telegram documentation: https://core.telegram.org/bots/api#locationaddress
+
+    :param country_code: The two-letter ISO 3166-1 alpha-2 country code of the country where the location is located
+    :type country_code: :obj:`str`
+
+    :param state: Optional. State of the location
+    :type state: :obj:`str`
+
+    :param city: Optional. City of the location
+    :type city: :obj:`str`
+
+    :param street: Optional. Street address of the location
+    :type street: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`LocationAddress`
+    """
+    def __init__(self, country_code: str, state: Optional[str] = None, city: Optional[str] = None,
+                    street: Optional[str] = None, **kwargs):
+        self.country_code: str = country_code
+        self.state: Optional[str] = state
+        self.city: Optional[str] = city
+        self.street: Optional[str] = street
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    def to_dict(self):
+        data = {
+            'country_code': self.country_code
+        }
+        if self.state is not None:
+            data['state'] = self.state
+        if self.city is not None:
+            data['city'] = self.city
+        if self.street is not None:
+            data['street'] = self.street
+        return data
+    
+class StoryAreaType(JsonSerializable):
+    """
+    Describes the type of a clickable area on a story. Currently, it can be one of
+    StoryAreaTypeLocation
+    StoryAreaTypeSuggestedReaction
+    StoryAreaTypeLink
+    StoryAreaTypeWeather
+    StoryAreaTypeUniqueGift
+
+    Telegram documentation: https://core.telegram.org/bots/api#storyarea
+
+    :return: Instance of the class
+    :rtype: :class:`StoryArea`
+    """
+
+
+class StoryAreaTypeLocation(StoryAreaType):
+    """
+    Describes a story area pointing to a location. Currently, a story can have up to 10 location areas.
+
+    Telegram documentation: https://core.telegram.org/bots/api#storyareatypelocation
+
+    :param type: Type of the area, always “location”
+    :type type: :obj:`str`
+
+    :param latitude: Location latitude in degrees
+    :type latitude: :obj:`float`
+
+    :param longitude: Location longitude in degrees
+    :type longitude: :obj:`float`
+
+    :param address: Location address
+    :type address: :class:`LocationAddress`
+
+    :return: Instance of the class
+    :rtype: :class:`StoryAreaTypeLocation`
+    """
+    def __init__(self,latitude: float, longitude: float, address: LocationAddress, **kwargs):
+        self.type: str = "location"
+        self.latitude: float = latitude
+        self.longitude: float = longitude
+        self.address: LocationAddress = address
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    def to_dict(self):
+        data = {
+            'type': self.type,
+            'latitude': self.latitude,
+            'longitude': self.longitude,
+            'address': self.address.to_json()
+        }
+        return data
+    
+
+class StoryAreaTypeSuggestedReaction(StoryAreaType):
+    """
+    Describes a story area pointing to a suggested reaction. Currently, a story can have up to 5 suggested reaction areas.
+
+    Telegram documentation: https://core.telegram.org/bots/api#storyareatypesuggestedreaction
+
+    :param type: Type of the area, always “suggested_reaction”
+    :type type: :obj:`str`
+
+    :param reaction_type: Type of the reaction
+    :type reaction_type: :class:`ReactionType`
+
+    :param is_dark: Optional. Pass True if the reaction area has a dark background
+    :type is_dark: :obj:`bool`
+
+    :param is_flipped: Optional. Pass True if reaction area corner is flipped
+    :type is_flipped: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`StoryAreaTypeSuggestedReaction`
+    """
+    def __init__(self, reaction_type: ReactionType, is_dark: Optional[bool] = None, is_flipped: Optional[bool] = None, **kwargs):
+        self.type: str = "suggested_reaction"
+        self.reaction_type: ReactionType = reaction_type
+        self.is_dark: Optional[bool] = is_dark
+        self.is_flipped: Optional[bool] = is_flipped
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    def to_dict(self):
+        data = {
+            'type': self.type,
+            'reaction_type': self.reaction_type.to_json()
+        }
+        if self.is_dark is not None:
+            data['is_dark'] = self.is_dark
+        if self.is_flipped is not None:
+            data['is_flipped'] = self.is_flipped
+        return data
+    
+class StoryAreaTypeLink(StoryAreaType):
+    """
+    Describes a story area pointing to an HTTP or tg:// link. Currently, a story can have up to 3 link areas.
+
+    Telegram documentation: https://core.telegram.org/bots/api#storyareatypelink
+
+    :param type: Type of the area, always “link”
+    :type type: :obj:`str`
+
+    :param url: HTTP or tg:// URL to be opened when the area is clicked
+    :type url: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`StoryAreaTypeLink`
+    """
+    def __init__(self, url: str, **kwargs):
+        self.type: str = "link"
+        self.url: str = url
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    def to_dict(self):
+        data = {
+            'type': self.type,
+            'url': self.url
+        }
+        return data
+    
+class StoryAreaTypeWeather(StoryAreaType):
+    """
+    Describes a story area containing weather information. Currently, a story can have up to 3 weather areas.
+
+    Telegram documentation: https://core.telegram.org/bots/api#storyareatypeweather
+
+    :param type: Type of the area, always “weather”
+    :type type: :obj:`str`
+
+    :param temperature: Temperature, in degree Celsius
+    :type temperature: :obj:`float`
+
+    :param emoji: Emoji representing the weather
+    :type emoji: :obj:`str`
+
+    :param background_color: A color of the area background in the ARGB format
+    :type background_color: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`StoryAreaTypeWeather`
+    """
+    def __init__(self, temperature: float, emoji: str, background_color: int, **kwargs):
+        self.type: str = "weather"
+        self.temperature: float = temperature
+        self.emoji: str = emoji
+        self.background_color: int = background_color
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    def to_dict(self):
+        data = {
+            'type': self.type,
+            'temperature': self.temperature,
+            'emoji': self.emoji,
+            'background_color': self.background_color
+        }
+        return data
+    
+class StoryAreaTypeUniqueGift(StoryAreaType):
+    """
+    Describes a story area pointing to a unique gift. Currently, a story can have at most 1 unique gift area.
+
+    Telegram documentation: https://core.telegram.org/bots/api#storyareatypeuniquegift
+
+    :param type: Type of the area, always “unique_gift”
+    :type type: :obj:`str`
+
+    :param name: Unique name of the gift
+    :type name: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`StoryAreaTypeUniqueGift`
+    """
+    def __init__(self, name: str, **kwargs):
+        self.type: str = "unique_gift"
+        self.name: str = name
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    def to_dict(self):
+        data = {
+            'type': self.type,
+            'name': self.name
+        }
+
+        return data
+    
+
+class StoryArea(JsonSerializable):
+    """
+    Describes a clickable area on a story media.
+
+    Telegram documentation: https://core.telegram.org/bots/api#storyarea
+
+    :param position: Position of the area
+    :type position: :class:`StoryAreaPosition`
+
+    :param type: Type of the area
+    :type type: :class:`StoryAreaType`
+
+    :return: Instance of the class
+    :rtype: :class:`StoryArea`
+    """
+    def __init__(self, position: StoryAreaPosition, type: StoryAreaType, **kwargs):
+        self.position: StoryAreaPosition = position
+        self.type: StoryAreaType = type
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    def to_dict(self):
+        data = {
+            'position': self.position.to_json(),
+            'type': self.type.to_json()
+        }
+        return data
+    
+
+

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -10569,12 +10569,15 @@ class TransactionPartnerUser(TransactionPartner):
     :param gift: Optional. The gift sent to the user by the bot
     :type gift: :class:`Gift`
 
+    :param premium_subscription_duration: Optional. Number of months the gifted Telegram Premium subscription will be active for; for “premium_purchase” transactions only
+    :type premium_subscription_duration: :obj:`int`
+
     :return: Instance of the class
     :rtype: :class:`TransactionPartnerUser`
     """
 
     def __init__(self, type, user, affiliate=None, invoice_payload=None, paid_media: Optional[List[PaidMedia]] = None, 
-                    subscription_period=None, gift: Optional[Gift] = None, **kwargs):
+                    subscription_period=None, gift: Optional[Gift] = None, premium_subscription_duration: Optional[int] = None, **kwargs):
         self.type: str = type
         self.user: User = user
         self.affiliate: Optional[AffiliateInfo] = affiliate
@@ -10582,6 +10585,7 @@ class TransactionPartnerUser(TransactionPartner):
         self.paid_media: Optional[List[PaidMedia]] = paid_media
         self.subscription_period: Optional[int] = subscription_period
         self.gift: Optional[Gift] = gift
+        self.premium_subscription_duration: Optional[int] = premium_subscription_duration
 
     @classmethod
     def de_json(cls, json_string):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -11429,3 +11429,350 @@ class StarAmount(JsonDeserializable):
         obj = cls.check_json(json_string)
         return cls(**obj)
     
+
+class OwnedGift(JsonDeserializable):
+    """
+    This object describes a gift received and owned by a user or a chat. Currently, it can be one of
+        OwnedGiftRegular
+        OwnedGiftUnique
+
+    Telegram documentation: https://core.telegram.org/bots/api#ownedgift
+    """
+    
+    
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        if obj["type"] == "regular":
+            return OwnedGiftRegular.de_json(obj)
+        elif obj["type"] == "unique":
+            return OwnedGiftUnique.de_json(obj)
+        
+class OwnedGiftRegular(OwnedGift):
+    """
+    This object describes a regular gift owned by a user or a chat.
+
+    Telegram documentation: https://core.telegram.org/bots/api#ownedgiftregular
+
+    :param type: Type of the gift, always “regular”
+    :type type: :obj:`str`
+
+    :param gift: Information about the regular gift
+    :type gift: :class:`Gift`
+
+    :param owned_gift_id: Optional. Unique identifier of the gift for the bot; for gifts received on behalf of business accounts only
+    :type owned_gift_id: :obj:`str`
+
+    :param sender_user: Optional. Sender of the gift if it is a known user
+    :type sender_user: :class:`User`
+
+    :param send_date: Date the gift was sent in Unix time
+    :type send_date: :obj:`int`
+    
+    :param text: Optional. Text of the message that was added to the gift
+    :type text: :obj:`str`
+
+    :param entities: Optional. Special entities that appear in the text
+    :type entities: :obj:`list` of :class:`MessageEntity`
+
+    :param is_private: Optional. True, if the sender and gift text are shown only to the gift receiver; otherwise, everyone will be able to see them
+    :type is_private: :obj:`bool`
+
+    :param is_saved: Optional. True, if the gift is displayed on the account's profile page; for gifts received on behalf of business accounts only
+    :type is_saved: :obj:`bool`
+
+    :param can_be_upgraded: Optional. True, if the gift can be upgraded to a unique gift; for gifts received on behalf of business accounts only
+    :type can_be_upgraded: :obj:`bool`
+
+    :param was_refunded: Optional. True, if the gift was refunded and isn't available anymore
+    :type was_refunded: :obj:`bool`
+
+    :param convert_star_count: Optional. Number of Telegram Stars that can be claimed by the receiver instead of the gift; omitted if the gift cannot be converted to Telegram Stars
+    :type convert_star_count: :obj:`int`
+
+    :param prepaid_upgrade_star_count: Optional. Number of Telegram Stars that were paid by the sender for the ability to upgrade the gift
+    :type prepaid_upgrade_star_count: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`OwnedGiftRegular`
+    """
+    def __init__(self, type, gift, owned_gift_id=None, sender_user=None, send_date=None, text=None, entities=None,
+                    is_private=None, is_saved=None, can_be_upgraded=None, was_refunded=None, convert_star_count=None,
+                    prepaid_upgrade_star_count=None, **kwargs):
+        self.type: str = type
+        self.gift: Gift = gift
+        self.owned_gift_id: Optional[str] = owned_gift_id
+        self.sender_user: Optional[User] = sender_user
+        self.send_date: Optional[int] = send_date
+        self.text: Optional[str] = text
+        self.entities: Optional[List[MessageEntity]] = entities
+        self.is_private: Optional[bool] = is_private
+        self.is_saved: Optional[bool] = is_saved
+        self.can_be_upgraded: Optional[bool] = can_be_upgraded
+        self.was_refunded: Optional[bool] = was_refunded
+        self.convert_star_count: Optional[int] = convert_star_count
+        self.prepaid_upgrade_star_count: Optional[int] = prepaid_upgrade_star_count
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['gift'] = Gift.de_json(obj['gift'])
+        if 'sender_user' in obj:
+            obj['sender_user'] = User.de_json(obj['sender_user'])
+        if 'entities' in obj:
+            obj['entities'] = [MessageEntity.de_json(entity) for entity in obj['entities']]
+        return cls(**obj)
+    
+class OwnedGiftUnique(OwnedGift):
+    """
+    This object describes a unique gift owned by a user or a chat.
+
+    Telegram documentation: https://core.telegram.org/bots/api#ownedgiftunique
+
+    :param type: Type of the gift, always “unique”
+    :type type: :obj:`str`
+
+    :param gift: Information about the unique gift
+    :type gift: :class:`UniqueGift`
+
+    :param owned_gift_id: Optional. Unique identifier of the received gift for the bot; for gifts received on behalf of business accounts only
+    :type owned_gift_id: :obj:`str`
+
+    :param sender_user: Optional. Sender of the gift if it is a known user
+    :type sender_user: :class:`User`
+
+    :param send_date: Date the gift was sent in Unix time
+    :type send_date: :obj:`int`
+
+    :param is_saved: Optional. True, if the gift is displayed on the account's profile page; for gifts received on behalf of business accounts only
+    :type is_saved: :obj:`bool`
+
+    :param can_be_transferred: Optional. True, if the gift can be transferred to another owner; for gifts received on behalf of business accounts only
+    :type can_be_transferred: :obj:`bool`
+
+    :param transfer_star_count: Optional. Number of Telegram Stars that must be paid to transfer the gift; omitted if the bot cannot transfer the gift
+    :type transfer_star_count: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`OwnedGiftUnique`
+    """
+    def __init__(self, type, gift, owned_gift_id=None, sender_user=None, send_date=None, is_saved=None,
+                    can_be_transferred=None, transfer_star_count=None, **kwargs):
+        self.type: str = type
+        self.gift: UniqueGift = gift
+        self.owned_gift_id: Optional[str] = owned_gift_id
+        self.sender_user: Optional[User] = sender_user
+        self.send_date: Optional[int] = send_date
+        self.is_saved: Optional[bool] = is_saved
+        self.can_be_transferred: Optional[bool] = can_be_transferred
+        self.transfer_star_count: Optional[int] = transfer_star_count
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['gift'] = UniqueGift.de_json(obj['gift'])
+        if 'sender_user' in obj:
+            obj['sender_user'] = User.de_json(obj['sender_user'])
+        return cls(**obj)
+    
+
+class OwnedGifts(JsonDeserializable):
+    """
+    Contains the list of gifts received and owned by a user or a chat.
+
+    Telegram documentation: https://core.telegram.org/bots/api#ownedgifts
+
+    :param total_count: The total number of gifts owned by the user or the chat
+    :type total_count: :obj:`int`
+
+    :param gifts: The list of gifts
+    :type gifts: :obj:`list` of :class:`OwnedGift`
+
+    :param next_offset: Optional. Offset for the next request. If empty, then there are no more results
+    :type next_offset: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`OwnedGifts`
+
+    """
+    def __init__(self, total_count, gifts, next_offset=None, **kwargs):
+        self.total_count: int = total_count
+        self.gifts: List[OwnedGift] = gifts
+        self.next_offset: Optional[str] = next_offset
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['gifts'] = [OwnedGift.de_json(gift) for gift in obj['gifts']]
+        return cls(**obj)
+
+
+
+class UniqueGift(JsonDeserializable):
+    """
+    This object describes a unique gift that was upgraded from a regular gift.
+
+    Telegram documentation: https://core.telegram.org/bots/api#uniquegift
+
+    :param base_name: Human-readable name of the regular gift from which this unique gift was upgraded
+    :type base_name: :obj:`str`
+
+    :param name: Unique name of the gift. This name can be used in https://t.me/nft/... links and story areas
+    :type name: :obj:`str`
+
+    :param number: Unique number of the upgraded gift among gifts upgraded from the same regular gift
+    :type number: :obj:`int`
+
+    :param model: Model of the gift
+    :type model: :class:`UniqueGiftModel`
+
+    :param symbol: Symbol of the gift
+    :type symbol: :class:`UniqueGiftSymbol`
+
+    :param backdrop: Backdrop of the gift
+    :type backdrop: :class:`UniqueGiftBackdrop`
+
+    :return: Instance of the class
+    :rtype: :class:`UniqueGift`
+    """
+    def __init__(self, base_name, name, number, model, symbol, backdrop, **kwargs):
+        self.base_name: str = base_name
+        self.name: str = name
+        self.number: int = number
+        self.model: UniqueGiftModel = model
+        self.symbol: UniqueGiftSymbol = symbol
+        self.backdrop: UniqueGiftBackdrop = backdrop
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['model'] = UniqueGiftModel.de_json(obj['model'])
+        obj['symbol'] = UniqueGiftSymbol.de_json(obj['symbol'])
+        obj['backdrop'] = UniqueGiftBackdrop.de_json(obj['backdrop'])
+        return cls(**obj)
+    
+    
+class UniqueGiftModel(JsonDeserializable):
+    """
+    This object describes the model of a unique gift.
+
+    Telegram documentation: https://core.telegram.org/bots/api#uniquegiftmodel
+
+    :param name: Name of the model
+    :type name: :obj:`str`
+
+    :param sticker: The sticker that represents the unique gift
+    :type sticker: :class:`Sticker`
+
+    :param rarity_per_mille: The number of unique gifts that receive this model for every 1000 gifts upgraded
+    :type rarity_per_mille: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`UniqueGiftModel`
+
+    """
+    def __init__(self, name, sticker, rarity_per_mille, **kwargs):
+        self.name: str = name
+        self.sticker: Sticker = sticker
+        self.rarity_per_mille: int = rarity_per_mille
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['sticker'] = Sticker.de_json(obj['sticker'])
+        return cls(**obj)
+    
+class UniqueGiftSymbol(JsonDeserializable):
+    """
+    This object describes the symbol shown on the pattern of a unique gift.
+
+    Telegram documentation: https://core.telegram.org/bots/api#uniquegiftsymbol
+
+    :param name: Name of the symbol
+    :type name: :obj:`str`
+
+    :param sticker: The sticker that represents the unique gift
+    :type sticker: :class:`Sticker`
+
+    :param rarity_per_mille: The number of unique gifts that receive this model for every 1000 gifts upgraded
+    :type rarity_per_mille: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`UniqueGiftSymbol`
+    """
+
+    def __init__(self, name, sticker, rarity_per_mille, **kwargs):
+        self.name: str = name
+        self.sticker: Sticker = sticker
+        self.rarity_per_mille: int = rarity_per_mille
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['sticker'] = Sticker.de_json(obj['sticker'])
+        return cls(**obj)
+    
+class UniqueGiftBackdropColors(JsonDeserializable):
+    """
+    This object describes the colors of the backdrop of a unique gift.
+
+    Telegram documentation: https://core.telegram.org/bots/api#uniquegiftbackdropcolors
+
+    :param center_color: The color in the center of the backdrop in RGB format
+    :type center_color: :obj:`int`
+
+    :param edge_color: The color on the edges of the backdrop in RGB format
+    :type edge_color: :obj:`int`
+
+    :param symbol_color: The color to be applied to the symbol in RGB format
+    :type symbol_color: :obj:`int`
+
+    :param text_color: The color for the text on the backdrop in RGB format
+    :type text_color: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`UniqueGiftBackdropColors`
+    """
+    def __init__(self, center_color, edge_color, symbol_color, text_color, **kwargs):
+        self.center_color: int = center_color
+        self.edge_color: int = edge_color
+        self.symbol_color: int = symbol_color
+        self.text_color: int = text_color
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+    
+class UniqueGiftBackdrop(JsonDeserializable):
+    """
+    This object describes the backdrop of a unique gift.
+
+    Telegram documentation: https://core.telegram.org/bots/api#uniquegiftbackdrop
+
+    :param name: Name of the backdrop
+    :type name: :obj:`str`
+
+    :param colors: Colors of the backdrop
+    :type colors: :class:`UniqueGiftBackdropColors`
+
+    :param rarity_per_mille: The number of unique gifts that receive this backdrop for every 1000 gifts upgraded
+    :type rarity_per_mille: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`UniqueGiftBackdrop`
+    """
+    def __init__(self, name, colors, rarity_per_mille, **kwargs):
+        self.name: str = name
+        self.colors: UniqueGiftBackdropColors = colors
+        self.rarity_per_mille: int = rarity_per_mille
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['colors'] = UniqueGiftBackdropColors.de_json(obj['colors'])
+        return cls(**obj)
+    
+
+

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -11440,12 +11440,12 @@ class AcceptedGiftTypes(JsonDeserializable, JsonSerializable):
     :return: Instance of the class
     :rtype: :class:`AcceptedGiftTypes`
     """
-    def __init__(self, unlimited_gifts: Optional[bool], limited_gifts: Optional[bool],
-                    unique_gifts: Optional[bool], premium_subscription: Optional[bool], **kwargs):
-        self.unlimited_gifts: Optional[bool] = unlimited_gifts
-        self.limited_gifts: Optional[bool] = limited_gifts
-        self.unique_gifts: Optional[bool] = unique_gifts
-        self.premium_subscription: Optional[bool] = premium_subscription
+    def __init__(self, unlimited_gifts: bool, limited_gifts: bool,
+                    unique_gifts: bool, premium_subscription: bool, **kwargs):
+        self.unlimited_gifts: bool = unlimited_gifts
+        self.limited_gifts: bool = limited_gifts
+        self.unique_gifts: bool = unique_gifts
+        self.premium_subscription: bool = premium_subscription
         
     def to_json(self):
         return json.dumps(self.to_dict())

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -11403,4 +11403,29 @@ class AcceptedGiftTypes(JsonDeserializable, JsonSerializable):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         return cls(**obj)
+
+
+class StarAmount(JsonDeserializable):
+    """
+    Describes an amount of Telegram Stars.
+
+    Telegram documentation: https://core.telegram.org/bots/api#staramount
+
+    :param amount: Integer amount of Telegram Stars, rounded to 0; can be negative
+    :type amount: :obj:`int`
+
+    :param nanostar_amount: Optional. The number of 1/1000000000 shares of Telegram Stars; from -999999999 to 999999999; can be negative if and only if amount is non-positive
+    :type nanostar_amount: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`StarAmount`
+    """
+    def __init__(self, amount, nanostar_amount=None, **kwargs):
+        self.amount: int = amount
+        self.nanostar_amount: Optional[int] = nanostar_amount
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
     

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -11354,4 +11354,53 @@ class BusinessBotRights(JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         return cls(**obj)
+
+
+class AcceptedGiftTypes(JsonDeserializable, JsonSerializable):
+    """
+    This object describes the types of gifts that can be gifted to a user or a chat.
+
+    Telegram documentation: https://core.telegram.org/bots/api#acceptedgifttypes
+
+    :param unlimited_gifts: True, if unlimited regular gifts are accepted
+    :type unlimited_gifts: :obj:`bool`
+
+    :param limited_gifts: True, if limited regular gifts are accepted
+    :type limited_gifts: :obj:`bool`
+
+    :param unique_gifts: True, if unique gifts or gifts that can be upgraded to unique for free are accepted
+    :type unique_gifts: :obj:`bool`
+    
+    :param premium_subscription: True, if a Telegram Premium subscription is accepted
+    :type premium_subscription: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`AcceptedGiftTypes`
+    """
+    def __init__(self, unlimited_gifts: Optional[bool] = None, limited_gifts: Optional[bool] = None,
+                    unique_gifts: Optional[bool] = None, premium_subscription: Optional[bool] = None, **kwargs):
+        self.unlimited_gifts: Optional[bool] = unlimited_gifts
+        self.limited_gifts: Optional[bool] = limited_gifts
+        self.unique_gifts: Optional[bool] = unique_gifts
+        self.premium_subscription: Optional[bool] = premium_subscription
+        
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    
+    def to_dict(self):
+        data = {}
+        if self.unlimited_gifts is not None:
+            data['unlimited_gifts'] = self.unlimited_gifts
+        if self.limited_gifts is not None:
+            data['limited_gifts'] = self.limited_gifts
+        if self.unique_gifts is not None:
+            data['unique_gifts'] = self.unique_gifts
+        if self.premium_subscription is not None:
+            data['premium_subscription'] = self.premium_subscription
+        return data
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
     

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1181,6 +1181,9 @@ class Message(JsonDeserializable):
     :param giveaway_completed: Optional. Service message: giveaway completed, without public winners
     :type giveaway_completed: :class:`telebot.types.GiveawayCompleted`
 
+    :param paid_message_price_changed: Optional. Service message: the price for paid messages has changed in the chat
+    :type paid_message_price_changed: :class:`telebot.types.PaidMessagePriceChanged`
+
     :param video_chat_scheduled: Optional. Service message: video chat scheduled
     :type video_chat_scheduled: :class:`telebot.types.VideoChatScheduled`
 
@@ -1443,6 +1446,9 @@ class Message(JsonDeserializable):
         if 'unique_gift' in obj:
             opts['unique_gift'] = UniqueGiftInfo.de_json(obj['unique_gift'])
             content_type = 'unique_gift'
+        if 'paid_message_price_changed' in obj:
+            opts['paid_message_price_changed'] = PaidMessagePriceChanged.de_json(obj['paid_message_price_changed'])
+            content_type = 'paid_message_price_changed'
 
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
@@ -1563,6 +1569,7 @@ class Message(JsonDeserializable):
         self.message_auto_delete_timer_changed: Optional[MessageAutoDeleteTimerChanged] = None
         self.gift : Optional[GiftInfo] = None
         self.unique_gift : Optional[UniqueGiftInfo] = None
+        self.paid_message_price_changed: Optional[PaidMessagePriceChanged] = None
         
 
         for key in options:
@@ -12291,5 +12298,26 @@ class UniqueGiftInfo(JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         obj['gift'] = UniqueGift.de_json(obj['gift'])
+        return cls(**obj)
+    
+
+class PaidMessagePriceChanged(JsonDeserializable):
+    """
+    Describes a service message about a change in the price of paid messages within a chat.
+
+    Telegram documentation: https://core.telegram.org/bots/api#paidmessagepricechanged
+
+    :param paid_message_star_count: The new number of Telegram Stars that must be paid by non-administrator users of the supergroup chat for each sent message
+    :type paid_message_star_count: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`PaidMessagePriceChanged`
+    """
+    def __init__(self, paid_message_star_count: int, **kwargs):
+        self.paid_message_star_count: int = paid_message_star_count
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
         return cls(**obj)
     

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1124,6 +1124,12 @@ class Message(JsonDeserializable):
     :param chat_shared: Optional. Service message: a chat was shared with the bot
     :type chat_shared: :class:`telebot.types.ChatShared`
 
+    :param gift: Optional. Service message: a regular gift was sent or received
+    :type gift: :class:`telebot.types.GiftInfo`
+
+    :param unique_gift: Optional. Service message: a unique gift was sent or received
+    :type unique_gift: :class:`telebot.types.UniqueGiftInfo`
+
     :param connected_website: Optional. The domain name of the website on which the user has logged in. More about
         Telegram Login »
     :type connected_website: :obj:`str`
@@ -1431,6 +1437,12 @@ class Message(JsonDeserializable):
             opts['paid_media'] = PaidMediaInfo.de_json(obj['paid_media'])
         if 'refunded_payment' in obj:
             opts['refunded_payment'] = RefundedPayment.de_json(obj['refunded_payment'])
+        if 'gift' in obj:
+            opts['gift'] = GiftInfo.de_json(obj['gift'])
+            content_type = 'gift'
+        if 'unique_gift' in obj:
+            opts['unique_gift'] = UniqueGiftInfo.de_json(obj['unique_gift'])
+            content_type = 'unique_gift'
 
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
@@ -1549,6 +1561,8 @@ class Message(JsonDeserializable):
         self.video_chat_participants_invited: Optional[VideoChatParticipantsInvited] = None
         self.web_app_data: Optional[WebAppData] = None
         self.message_auto_delete_timer_changed: Optional[MessageAutoDeleteTimerChanged] = None
+        self.gift : Optional[GiftInfo] = None
+        self.unique_gift : Optional[UniqueGiftInfo] = None
         
 
         for key in options:
@@ -12180,4 +12194,91 @@ class StoryArea(JsonSerializable):
         return data
     
 
+class GiftInfo(JsonDeserializable):
+    """
+    This object describes a service message about a regular gift that was sent or received.
 
+    Telegram documentation: https://core.telegram.org/bots/api#giftinfo
+
+    :param gift: Information about the gift
+    :type gift: :class:`Gift`
+
+    :param owned_gift_id: Optional. Unique identifier of the received gift for the bot; only present for gifts received on behalf of business accounts
+    :type owned_gift_id: :obj:`str`
+
+    :param convert_star_count: Optional. Number of Telegram Stars that can be claimed by the receiver by converting the gift; omitted if conversion to Telegram Stars is impossible
+    :type convert_star_count: :obj:`int`
+
+    :param prepaid_upgrade_star_count: Optional. Number of Telegram Stars that were prepaid by the sender for the ability to upgrade the gift
+    :type prepaid_upgrade_star_count: :obj:`int`
+
+    :param can_be_upgraded: Optional. True, if the gift can be upgraded to a unique gift
+    :type can_be_upgraded: :obj:`bool`
+
+    :param text: Optional. Text of the message that was added to the gift
+    :type text: :obj:`str`
+
+    :param entities: Optional. Special entities that appear in the text
+    :type entities: :obj:`list` of :class:`MessageEntity`
+
+    :param is_private: Optional. True, if the sender and gift text are shown only to the gift receiver; otherwise, everyone will be able to see them
+    :type is_private: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`GiftInfo`
+    """
+    def __init__(self, gift: Gift, owned_gift_id: Optional[str] = None, convert_star_count: Optional[int] = None,
+                    prepaid_upgrade_star_count: Optional[int] = None, can_be_upgraded: Optional[bool] = None,
+                    text: Optional[str] = None, entities: Optional[List[MessageEntity]] = None,
+                    is_private: Optional[bool] = None, **kwargs):
+        self.gift: Gift = gift
+        self.owned_gift_id: Optional[str] = owned_gift_id
+        self.convert_star_count: Optional[int] = convert_star_count
+        self.prepaid_upgrade_star_count: Optional[int] = prepaid_upgrade_star_count
+        self.can_be_upgraded: Optional[bool] = can_be_upgraded
+        self.text: Optional[str] = text
+        self.entities: Optional[List[MessageEntity]] = entities
+        self.is_private: Optional[bool] = is_private
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['gift'] = Gift.de_json(obj['gift'])
+        if 'entities' in obj:
+            obj['entities'] = [MessageEntity.de_json(entity) for entity in obj['entities']]
+        return cls(**obj)
+    
+class UniqueGiftInfo(JsonDeserializable):
+    """
+    This object describes a service message about a unique gift that was sent or received.
+
+    Telegram documentation: https://core.telegram.org/bots/api#uniquegiftinfo
+
+    :param gift: Information about the gift
+    :type gift: :class:`UniqueGift`
+
+    :param origin: Origin of the gift. Currently, either “upgrade” or “transfer”
+    :type origin: :obj:`str`
+
+    :param owned_gift_id: Optional. Unique identifier of the received gift for the bot; only present for gifts received on behalf of business accounts
+    :type owned_gift_id: :obj:`str`
+
+    :param transfer_star_count: Optional. Number of Telegram Stars that must be paid to transfer the gift; omitted if the bot cannot transfer the gift
+    :type transfer_star_count: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`UniqueGiftInfo`
+    """
+    def __init__(self, gift: UniqueGift, origin: str, owned_gift_id: Optional[str] = None,
+                    transfer_star_count: Optional[int] = None, **kwargs): 
+        self.gift: UniqueGift = gift
+        self.origin: str = origin
+        self.owned_gift_id: Optional[str] = owned_gift_id
+        self.transfer_star_count: Optional[int] = transfer_star_count
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['gift'] = UniqueGift.de_json(obj['gift'])
+        return cls(**obj)
+    

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -691,6 +691,9 @@ class ChatFullInfo(JsonDeserializable):
     :param can_send_gift: Optional. True, if gifts can be sent to the chat
     :type can_send_gift: :obj:`bool`
 
+    :param accepted_gift_types: Information about types of gifts that are accepted by the chat or by the corresponding user for private chats
+    :type accepted_gift_types: :class:`telebot.types.AcceptedGiftTypes`
+
     :param can_send_paid_media: Optional. True, if paid media messages can be sent or forwarded to the channel chat.
         The field is available only for channel chats.
     :type can_send_paid_media: :obj:`bool`
@@ -762,6 +765,8 @@ class ChatFullInfo(JsonDeserializable):
             obj['personal_chat'] = Chat.de_json(obj['personal_chat'])
         if 'birthdate' in obj:
             obj['birthdate'] = Birthdate.de_json(obj['birthdate'])
+        if 'accepted_gift_types' in obj:
+            obj['accepted_gift_types'] = AcceptedGiftTypes.de_json(obj['accepted_gift_types'])
         return cls(**obj)
 
     def __init__(self, id, type, title=None, username=None, first_name=None,
@@ -777,7 +782,8 @@ class ChatFullInfo(JsonDeserializable):
                  profile_background_custom_emoji_id=None, has_visible_history=None, 
                  unrestrict_boost_count=None, custom_emoji_sticker_set_name=None, business_intro=None, business_location=None,
                     business_opening_hours=None, personal_chat=None, birthdate=None, 
-                    can_send_paid_media=None, can_send_gift=None, **kwargs):
+                    can_send_paid_media=None,
+                    accepted_gift_types=None, **kwargs):
         self.id: int = id
         self.type: str = type
         self.title: Optional[str] = title
@@ -822,7 +828,11 @@ class ChatFullInfo(JsonDeserializable):
         self.personal_chat: Optional[Chat] = personal_chat
         self.birthdate: Optional[Birthdate] = birthdate
         self.can_send_paid_media: Optional[bool] = can_send_paid_media
-        self.can_send_gift: Optional[bool] = can_send_gift
+        self.accepted_gift_types: AcceptedGiftTypes = accepted_gift_types
+        self.can_send_gift: Optional[bool] = None
+        if self.accepted_gift_types is not None: # not optional but still
+            # skip premium subscription?
+            self.can_send_gift: Optional[bool] = any([self.accepted_gift_types.unique_gifts, self.accepted_gift_types.unlimited_gifts, self.accepted_gift_types.limited_gifts])
 
 
 class Chat(ChatFullInfo):

--- a/telebot/version.py
+++ b/telebot/version.py
@@ -1,0 +1,3 @@
+# Versions should comply with PEP440.
+# This line is parsed in setup.py:
+__version__ = '4.26.0'

--- a/telebot/version.py
+++ b/telebot/version.py
@@ -1,3 +1,0 @@
-# Versions should comply with PEP440.
-# This line is parsed in setup.py:
-__version__ = '4.26.0'


### PR DESCRIPTION
April 11, 2025
Bot API 9.0

Business Accounts

- [x] Added the class [BusinessBotRights](https://core.telegram.org/bots/api#businessbotrights) and replaced the field can_reply with the field rights of the type [BusinessBotRights](https://core.telegram.org/bots/api#businessbotrights) in the class [BusinessConnection](https://core.telegram.org/bots/api#businessconnection).
- [x] Added the method [readBusinessMessage](https://core.telegram.org/bots/api#readbusinessmessage), allowing bots to mark incoming messages as read on behalf of a business account.
- [x] Added the method [deleteBusinessMessages](https://core.telegram.org/bots/api#deletebusinessmessages), allowing bots to delete messages on behalf of a business account.
- [x] Added the method [setBusinessAccountName](https://core.telegram.org/bots/api#setbusinessaccountname), allowing bots to change the first and last name of a managed business account.
- [x] Added the method [setBusinessAccountUsername](https://core.telegram.org/bots/api#setbusinessaccountusername), allowing bots to change the username of a managed business account.
- [x] Added the method [setBusinessAccountBio](https://core.telegram.org/bots/api#setbusinessaccountbio), allowing bots to change the bio of a managed business account.
- [x] Added the class [InputProfilePhoto](https://core.telegram.org/bots/api#inputprofilephoto), describing a profile photo to be set.
- [x] Added the methods [setBusinessAccountProfilePhoto](https://core.telegram.org/bots/api#setbusinessaccountprofilephoto) and [removeBusinessAccountProfilePhoto](https://core.telegram.org/bots/api#removebusinessaccountprofilephoto), allowing bots to change the profile photo of a managed business account.
- [x] Added the method [setBusinessAccountGiftSettings](https://core.telegram.org/bots/api#setbusinessaccountgiftsettings), allowing bots to change the privacy settings pertaining to incoming gifts in a managed business account.
- [x] Added the class [StarAmount](https://core.telegram.org/bots/api#staramount) and the method [getBusinessAccountStarBalance](https://core.telegram.org/bots/api#getbusinessaccountstarbalance), allowing bots to check the current Telegram Star balance of a managed business account.
- [x] Added the method [transferBusinessAccountStars](https://core.telegram.org/bots/api#transferbusinessaccountstars), allowing bots to transfer Telegram Stars from the balance of a managed business account to their own balance for withdrawal.
- [x] Added the classes [OwnedGiftRegular](https://core.telegram.org/bots/api#ownedgiftregular), [OwnedGiftUnique](https://core.telegram.org/bots/api#ownedgiftunique), [OwnedGifts](https://core.telegram.org/bots/api#ownedgifts) and the method [getBusinessAccountGifts](https://core.telegram.org/bots/api#getbusinessaccountgifts), allowing bots to fetch the list of gifts owned by a managed business account.
- [x] Added the method [convertGiftToStars](https://core.telegram.org/bots/api#convertgifttostars), allowing bots to convert gifts received by a managed business account to Telegram Stars.
- [x] Added the method [upgradeGift](https://core.telegram.org/bots/api#upgradegift), allowing bots to upgrade regular gifts received by a managed business account to unique gifts.
- [x] Added the method [transferGift](https://core.telegram.org/bots/api#transfergift), allowing bots to transfer unique gifts owned by a managed business account.
- [x] Added the classes [InputStoryContentPhoto](https://core.telegram.org/bots/api#inputstorycontentphoto) and [InputStoryContentVideo](https://core.telegram.org/bots/api#inputstorycontentvideo) representing the content of a story to post.
- [x] Added the classes [StoryArea](https://core.telegram.org/bots/api#storyarea), [StoryAreaPosition](https://core.telegram.org/bots/api#storyareaposition), [LocationAddress](https://core.telegram.org/bots/api#locationaddress), [StoryAreaTypeLocation](https://core.telegram.org/bots/api#storyareatypelocation), [StoryAreaTypeSuggestedReaction](https://core.telegram.org/bots/api#storyareatypesuggestedreaction), [StoryAreaTypeLink](https://core.telegram.org/bots/api#storyareatypelink), [StoryAreaTypeWeather](https://core.telegram.org/bots/api#storyareatypeweather) and [StoryAreaTypeUniqueGift](https://core.telegram.org/bots/api#storyareatypeuniquegift), describing clickable active areas on stories.
- [x] Added the method [postStory](https://core.telegram.org/bots/api#poststory), allowing bots to post a story on behalf of a managed business account.
- [x] Added the method [editStory](https://core.telegram.org/bots/api#editstory), allowing bots to edit stories they had previously posted on behalf of a managed business account.
- [x] Added the method [deleteStory](https://core.telegram.org/bots/api#deletestory), allowing bots to delete stories they had previously posted on behalf of a managed business account.

Mini Apps
- [x] Added the field [DeviceStorage](https://core.telegram.org/bots/webapps#devicestorage), allowing Mini Apps to use persistent local storage on the user's device.
- [x] Added the field [SecureStorage](https://core.telegram.org/bots/webapps#securestorage), allowing Mini Apps to use a secure local storage on the user's device for sensitive data.

Gifts
- [x] Added the classes [UniqueGiftModel](https://core.telegram.org/bots/api#uniquegiftmodel), [UniqueGiftSymbol](https://core.telegram.org/bots/api#uniquegiftsymbol), [UniqueGiftBackdropColors](https://core.telegram.org/bots/api#uniquegiftbackdropcolors), and [UniqueGiftBackdrop](https://core.telegram.org/bots/api#uniquegiftbackdrop) to describe the properties of a unique gift.
- [x] Added the class [UniqueGift](https://core.telegram.org/bots/api#uniquegift) describing a gift that was upgraded to a unique one.
- [x] Added the class [AcceptedGiftTypes](https://core.telegram.org/bots/api#acceptedgifttypes) describing the types of gifts that are accepted by a user or a chat.
- [x] Replaced the field can_send_gift with the field accepted_gift_types of the type [AcceptedGiftTypes](https://core.telegram.org/bots/api#acceptedgifttypes) in the class [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo).
- [x] Added the class [GiftInfo](https://core.telegram.org/bots/api#giftinfo) and the field gift to the class [Message](https://core.telegram.org/bots/api#message), describing a service message about a regular gift that was sent or received.
- [x] Added the class [UniqueGiftInfo](https://core.telegram.org/bots/api#uniquegiftinfo) and the field unique_gift to the class [Message](https://core.telegram.org/bots/api#message), describing a service message about a unique gift that was sent or received.

Telegram Premium

- [x] Added the method [giftPremiumSubscription](https://core.telegram.org/bots/api#giftpremiumsubscription), allowing bots to gift a user a Telegram Premium subscription paid in Telegram Stars.
- [x] Added the field premium_subscription_duration to the class [TransactionPartnerUser](https://core.telegram.org/bots/api#transactionpartneruser) for transactions involving a Telegram Premium subscription purchased by the bot.
- [x] Added the field transaction_type to the class [TransactionPartnerUser](https://core.telegram.org/bots/api#transactionpartneruser), simplifying the differentiation and processing of all transaction types.

General

- [x] Increased the maximum price for paid media to 10000 Telegram Stars.
- [x] Increased the maximum price for a subscription period to 10000 Telegram Stars.
- [x] Added the class [PaidMessagePriceChanged](https://core.telegram.org/bots/api#paidmessagepricechanged) and the field paid_message_price_changed to the class [Message](https://core.telegram.org/bots/api#message), describing a service message about a price change for paid messages sent to the chat.
- [x] Added the field paid_star_count to the class [Message](https://core.telegram.org/bots/api#message), containing the number of [Telegram Stars](https://telegram.org/blog/telegram-stars) that were paid to send the message.