### PR TITLE
Fix type annotations

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -3528,7 +3528,7 @@ class TeleBot:
             proximity_alert_radius: Optional[int]=None,
             live_period: Optional[int]=None,
             business_connection_id: Optional[str]=None
-    ) -> types.Message or bool:
+    ) -> Union[types.Message, bool]:
         """
         Use this method to edit live location messages. A location can be edited until its live_period expires or editing is explicitly
             disabled by a call to stopMessageLiveLocation. On success, if the edited message is not an inline message, the edited Message
@@ -3590,7 +3590,7 @@ class TeleBot:
             inline_message_id: Optional[str]=None, 
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             timeout: Optional[int]=None,
-            business_connection_id: Optional[str]=None) -> types.Message or bool:
+            business_connection_id: Optional[str]=None) -> Union[types.Message, bool]:
         """
         Use this method to stop updating a live location message before live_period expires.
         On success, if the message is not an inline message, the edited Message is returned, otherwise True is returned.

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -255,7 +255,7 @@ def extract_command(text: str) -> Union[str, None]:
     return text.split()[0].split('@')[0][1:] if is_command(text) else None
 
 
-def extract_arguments(text: str) -> str or None:
+def extract_arguments(text: str) -> Union[str, None]:
     """
     Returns the argument after the command.
     


### PR DESCRIPTION
## Description
Fixed type annotations for 3 functions: `edit_message_live_location`, `stop_message_live_location` and `extract_arguments`

## Describe your tests
How did you test your change?

Python version: 3.13

OS: Windows

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [ ] I made changes both for sync and async
