### PR TITLE
Fix: Add thumbnail support for edit_message_media

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -6703,12 +6703,13 @@ class InputMedia(Dictionaryable, JsonSerializable):
         self.caption_entities: Optional[List[MessageEntity]] = caption_entities
         self.thumbnail: Optional[Union[str, InputFile]] = thumbnail
 
-        if isinstance(self.thumbnail, InputFile):
-            self._thumbnail_name = service_utils.generate_random_token()
-            self._thumbnail_dic = 'attach://{0}'.format(self._thumbnail_name)
-        else:
+        if service_utils.is_string(self.thumbnail):
             self._thumbnail_name = ''
             self._thumbnail_dic = self.thumbnail
+
+        else:
+            self._thumbnail_name = service_utils.generate_random_token()
+            self._thumbnail_dic = 'attach://{0}'.format(self._thumbnail_name)
 
         if service_utils.is_string(self.media):
             self._media_name = ''
@@ -6721,7 +6722,9 @@ class InputMedia(Dictionaryable, JsonSerializable):
         return json.dumps(self.to_dict())
 
     def to_dict(self):
-        json_dict = {'type': self.type, 'media': self._media_dic, 'thumbnail': self._thumbnail_dic}
+        json_dict = {'type': self.type, 'media': self._media_dic}
+        if self._thumbnail_dic:
+            json_dict['thumbnail'] = self._thumbnail_dic
         if self.caption:
             json_dict['caption'] = self.caption
         if self.parse_mode:
@@ -6736,8 +6739,12 @@ class InputMedia(Dictionaryable, JsonSerializable):
         """
         if service_utils.is_string(self.media):
             return self.to_json(), None
+        
+        media_dict = {self._media_name: self.media}
+        if self._thumbnail_name:
+            media_dict[self._thumbnail_name] = self.thumbnail
 
-        return self.to_json(), {self._media_name: self.media, self._thumbnail_name: self.thumbnail}
+        return self.to_json(), media_dict
 
 
 class InputMediaPhoto(InputMedia):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -6703,10 +6703,12 @@ class InputMedia(Dictionaryable, JsonSerializable):
         self.caption_entities: Optional[List[MessageEntity]] = caption_entities
         self.thumbnail: Optional[Union[str, InputFile]] = thumbnail
 
-        if service_utils.is_string(self.thumbnail):
+        if thumbnail is None:
+            self._thumbnail_name = ''
+            self._thumbnail_dic = None
+        elif service_utils.is_string(self.thumbnail):
             self._thumbnail_name = ''
             self._thumbnail_dic = self.thumbnail
-
         else:
             self._thumbnail_name = service_utils.generate_random_token()
             self._thumbnail_dic = 'attach://{0}'.format(self._thumbnail_name)

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -6695,12 +6695,20 @@ class InputMedia(Dictionaryable, JsonSerializable):
     * :class:`InputMediaPhoto`
     * :class:`InputMediaVideo`
     """
-    def __init__(self, type, media, caption=None, parse_mode=None, caption_entities=None):
+    def __init__(self, type, media, caption=None, parse_mode=None, caption_entities=None, thumbnail=None):
         self.type: str = type
         self.media: str = media
         self.caption: Optional[str] = caption
         self.parse_mode: Optional[str] = parse_mode
         self.caption_entities: Optional[List[MessageEntity]] = caption_entities
+        self.thumbnail: Optional[Union[str, InputFile]] = thumbnail
+
+        if isinstance(self.thumbnail, InputFile):
+            self._thumbnail_name = service_utils.generate_random_token()
+            self._thumbnail_dic = 'attach://{0}'.format(self._thumbnail_name)
+        else:
+            self._thumbnail_name = ''
+            self._thumbnail_dic = self.thumbnail
 
         if service_utils.is_string(self.media):
             self._media_name = ''
@@ -6713,7 +6721,7 @@ class InputMedia(Dictionaryable, JsonSerializable):
         return json.dumps(self.to_dict())
 
     def to_dict(self):
-        json_dict = {'type': self.type, 'media': self._media_dic}
+        json_dict = {'type': self.type, 'media': self._media_dic, 'thumbnail': self._thumbnail_dic}
         if self.caption:
             json_dict['caption'] = self.caption
         if self.parse_mode:
@@ -6729,7 +6737,7 @@ class InputMedia(Dictionaryable, JsonSerializable):
         if service_utils.is_string(self.media):
             return self.to_json(), None
 
-        return self.to_json(), {self._media_name: self.media}
+        return self.to_json(), {self._media_name: self.media, self._thumbnail_name: self.thumbnail}
 
 
 class InputMediaPhoto(InputMedia):
@@ -6850,8 +6858,7 @@ class InputMediaVideo(InputMedia):
                     show_caption_above_media: Optional[bool] = None, cover: Optional[Union[str, InputFile]] = None,
                     start_timestamp: Optional[int] = None):
         super(InputMediaVideo, self).__init__(
-            type="video", media=media, caption=caption, parse_mode=parse_mode, caption_entities=caption_entities)
-        self.thumbnail: Optional[Union[str, InputFile]] = thumbnail
+            type="video", media=media, caption=caption, parse_mode=parse_mode, caption_entities=caption_entities, thumbnail=thumbnail)
         self.width: Optional[int] = width
         self.height: Optional[int] = height
         self.duration: Optional[int] = duration
@@ -6868,8 +6875,6 @@ class InputMediaVideo(InputMedia):
 
     def to_dict(self):
         ret = super(InputMediaVideo, self).to_dict()
-        if self.thumbnail:
-            ret['thumbnail'] = self.thumbnail
         if self.width:
             ret['width'] = self.width
         if self.height:
@@ -6943,8 +6948,7 @@ class InputMediaAnimation(InputMedia):
                     height: Optional[int] = None, duration: Optional[int] = None,
                     has_spoiler: Optional[bool] = None, show_caption_above_media: Optional[bool] = None):
         super(InputMediaAnimation, self).__init__(
-            type="animation", media=media, caption=caption, parse_mode=parse_mode, caption_entities=caption_entities)
-        self.thumbnail: Optional[Union[str, InputFile]] = thumbnail
+            type="animation", media=media, caption=caption, parse_mode=parse_mode, caption_entities=caption_entities, thumbnail=thumbnail)
         self.width: Optional[int] = width
         self.height: Optional[int] = height
         self.duration: Optional[int] = duration
@@ -6959,8 +6963,6 @@ class InputMediaAnimation(InputMedia):
 
     def to_dict(self):
         ret = super(InputMediaAnimation, self).to_dict()
-        if self.thumbnail:
-            ret['thumbnail'] = self.thumbnail
         if self.width:
             ret['width'] = self.width
         if self.height:
@@ -7020,8 +7022,7 @@ class InputMediaAudio(InputMedia):
                     caption_entities: Optional[List[MessageEntity]] = None, duration: Optional[int] = None,
                     performer: Optional[str] = None, title: Optional[str] = None):
         super(InputMediaAudio, self).__init__(
-            type="audio", media=media, caption=caption, parse_mode=parse_mode, caption_entities=caption_entities)
-        self.thumbnail: Optional[Union[str, InputFile]] = thumbnail
+            type="audio", media=media, caption=caption, parse_mode=parse_mode, caption_entities=caption_entities, thumbnail=thumbnail)
         self.duration: Optional[int] = duration
         self.performer: Optional[str] = performer
         self.title: Optional[str] = title
@@ -7033,8 +7034,6 @@ class InputMediaAudio(InputMedia):
 
     def to_dict(self):
         ret = super(InputMediaAudio, self).to_dict()
-        if self.thumbnail:
-            ret['thumbnail'] = self.thumbnail
         if self.duration:
             ret['duration'] = self.duration
         if self.performer:
@@ -7085,8 +7084,7 @@ class InputMediaDocument(InputMedia):
                     caption_entities: Optional[List[MessageEntity]] = None,
                     disable_content_type_detection: Optional[bool] = None):
         super(InputMediaDocument, self).__init__(
-            type="document", media=media, caption=caption, parse_mode=parse_mode, caption_entities=caption_entities)
-        self.thumbnail: Optional[Union[str, InputFile]] = thumbnail
+            type="document", media=media, caption=caption, parse_mode=parse_mode, caption_entities=caption_entities, thumbnail=thumbnail)
         self.disable_content_type_detection: Optional[bool] = disable_content_type_detection
 
     @property
@@ -7096,8 +7094,6 @@ class InputMediaDocument(InputMedia):
 
     def to_dict(self):
         ret = super(InputMediaDocument, self).to_dict()
-        if self.thumbnail:
-            ret['thumbnail'] = self.thumbnail
         if self.disable_content_type_detection is not None:
             ret['disable_content_type_detection'] = self.disable_content_type_detection
         return ret


### PR DESCRIPTION
**Description:**  

By Telegram specification, thumbnails can be used in the following methods:

- `InputMediaAnimation`
- `InputMediaDocument`
- `InputMediaAudio`
- `InputMediaVideo`

When using **send_media_group**, everything works correctly. For example:

```python
bot.send_media_group(
    chat_id=CHAT_ID,
    media=[InputMediaAudio(
        media=InputFile(file=audio_path), 
        thumbnail=InputFile(file=thumbnail_path)
    )],
)
```

*Result:*
<img width="366" alt="image" src="https://github.com/user-attachments/assets/499c3564-1cce-4388-a8db-e14527cf159b" />

Audio is successfully sent with a thumbnail.

---

However, currently **edit_message_media** does not support sending thumbnails.

Example with `edit_message_media`:  
```python
initial_message = bot.send_message(CHAT_ID, "Тестовое сообщение.")

  bot.edit_message_media(
     chat_id=CHAT_ID,
     message_id=initial_message.message_id,
     media=InputMediaAudio(
         media=InputFile(file=audio_path),
         thumbnail=InputFile(file=thumbnail_path)
     )
 )
```
This throws an exception:
<img width="563" alt="image-1" src="https://github.com/user-attachments/assets/90f3cf3a-6323-47bf-990f-1483cead8048" />


The issue is caused because we try to JSON serialize a raw file, but according to Telegram's specification, the thumbnail should be sent using `attach://<file_attach_name>`, not serialized directly.

Relevant part of the spec:

> "The thumbnail should be in JPEG format and less than 200 kB in size. Thumbnails can't be reused and must be uploaded as a new file, so you can pass `attach://<file_attach_name>` if the thumbnail was uploaded using multipart/form-data."

---

**Why this fix is needed:**  
Without this fix, it is impossible to send or edit media messages with a thumbnail via `edit_message_media`, even though Telegram's API supports it.

**Polite closing:**  
Please review this PR. Feedback is welcome!