### PR TITLE
Default to None for filter func in inline_handler

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -46,7 +46,7 @@ from telebot.custom_filters import SimpleCustomFilter, AdvancedCustomFilter
 
 
 REPLY_MARKUP_TYPES = Union[
-    types.InlineKeyboardMarkup, types.ReplyKeyboardMarkup, 
+    types.InlineKeyboardMarkup, types.ReplyKeyboardMarkup,
     types.ReplyKeyboardRemove, types.ForceReply]
 
 
@@ -93,7 +93,7 @@ class TeleBot:
 
         from telebot import TeleBot
         bot = TeleBot('token') # get token from @BotFather
-        # now you can register other handlers/update listeners, 
+        # now you can register other handlers/update listeners,
         # and use bot methods.
 
     See more examples in examples/ directory:
@@ -139,7 +139,7 @@ class TeleBot:
 
     :param use_class_middlewares: Use class middlewares, defaults to False
     :type use_class_middlewares: :obj:`bool`, optional
-    
+
     :param disable_web_page_preview: Default value for disable_web_page_preview, defaults to None
     :type disable_web_page_preview: :obj:`bool`, optional
 
@@ -151,7 +151,7 @@ class TeleBot:
 
     :param allow_sending_without_reply: Default value for allow_sending_without_reply, defaults to None
     :type allow_sending_without_reply: :obj:`bool`, optional
-    
+
     :param colorful_logs: Outputs colorful logs
     :type colorful_logs: :obj:`bool`, optional
 
@@ -168,7 +168,7 @@ class TeleBot:
             next_step_backend: Optional[HandlerBackend]=None, reply_backend: Optional[HandlerBackend]=None,
             exception_handler: Optional[ExceptionHandler]=None, last_update_id: Optional[int]=0,
             suppress_middleware_excepions: Optional[bool]=False, state_storage: Optional[StateStorageBase]=StateMemoryStorage(),
-            use_class_middlewares: Optional[bool]=False, 
+            use_class_middlewares: Optional[bool]=False,
             disable_web_page_preview: Optional[bool]=None,
             disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
@@ -194,7 +194,7 @@ class TeleBot:
 
         if validate_token:
             util.validate_token(self.token)
-        
+
         self.bot_id: Union[int, None] = util.extract_bot_id(self.token) # subject to change in future, unspecified
 
         # logs-related
@@ -292,7 +292,7 @@ class TeleBot:
         self.threaded = threaded
         if self.threaded:
             self.worker_pool = util.ThreadPool(self, num_threads=num_threads)
-        
+
     @property
     def user(self) -> types.User:
         """
@@ -438,15 +438,15 @@ class TeleBot:
             Defaults to 40. Use lower values to limit the load on your bot's server, and higher values to increase your bot's throughput,
             defaults to None
         :type max_connections: :obj:`int`, optional
-        
+
         :param allowed_updates: A JSON-serialized list of the update types you want your bot to receive. For example,
             specify [“message”, “edited_channel_post”, “callback_query”] to only receive updates of these types. See Update
             for a complete list of available update types. Specify an empty list to receive all update types except chat_member (default).
             If not specified, the previous setting will be used.
-            
+
             Please note that this parameter doesn't affect updates created before the call to the setWebhook, so unwanted updates may be received
             for a short period of time. Defaults to None
-        
+
         :type allowed_updates: :obj:`list`, optional
 
         :param ip_address: The fixed IP address which will be used to send webhook requests instead of the IP address
@@ -516,7 +516,7 @@ class TeleBot:
         :type max_connections: :obj:`int`, optional
 
         :param allowed_updates: A JSON-serialized list of the update types you want your bot to receive. For example, specify [“message”, “edited_channel_post”, “callback_query”]
-            to only receive updates of these types. See Update for a complete list of available update types. Specify an empty list to receive all updates regardless of type (default). 
+            to only receive updates of these types. See Update for a complete list of available update types. Specify an empty list to receive all updates regardless of type (default).
             If not specified, the previous setting will be used. defaults to None
         :type allowed_updates: :obj:`list`, optional
 
@@ -545,7 +545,7 @@ class TeleBot:
         if not url_path:
             url_path = self.token + '/'
         if url_path[-1] != '/': url_path += '/'
-        
+
         protocol = "https" if certificate else "http"
         if not webhook_url:
             webhook_url = "{}://{}:{}/{}".format(protocol, listen, port, url_path)
@@ -627,8 +627,8 @@ class TeleBot:
         return self.set_webhook()  # No params resets webhook
 
 
-    def get_updates(self, offset: Optional[int]=None, limit: Optional[int]=None, 
-            timeout: Optional[int]=20, allowed_updates: Optional[List[str]]=None, 
+    def get_updates(self, offset: Optional[int]=None, limit: Optional[int]=None,
+            timeout: Optional[int]=20, allowed_updates: Optional[List[str]]=None,
             long_polling_timeout: int=20) -> List[types.Update]:
         """
         Use this method to receive incoming updates using long polling (wiki). An Array of Update objects is returned.
@@ -678,14 +678,14 @@ class TeleBot:
         Registered listeners and applicable message handlers will be notified when a new message arrives.
 
         :meta private:
-        
+
         :raises ApiException when a call has failed.
         """
         if self.skip_pending:
             self.__skip_updates()
             logger.debug('Skipped all pending messages')
             self.skip_pending = False
-        updates = self.get_updates(offset=(self.last_update_id + 1), 
+        updates = self.get_updates(offset=(self.last_update_id + 1),
                                    allowed_updates=allowed_updates,
                                    timeout=timeout, long_polling_timeout=long_polling_timeout)
         self.process_new_updates(updates)
@@ -726,7 +726,7 @@ class TeleBot:
         new_edited_business_messages = None
         new_deleted_business_messages = None
         new_purchased_paid_media = None
-        
+
         for update in updates:
             if apihelper.ENABLE_MIDDLEWARE and not self.use_class_middlewares:
                 try:
@@ -810,7 +810,7 @@ class TeleBot:
             if update.purchased_paid_media:
                 if new_purchased_paid_media is None: new_purchased_paid_media = []
                 new_purchased_paid_media.append(update.purchased_paid_media)
-                
+
         if new_messages:
             self.process_new_messages(new_messages)
         if new_edited_messages:
@@ -890,7 +890,7 @@ class TeleBot:
         :meta private:
         """
         self._notify_command_handlers(self.message_reaction_handlers, new_message_reactions, 'message_reaction')
-    
+
     def process_new_message_reaction_count(self, new_message_reaction_counts):
         """
         :meta private:
@@ -938,7 +938,7 @@ class TeleBot:
         :meta private:
         """
         self._notify_command_handlers(self.poll_answer_handlers, new_poll_answers, 'poll_answer')
-    
+
     def process_new_my_chat_member(self, new_my_chat_members):
         """
         :meta private:
@@ -986,13 +986,13 @@ class TeleBot:
         :meta private:
         """
         self._notify_command_handlers(self.edited_business_message_handlers, new_edited_business_messages, 'edited_business_message')
-        
+
     def process_new_deleted_business_messages(self, new_deleted_business_messages):
         """
         :meta private:
         """
         self._notify_command_handlers(self.deleted_business_messages_handlers, new_deleted_business_messages, 'deleted_business_messages')
-    
+
     def process_new_purchased_paid_media(self, new_purchased_paid_media):
         """
         :meta private:
@@ -1047,7 +1047,7 @@ class TeleBot:
             # Make it possible to specify --path argument to the script
             path = sys.argv[sys.argv.index('--path') + 1] if '--path' in sys.argv else '.'
 
-            
+
         self.event_observer = Observer()
         self.event_observer.schedule(self.event_handler, path, recursive=True)
         self.event_observer.start()
@@ -1066,7 +1066,7 @@ class TeleBot:
         Wrap polling with infinite loop and exception handling to avoid bot stops polling.
 
         .. note::
-        
+
             Install watchdog and psutil before using restart_on_change option.
 
         :param timeout: Request connection timeout.
@@ -1083,11 +1083,11 @@ class TeleBot:
         :type logger_level: :obj:`int`.
 
         :param allowed_updates: A list of the update types you want your bot to receive.
-            For example, specify [“message”, “edited_channel_post”, “callback_query”] to only receive updates of these types. 
-            See util.update_types for a complete list of available update types. 
-            Specify an empty list to receive all update types except chat_member (default). 
+            For example, specify [“message”, “edited_channel_post”, “callback_query”] to only receive updates of these types.
+            See util.update_types for a complete list of available update types.
+            Specify an empty list to receive all update types except chat_member (default).
             If not specified, the previous setting will be used.
-            Please note that this parameter doesn't affect updates created before the call to the get_updates, 
+            Please note that this parameter doesn't affect updates created before the call to the get_updates,
             so unwanted updates may be received for a short period of time.
         :type allowed_updates: :obj:`list` of :obj:`str`
 
@@ -1132,14 +1132,14 @@ class TeleBot:
         This allows the bot to retrieve Updates automatically and notify listeners and message handlers accordingly.
 
         Warning: Do not call this function more than once!
-        
+
         Always gets updates.
 
         .. deprecated:: 4.1.1
             Use :meth:`infinity_polling` instead.
 
         .. note::
-        
+
             Install watchdog and psutil before using restart_on_change option.
 
         :param interval: Delay between two update retrivals
@@ -1153,7 +1153,7 @@ class TeleBot:
 
         :param skip_pending: skip old updates
         :type skip_pending: :obj:`bool`
-        
+
         :param long_polling_timeout: Timeout in seconds for long polling (see API docs)
         :type long_polling_timeout: :obj:`int`
 
@@ -1162,12 +1162,12 @@ class TeleBot:
         :type logger_level: :obj:`int`
 
         :param allowed_updates: A list of the update types you want your bot to receive.
-            For example, specify [“message”, “edited_channel_post”, “callback_query”] to only receive updates of these types. 
-            See util.update_types for a complete list of available update types. 
-            Specify an empty list to receive all update types except chat_member (default). 
+            For example, specify [“message”, “edited_channel_post”, “callback_query”] to only receive updates of these types.
+            See util.update_types for a complete list of available update types.
+            Specify an empty list to receive all update types except chat_member (default).
             If not specified, the previous setting will be used.
-            
-            Please note that this parameter doesn't affect updates created before the call to the get_updates, 
+
+            Please note that this parameter doesn't affect updates created before the call to the get_updates,
             so unwanted updates may be received for a short period of time.
         :type allowed_updates: :obj:`list` of :obj:`str`
 
@@ -1179,7 +1179,7 @@ class TeleBot:
 
         :param path_to_watch: Path to watch for changes. Defaults to None
         :type path_to_watch: :obj:`str`
-        
+
         :return:
         """
         if none_stop is not None:
@@ -1193,7 +1193,7 @@ class TeleBot:
             self._setup_change_detector(path_to_watch)
 
         logger.info('Starting your bot with username: [@%s]', self.user.username)
-            
+
         if self.threaded:
             self.__threaded_polling(non_stop=non_stop, interval=interval, timeout=timeout, long_polling_timeout=long_polling_timeout,
                                     logger_level=logger_level, allowed_updates=allowed_updates)
@@ -1386,9 +1386,9 @@ class TeleBot:
     def get_file(self, file_id: Optional[str]) -> types.File:
         """
         Use this method to get basic info about a file and prepare it for downloading.
-        For the moment, bots can download files of up to 20MB in size. 
-        On success, a File object is returned. 
-        It is guaranteed that the link will be valid for at least 1 hour. 
+        For the moment, bots can download files of up to 20MB in size.
+        On success, a File object is returned.
+        It is guaranteed that the link will be valid for at least 1 hour.
         When the link expires, a new one can be requested by calling get_file again.
 
         Telegram documentation: https://core.telegram.org/bots/api#getfile
@@ -1431,11 +1431,11 @@ class TeleBot:
 
     def log_out(self) -> bool:
         """
-        Use this method to log out from the cloud Bot API server before launching the bot locally. 
+        Use this method to log out from the cloud Bot API server before launching the bot locally.
         You MUST log out the bot before running it locally, otherwise there is no guarantee
         that the bot will receive updates.
-        After a successful call, you can immediately log in on a local server, 
-        but will not be able to log in back to the cloud Bot API server for 10 minutes. 
+        After a successful call, you can immediately log in on a local server,
+        but will not be able to log in back to the cloud Bot API server for 10 minutes.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#logout
@@ -1444,14 +1444,14 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.log_out(self.token)
-    
-    
+
+
     def close(self) -> bool:
         """
-        Use this method to close the bot instance before moving it from one local server to another. 
+        Use this method to close the bot instance before moving it from one local server to another.
         You need to delete the webhook before calling this method to ensure that the bot isn't launched again
         after server restart.
-        The method will return error 429 in the first 10 minutes after the bot is launched. 
+        The method will return error 429 in the first 10 minutes after the bot is launched.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#close
@@ -1459,10 +1459,10 @@ class TeleBot:
         :return: :obj:`bool`
         """
         return apihelper.close(self.token)
-    
+
     def set_message_reaction(self, chat_id: Union[int, str], message_id: int, reaction: Optional[List[types.ReactionType]]=None, is_big: Optional[bool]=None) -> bool:
         """
-        Use this method to change the chosen reactions on a message. 
+        Use this method to change the chosen reactions on a message.
         Service messages can't be reacted to. Automatically forwarded messages from a channel to its discussion group have the same
         available reactions as messages in the channel. Returns True on success.
 
@@ -1487,7 +1487,7 @@ class TeleBot:
             self.token, chat_id, message_id, reaction = reaction, is_big = is_big)
 
 
-    def get_user_profile_photos(self, user_id: int, offset: Optional[int]=None, 
+    def get_user_profile_photos(self, user_id: int, offset: Optional[int]=None,
             limit: Optional[int]=None) -> types.UserProfilePhotos:
         """
         Use this method to get a list of profile pictures for a user.
@@ -1531,7 +1531,7 @@ class TeleBot:
         """
         return apihelper.set_user_emoji_status(
             self.token, user_id, emoji_status_custom_emoji_id=emoji_status_custom_emoji_id, emoji_status_expiration_date=emoji_status_expiration_date)
-    
+
 
     def get_chat(self, chat_id: Union[int, str]) -> types.ChatFullInfo:
         """
@@ -1571,7 +1571,7 @@ class TeleBot:
         On success, returns an Array of ChatMember objects that contains
         information about all chat administrators except other bots.
 
-        Telegram documentation: https://core.telegram.org/bots/api#getchatadministrators    
+        Telegram documentation: https://core.telegram.org/bots/api#getchatadministrators
 
         :param chat_id: Unique identifier for the target chat or username
             of the target supergroup or channel (in the format @channelusername)
@@ -1623,7 +1623,7 @@ class TeleBot:
         Use this method to set a new group sticker set for a supergroup. The bot must be an administrator in the chat
         for this to work and must have the appropriate administrator rights. Use the field can_set_sticker_set optionally returned
         in getChat requests to check if the bot can use this method. Returns True on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#setchatstickerset
 
         :param chat_id: Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
@@ -1643,7 +1643,7 @@ class TeleBot:
         Use this method to delete a group sticker set from a supergroup. The bot must be an administrator in the chat
         for this to work and must have the appropriate admin rights. Use the field can_set_sticker_set
         optionally returned in getChat requests to check if the bot can use this method. Returns True on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#deletechatstickerset
 
         :param chat_id:	Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
@@ -1658,7 +1658,7 @@ class TeleBot:
     def get_chat_member(self, chat_id: Union[int, str], user_id: int) -> types.ChatMember:
         """
         Use this method to get information about a member of a chat. Returns a ChatMember object on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#getchatmember
 
         :param chat_id: Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
@@ -1676,11 +1676,11 @@ class TeleBot:
 
 
     def send_message(
-            self, chat_id: Union[int, str], text: str, 
-            parse_mode: Optional[str]=None, 
+            self, chat_id: Union[int, str], text: str,
+            parse_mode: Optional[str]=None,
             entities: Optional[List[types.MessageEntity]]=None,
             disable_web_page_preview: Optional[bool]=None,    # deprecated, for backward compatibility
-            disable_notification: Optional[bool]=None, 
+            disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
@@ -1696,7 +1696,7 @@ class TeleBot:
         Use this method to send text messages.
 
         Warning: Do not send more than about 4096 characters each message, otherwise you'll risk an HTTP 414 error.
-        If you must send more than 4096 characters, 
+        If you must send more than 4096 characters,
         use the `split_string` or `smart_split` function in util.py.
 
         Telegram documentation: https://core.telegram.org/bots/api#sendmessage
@@ -1806,7 +1806,7 @@ class TeleBot:
 
 
     def forward_message(
-            self, chat_id: Union[int, str], from_chat_id: Union[int, str], 
+            self, chat_id: Union[int, str], from_chat_id: Union[int, str],
             message_id: int, disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             timeout: Optional[int]=None,
@@ -1855,13 +1855,13 @@ class TeleBot:
 
 
     def copy_message(
-            self, chat_id: Union[int, str], 
-            from_chat_id: Union[int, str], 
-            message_id: int, 
-            caption: Optional[str]=None, 
-            parse_mode: Optional[str]=None, 
+            self, chat_id: Union[int, str],
+            from_chat_id: Union[int, str],
+            message_id: int,
+            caption: Optional[str]=None,
+            parse_mode: Optional[str]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
-            disable_notification: Optional[bool]=None, 
+            disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
@@ -1933,11 +1933,11 @@ class TeleBot:
         :param allow_paid_broadcast: Pass True to allow up to 1000 messages per second, ignoring broadcasting limits for a fee
             of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
         :type allow_paid_broadcast: :obj:`bool`
-        
+
         :return: On success, the MessageId of the sent message is returned.
         :rtype: :class:`telebot.types.MessageID`
         """
-        
+
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         protect_content = self.protect_content if (protect_content is None) else protect_content
@@ -1969,7 +1969,7 @@ class TeleBot:
                 video_start_timestamp=video_start_timestamp))
 
 
-    def delete_message(self, chat_id: Union[int, str], message_id: int, 
+    def delete_message(self, chat_id: Union[int, str], message_id: int,
             timeout: Optional[int]=None) -> bool:
         """
         Use this method to delete a message, including service messages, with the following limitations:
@@ -1998,7 +1998,7 @@ class TeleBot:
         """
         return apihelper.delete_message(self.token, chat_id, message_id, timeout=timeout)
 
-    
+
     def delete_messages(self, chat_id: Union[int, str], message_ids: List[int]):
         """
         Use this method to delete multiple messages simultaneously. If some of the specified messages can't be found, they are skipped.
@@ -2016,7 +2016,7 @@ class TeleBot:
         """
         return apihelper.delete_messages(self.token, chat_id, message_ids)
 
-    
+
     def forward_messages(self, chat_id: Union[str, int], from_chat_id: Union[str, int], message_ids: List[int],
                          disable_notification: Optional[bool]=None, message_thread_id: Optional[int]=None,
                          protect_content: Optional[bool]=None) -> List[types.MessageID]:
@@ -2058,7 +2058,7 @@ class TeleBot:
             protect_content=protect_content)
         return [types.MessageID.de_json(message_id) for message_id in result]
 
-    
+
     def copy_messages(self, chat_id: Union[str, int], from_chat_id: Union[str, int], message_ids: List[int],
                         disable_notification: Optional[bool] = None, message_thread_id: Optional[int] = None,
                         protect_content: Optional[bool] = None, remove_caption: Optional[bool] = None) -> List[types.MessageID]:
@@ -2103,7 +2103,7 @@ class TeleBot:
             self.token, chat_id, from_chat_id, message_ids, disable_notification=disable_notification,
             message_thread_id=message_thread_id, protect_content=protect_content, remove_caption=remove_caption)
         return [types.MessageID.de_json(message_id) for message_id in result]
-    
+
     def send_checklist(
             self, business_connection_id: str, chat_id: Union[int, str],
             checklist: types.InputChecklist,
@@ -2147,7 +2147,7 @@ class TeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
         if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
             reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
@@ -2156,7 +2156,7 @@ class TeleBot:
                 self.token, business_connection_id, chat_id, checklist, disable_notification=disable_notification,
                 protect_content=protect_content, message_effect_id=message_effect_id,
                 reply_parameters=reply_parameters, reply_markup=reply_markup))
-    
+
     def edit_message_checklist(
             self, business_connection_id: str, chat_id: Union[int, str],
             message_id: int, checklist: types.InputChecklist,
@@ -2191,9 +2191,9 @@ class TeleBot:
 
     def send_dice(
             self, chat_id: Union[int, str],
-            emoji: Optional[str]=None, disable_notification: Optional[bool]=None, 
+            emoji: Optional[str]=None, disable_notification: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             protect_content: Optional[bool]=None,
@@ -2284,7 +2284,7 @@ class TeleBot:
 
 
     def send_photo(
-            self, chat_id: Union[int, str], photo: Union[Any, str], 
+            self, chat_id: Union[int, str], photo: Union[Any, str],
             caption: Optional[str]=None, parse_mode: Optional[str]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             disable_notification: Optional[bool]=None,
@@ -2304,7 +2304,7 @@ class TeleBot:
         Use this method to send photos. On success, the sent Message is returned.
 
         Telegram documentation: https://core.telegram.org/bots/api#sendphoto
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -2363,7 +2363,7 @@ class TeleBot:
         :param allow_paid_broadcast: Pass True to allow up to 1000 messages per second, ignoring broadcasting limits for a fee
             of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
         :type allow_paid_broadcast: :obj:`bool`
-        
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2400,14 +2400,14 @@ class TeleBot:
 
 
     def send_audio(
-            self, chat_id: Union[int, str], audio: Union[Any, str], 
-            caption: Optional[str]=None, duration: Optional[int]=None, 
+            self, chat_id: Union[int, str], audio: Union[Any, str],
+            caption: Optional[str]=None, duration: Optional[int]=None,
             performer: Optional[str]=None, title: Optional[str]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            parse_mode: Optional[str]=None, 
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
+            parse_mode: Optional[str]=None,
             disable_notification: Optional[bool]=None,
-            timeout: Optional[int]=None, 
+            timeout: Optional[int]=None,
             thumbnail: Optional[Union[Any, str]]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
@@ -2426,7 +2426,7 @@ class TeleBot:
         For sending voice messages, use the send_voice method instead.
 
         Telegram documentation: https://core.telegram.org/bots/api#sendaudio
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -2536,12 +2536,12 @@ class TeleBot:
 
 
     def send_voice(
-            self, chat_id: Union[int, str], voice: Union[Any, str], 
-            caption: Optional[str]=None, duration: Optional[int]=None, 
+            self, chat_id: Union[int, str], voice: Union[Any, str],
+            caption: Optional[str]=None, duration: Optional[int]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
-            parse_mode: Optional[str]=None, 
-            disable_notification: Optional[bool]=None, 
+            parse_mode: Optional[str]=None,
+            disable_notification: Optional[bool]=None,
             timeout: Optional[int]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
@@ -2555,7 +2555,7 @@ class TeleBot:
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .OGG file encoded with OPUS, or in .MP3 format, or in .M4A format (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
 
         Telegram documentation: https://core.telegram.org/bots/api#sendvoice
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -2648,11 +2648,11 @@ class TeleBot:
     def send_document(
             self, chat_id: Union[int, str], document: Union[Any, str],
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
-            caption: Optional[str]=None, 
+            caption: Optional[str]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
-            parse_mode: Optional[str]=None, 
-            disable_notification: Optional[bool]=None, 
-            timeout: Optional[int]=None, 
+            parse_mode: Optional[str]=None,
+            disable_notification: Optional[bool]=None,
+            timeout: Optional[int]=None,
             thumbnail: Optional[Union[Any, str]]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
@@ -2669,7 +2669,7 @@ class TeleBot:
         Use this method to send general files.
 
         Telegram documentation: https://core.telegram.org/bots/api#senddocument
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -2883,7 +2883,7 @@ class TeleBot:
         if data and (not sticker):
             logger.warning('The parameter "data" is deprecated. Use "sticker" instead.')
             sticker = data
-            
+
         return types.Message.de_json(
             apihelper.send_data(
                 self.token, chat_id, sticker, 'sticker',
@@ -2895,15 +2895,15 @@ class TeleBot:
 
 
     def send_video(
-            self, chat_id: Union[int, str], video: Union[Any, str], 
+            self, chat_id: Union[int, str], video: Union[Any, str],
             duration: Optional[int]=None,
             width: Optional[int]=None,
             height: Optional[int]=None,
-            thumbnail: Optional[Union[Any, str]]=None, 
-            caption: Optional[str]=None, 
-            parse_mode: Optional[str]=None, 
+            thumbnail: Optional[Union[Any, str]]=None,
+            caption: Optional[str]=None,
+            parse_mode: Optional[str]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
-            supports_streaming: Optional[bool]=None, 
+            supports_streaming: Optional[bool]=None,
             disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
@@ -2923,7 +2923,7 @@ class TeleBot:
             start_timestamp: Optional[int]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#sendvideo
 
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -2953,7 +2953,7 @@ class TeleBot:
 
         :param start_timestamp: Start timestamp for the video in the message
         :type start_timestamp: :obj:`int`
-        
+
         :param caption: Video caption (may also be used when resending videos by file_id), 0-1024 characters after entities parsing
         :type caption: :obj:`str`
 
@@ -3061,19 +3061,19 @@ class TeleBot:
 
 
     def send_animation(
-            self, chat_id: Union[int, str], animation: Union[Any, str], 
+            self, chat_id: Union[int, str], animation: Union[Any, str],
             duration: Optional[int]=None,
             width: Optional[int]=None,
             height: Optional[int]=None,
             thumbnail: Optional[Union[Any, str]]=None,
-            caption: Optional[str]=None, 
+            caption: Optional[str]=None,
             parse_mode: Optional[str]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
@@ -3086,7 +3086,7 @@ class TeleBot:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#sendanimation
 
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -3104,7 +3104,7 @@ class TeleBot:
 
         :param height: Animation height
         :type height: :obj:`int`
-        
+
         :param thumbnail: Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side.
             The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320.
             Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file,
@@ -3206,13 +3206,13 @@ class TeleBot:
 
 
     def send_video_note(
-            self, chat_id: Union[int, str], data: Union[Any, str], 
-            duration: Optional[int]=None, 
+            self, chat_id: Union[int, str], data: Union[Any, str],
+            duration: Optional[int]=None,
             length: Optional[int]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
-            disable_notification: Optional[bool]=None, 
-            timeout: Optional[int]=None, 
+            disable_notification: Optional[bool]=None,
+            timeout: Optional[int]=None,
             thumbnail: Optional[Union[Any, str]]=None,
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             protect_content: Optional[bool]=None,
@@ -3227,10 +3227,10 @@ class TeleBot:
         Use this method to send video messages. On success, the sent Message is returned.
 
         Telegram documentation: https://core.telegram.org/bots/api#sendvideonote
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
-        
+
         :param data: Video note to send. Pass a file_id as String to send a video note that exists on the Telegram servers (recommended)
             or upload a new video using multipart/form-data. Sending video notes by a URL is currently unsupported
         :type data: :obj:`str` or :class:`telebot.types.InputFile`
@@ -3261,7 +3261,7 @@ class TeleBot:
         :param thumbnail: Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side.
             The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320.
             Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file,
-            so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. 
+            so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>.
         :type thumbnail: :obj:`str` or :class:`telebot.types.InputFile`
 
         :param protect_content: Protects the contents of the sent message from forwarding and saving
@@ -3321,7 +3321,7 @@ class TeleBot:
                 protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters,
                 business_connection_id=business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast)
         )
-    
+
     def send_paid_media(
             self, chat_id: Union[int, str], star_count: int, media: List[types.InputPaidMedia],
             caption: Optional[str]=None, parse_mode: Optional[str]=None, caption_entities: Optional[List[types.MessageEntity]]=None,
@@ -3392,11 +3392,11 @@ class TeleBot:
 
 
     def send_media_group(
-            self, chat_id: Union[int, str], 
+            self, chat_id: Union[int, str],
             media: List[Union[
-                types.InputMediaAudio, types.InputMediaDocument, 
+                types.InputMediaAudio, types.InputMediaDocument,
                 types.InputMediaPhoto, types.InputMediaVideo]],
-            disable_notification: Optional[bool]=None, 
+            disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
             timeout: Optional[int]=None,
@@ -3409,7 +3409,7 @@ class TeleBot:
         """
         Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files
         can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#sendmediagroup
 
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -3487,17 +3487,17 @@ class TeleBot:
 
 
     def send_location(
-            self, chat_id: Union[int, str], 
-            latitude: float, longitude: float, 
+            self, chat_id: Union[int, str],
+            latitude: float, longitude: float,
             live_period: Optional[int]=None,
-            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility 
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            disable_notification: Optional[bool]=None, 
+            reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
+            disable_notification: Optional[bool]=None,
             timeout: Optional[int]=None,
-            horizontal_accuracy: Optional[float]=None, 
-            heading: Optional[int]=None, 
+            horizontal_accuracy: Optional[float]=None,
+            heading: Optional[int]=None,
             proximity_alert_radius: Optional[int]=None,
-            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility 
+            allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
@@ -3601,14 +3601,14 @@ class TeleBot:
 
 
     def edit_message_live_location(
-            self, latitude: float, longitude: float, 
-            chat_id: Optional[Union[int, str]]=None, 
+            self, latitude: float, longitude: float,
+            chat_id: Optional[Union[int, str]]=None,
             message_id: Optional[int]=None,
-            inline_message_id: Optional[str]=None, 
+            inline_message_id: Optional[str]=None,
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             timeout: Optional[int]=None,
-            horizontal_accuracy: Optional[float]=None, 
-            heading: Optional[int]=None, 
+            horizontal_accuracy: Optional[float]=None,
+            heading: Optional[int]=None,
             proximity_alert_radius: Optional[int]=None,
             live_period: Optional[int]=None,
             business_connection_id: Optional[str]=None
@@ -3669,9 +3669,9 @@ class TeleBot:
 
 
     def stop_message_live_location(
-            self, chat_id: Optional[Union[int, str]]=None, 
+            self, chat_id: Optional[Union[int, str]]=None,
             message_id: Optional[int]=None,
-            inline_message_id: Optional[str]=None, 
+            inline_message_id: Optional[str]=None,
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             timeout: Optional[int]=None,
             business_connection_id: Optional[str]=None) -> Union[types.Message, bool]:
@@ -3680,7 +3680,7 @@ class TeleBot:
         On success, if the message is not an inline message, the edited Message is returned, otherwise True is returned.
 
         Telegram documentation: https://core.telegram.org/bots/api#stopmessagelivelocation
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -3711,14 +3711,14 @@ class TeleBot:
 
 
     def send_venue(
-            self, chat_id: Union[int, str], 
-            latitude: Optional[float], longitude: Optional[float], 
-            title: str, address: str, 
-            foursquare_id: Optional[str]=None, 
+            self, chat_id: Union[int, str],
+            latitude: Optional[float], longitude: Optional[float],
+            title: str, address: str,
+            foursquare_id: Optional[str]=None,
             foursquare_type: Optional[str]=None,
-            disable_notification: Optional[bool]=None, 
+            disable_notification: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             google_place_id: Optional[str]=None,
@@ -3731,12 +3731,12 @@ class TeleBot:
             allow_paid_broadcast: Optional[bool]=None) -> types.Message:
         """
         Use this method to send information about a venue. On success, the sent Message is returned.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#sendvenue
 
         :param chat_id: Unique identifier for the target chat or username of the target channel
         :type chat_id: :obj:`int` or :obj:`str`
-        
+
         :param latitude: Latitude of the venue
         :type latitude: :obj:`float`
 
@@ -3833,12 +3833,12 @@ class TeleBot:
 
 
     def send_contact(
-            self, chat_id: Union[int, str], phone_number: str, 
-            first_name: str, last_name: Optional[str]=None, 
+            self, chat_id: Union[int, str], phone_number: str,
+            first_name: str, last_name: Optional[str]=None,
             vcard: Optional[str]=None,
-            disable_notification: Optional[bool]=None, 
+            disable_notification: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             protect_content: Optional[bool]=None, message_thread_id: Optional[int]=None,
@@ -3950,7 +3950,7 @@ class TeleBot:
 
         :param chat_id: Unique identifier for the target chat or username of the target channel
         :type chat_id: :obj:`int` or :obj:`str`
-        
+
         :param action: Type of action to broadcast. Choose one, depending on what the user is about
             to receive: typing for text messages, upload_photo for photos, record_video or upload_video
             for videos, record_voice or upload_voice for voice notes, upload_document for general files,
@@ -3972,11 +3972,11 @@ class TeleBot:
         return apihelper.send_chat_action(
             self.token, chat_id, action, timeout=timeout, message_thread_id=message_thread_id, business_connection_id=business_connection_id)
 
-    
+
     @util.deprecated(deprecation_text="Use ban_chat_member instead")
     def kick_chat_member(
-            self, chat_id: Union[int, str], user_id: int, 
-            until_date:Optional[Union[int, datetime]]=None, 
+            self, chat_id: Union[int, str], user_id: int,
+            until_date:Optional[Union[int, datetime]]=None,
             revoke_messages: Optional[bool]=None) -> bool:
         """
         This function is deprecated. Use `ban_chat_member` instead.
@@ -3986,13 +3986,13 @@ class TeleBot:
 
 
     def ban_chat_member(
-            self, chat_id: Union[int, str], user_id: int, 
-            until_date: Optional[Union[int, datetime]]=None, 
+            self, chat_id: Union[int, str], user_id: int,
+            until_date: Optional[Union[int, datetime]]=None,
             revoke_messages: Optional[bool]=None) -> bool:
         """
-        Use this method to ban a user in a group, a supergroup or a channel. 
-        In the case of supergroups and channels, the user will not be able to return to the chat on their 
-        own using invite links, etc., unless unbanned first. 
+        Use this method to ban a user in a group, a supergroup or a channel.
+        In the case of supergroups and channels, the user will not be able to return to the chat on their
+        own using invite links, etc., unless unbanned first.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#banchatmember
@@ -4009,10 +4009,10 @@ class TeleBot:
         :type until_date: :obj:`int` or :obj:`datetime`
 
         :param revoke_messages: Pass True to delete all messages from the chat for the user that is being removed.
-            If False, the user will be able to see messages in the group that were sent before the user was removed. 
+            If False, the user will be able to see messages in the group that were sent before the user was removed.
             Always True for supergroups and channels.
         :type revoke_messages: :obj:`bool`
-        
+
         :return: Returns True on success.
         :rtype: :obj:`bool`
         """
@@ -4021,7 +4021,7 @@ class TeleBot:
 
 
     def unban_chat_member(
-            self, chat_id: Union[int, str], user_id: int, 
+            self, chat_id: Union[int, str], user_id: int,
             only_if_banned: Optional[bool]=False) -> bool:
         """
         Use this method to unban a previously kicked user in a supergroup or channel.
@@ -4049,15 +4049,15 @@ class TeleBot:
 
 
     def restrict_chat_member(
-            self, chat_id: Union[int, str], user_id: int, 
+            self, chat_id: Union[int, str], user_id: int,
             until_date: Optional[Union[int, datetime]]=None,
-            can_send_messages: Optional[bool]=None, 
+            can_send_messages: Optional[bool]=None,
             can_send_media_messages: Optional[bool]=None,
-            can_send_polls: Optional[bool]=None, 
+            can_send_polls: Optional[bool]=None,
             can_send_other_messages: Optional[bool]=None,
-            can_add_web_page_previews: Optional[bool]=None, 
+            can_add_web_page_previews: Optional[bool]=None,
             can_change_info: Optional[bool]=None,
-            can_invite_users: Optional[bool]=None, 
+            can_invite_users: Optional[bool]=None,
             can_pin_messages: Optional[bool]=None,
             permissions: Optional[types.ChatPermissions]=None,
             use_independent_chat_permissions: Optional[bool]=None) -> bool:
@@ -4085,10 +4085,10 @@ class TeleBot:
 
         :param can_send_messages: deprecated
         :type can_send_messages: :obj:`bool`
-        
+
         :param can_send_media_messages: deprecated
         :type can_send_media_messages: :obj:`bool`
-        
+
         :param can_send_polls: deprecated
         :type can_send_polls: :obj:`bool`
 
@@ -4139,16 +4139,16 @@ class TeleBot:
 
     def promote_chat_member(
             self, chat_id: Union[int, str], user_id: int,
-            can_change_info: Optional[bool]=None, 
+            can_change_info: Optional[bool]=None,
             can_post_messages: Optional[bool]=None,
-            can_edit_messages: Optional[bool]=None, 
-            can_delete_messages: Optional[bool]=None, 
+            can_edit_messages: Optional[bool]=None,
+            can_delete_messages: Optional[bool]=None,
             can_invite_users: Optional[bool]=None,
-            can_restrict_members: Optional[bool]=None, 
-            can_pin_messages: Optional[bool]=None, 
+            can_restrict_members: Optional[bool]=None,
+            can_pin_messages: Optional[bool]=None,
             can_promote_members: Optional[bool]=None,
-            is_anonymous: Optional[bool]=None, 
-            can_manage_chat: Optional[bool]=None, 
+            is_anonymous: Optional[bool]=None,
+            can_manage_chat: Optional[bool]=None,
             can_manage_video_chats: Optional[bool]=None,
             can_manage_voice_chats: Optional[bool]=None,
             can_manage_topics: Optional[bool]=None,
@@ -4198,9 +4198,9 @@ class TeleBot:
         :param is_anonymous: Pass True, if the administrator's presence in the chat is hidden
         :type is_anonymous: :obj:`bool`
 
-        :param can_manage_chat: Pass True, if the administrator can access the chat event log, chat statistics, 
-            message statistics in channels, see channel members, 
-            see anonymous administrators in supergroups and ignore slow mode. 
+        :param can_manage_chat: Pass True, if the administrator can access the chat event log, chat statistics,
+            message statistics in channels, see channel members,
+            see anonymous administrators in supergroups and ignore slow mode.
             Implied by any other administrator privilege
         :type can_manage_chat: :obj:`bool`
 
@@ -4267,14 +4267,14 @@ class TeleBot:
         """
         return apihelper.set_chat_administrator_custom_title(self.token, chat_id, user_id, custom_title)
 
-    
+
     def ban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str]) -> bool:
         """
         Use this method to ban a channel chat in a supergroup or a channel.
-        The owner of the chat will not be able to send messages and join live 
-        streams on behalf of the chat, unless it is unbanned first. 
-        The bot must be an administrator in the supergroup or channel 
-        for this to work and must have the appropriate administrator rights. 
+        The owner of the chat will not be able to send messages and join live
+        streams on behalf of the chat, unless it is unbanned first.
+        The bot must be an administrator in the supergroup or channel
+        for this to work and must have the appropriate administrator rights.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#banchatsenderchat
@@ -4293,8 +4293,8 @@ class TeleBot:
 
     def unban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str]) -> bool:
         """
-        Use this method to unban a previously banned channel chat in a supergroup or channel. 
-        The bot must be an administrator for this to work and must have the appropriate 
+        Use this method to unban a previously banned channel chat in a supergroup or channel.
+        The bot must be an administrator for this to work and must have the appropriate
         administrator rights.
         Returns True on success.
 
@@ -4345,7 +4345,7 @@ class TeleBot:
     def create_chat_invite_link(
             self, chat_id: Union[int, str],
             name: Optional[str]=None,
-            expire_date: Optional[Union[int, datetime]]=None, 
+            expire_date: Optional[Union[int, datetime]]=None,
             member_limit: Optional[int]=None,
             creates_join_request: Optional[bool]=None) -> types.ChatInviteLink:
         """
@@ -4432,7 +4432,7 @@ class TeleBot:
         :param chat_id: Unique identifier for the target channel chat or username of the target channel
             (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
-        
+
         :param name: Invite link name; 0-32 characters
         :type name: :obj:`str`
 
@@ -4450,7 +4450,7 @@ class TeleBot:
         return types.ChatInviteLink.de_json(
             apihelper.create_chat_subscription_invite_link(self.token, chat_id, subscription_period, subscription_price, name=name)
         )
-    
+
     def edit_chat_subscription_invite_link(
             self, chat_id: Union[int, str], invite_link: str, name: Optional[str]=None) -> types.ChatInviteLink:
         """
@@ -4480,7 +4480,7 @@ class TeleBot:
             self, chat_id: Union[int, str], invite_link: str) -> types.ChatInviteLink:
         """
         Use this method to revoke an invite link created by the bot.
-        Note: If the primary link is revoked, a new link is automatically generated The bot must be an administrator 
+        Note: If the primary link is revoked, a new link is automatically generated The bot must be an administrator
         in the chat for this to work and must have the appropriate admin rights.
 
         Telegram documentation: https://core.telegram.org/bots/api#revokechatinvitelink
@@ -4519,7 +4519,7 @@ class TeleBot:
 
     def approve_chat_join_request(self, chat_id: Union[str, int], user_id: Union[int, str]) -> bool:
         """
-        Use this method to approve a chat join request. 
+        Use this method to approve a chat join request.
         The bot must be an administrator in the chat for this to work and must have
         the can_invite_users administrator right. Returns True on success.
 
@@ -4540,7 +4540,7 @@ class TeleBot:
 
     def decline_chat_join_request(self, chat_id: Union[str, int], user_id: Union[int, str]) -> bool:
         """
-        Use this method to decline a chat join request. 
+        Use this method to decline a chat join request.
         The bot must be an administrator in the chat for this to work and must have
         the can_invite_users administrator right. Returns True on success.
 
@@ -4599,21 +4599,21 @@ class TeleBot:
         """
         return apihelper.delete_chat_photo(self.token, chat_id)
 
-    
-    def get_my_commands(self, scope: Optional[types.BotCommandScope]=None, 
+
+    def get_my_commands(self, scope: Optional[types.BotCommandScope]=None,
             language_code: Optional[str]=None) -> List[types.BotCommand]:
         """
-        Use this method to get the current list of the bot's commands. 
+        Use this method to get the current list of the bot's commands.
         Returns List of BotCommand on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#getmycommands
 
-        :param scope: The scope of users for which the commands are relevant. 
+        :param scope: The scope of users for which the commands are relevant.
             Defaults to BotCommandScopeDefault.
         :type scope: :class:`telebot.types.BotCommandScope`
 
-        :param language_code: A two-letter ISO 639-1 language code. If empty, 
-            commands will be applied to all users from the given scope, 
+        :param language_code: A two-letter ISO 639-1 language code. If empty,
+            commands will be applied to all users from the given scope,
             for whose language there are no dedicated commands
         :type language_code: :obj:`str`
 
@@ -4641,7 +4641,7 @@ class TeleBot:
         """
         return apihelper.set_my_name(self.token, name=name, language_code=language_code)
 
-    
+
     def get_my_name(self, language_code: Optional[str]=None):
         """
         Use this method to get the current bot name for the given user language.
@@ -4680,7 +4680,7 @@ class TeleBot:
         return apihelper.set_my_description(
             self.token, description=description, language_code=language_code)
 
-    
+
     def get_my_description(self, language_code: Optional[str]=None):
         """
         Use this method to get the current bot description for the given user language.
@@ -4696,11 +4696,11 @@ class TeleBot:
         return types.BotDescription.de_json(
             apihelper.get_my_description(self.token, language_code=language_code))
 
-    
+
     def set_my_short_description(self, short_description:Optional[str]=None, language_code:Optional[str]=None):
         """
         Use this method to change the bot's short description, which is shown on the bot's profile page and
-        is sent together with the link when users share the bot. 
+        is sent together with the link when users share the bot.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#setmyshortdescription
@@ -4717,7 +4717,7 @@ class TeleBot:
         return apihelper.set_my_short_description(
             self.token, short_description=short_description, language_code=language_code)
 
-    
+
     def get_my_short_description(self, language_code: Optional[str]=None):
         """
         Use this method to get the current bot short description for the given user language.
@@ -4736,13 +4736,13 @@ class TeleBot:
 
     def set_chat_menu_button(self, chat_id: Union[int, str]=None, menu_button: types.MenuButton=None) -> bool:
         """
-        Use this method to change the bot's menu button in a private chat, 
-        or the default menu button. 
+        Use this method to change the bot's menu button in a private chat,
+        or the default menu button.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#setchatmenubutton
 
-        :param chat_id: Unique identifier for the target private chat. 
+        :param chat_id: Unique identifier for the target private chat.
             If not specified, default bot's menu button will be changed.
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -4774,13 +4774,13 @@ class TeleBot:
             apihelper.get_chat_menu_button(self.token, chat_id=chat_id))
 
 
-    def set_my_default_administrator_rights(self, rights: types.ChatAdministratorRights=None, 
+    def set_my_default_administrator_rights(self, rights: types.ChatAdministratorRights=None,
                                     for_channels: Optional[bool]=None) -> bool:
         """
         Use this method to change the default administrator rights requested by the bot
         when it's added as an administrator to groups or channels.
         These rights will be suggested to users, but they are are free to modify
-        the list before adding the bot. 
+        the list before adding the bot.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#setmydefaultadministratorrights
@@ -4834,8 +4834,8 @@ class TeleBot:
         return types.BusinessConnection.de_json(
             apihelper.get_business_connection(self.token, business_connection_id)
         )
-    
-        
+
+
     def set_my_commands(self, commands: List[types.BotCommand],
             scope: Optional[types.BotCommandScope]=None,
             language_code: Optional[str]=None) -> bool:
@@ -4847,12 +4847,12 @@ class TeleBot:
         :param commands: List of BotCommand. At most 100 commands can be specified.
         :type commands: :obj:`list` of :class:`telebot.types.BotCommand`
 
-        :param scope: The scope of users for which the commands are relevant. 
+        :param scope: The scope of users for which the commands are relevant.
             Defaults to BotCommandScopeDefault.
         :type scope: :class:`telebot.types.BotCommandScope`
 
-        :param language_code: A two-letter ISO 639-1 language code. If empty, 
-            commands will be applied to all users from the given scope, 
+        :param language_code: A two-letter ISO 639-1 language code. If empty,
+            commands will be applied to all users from the given scope,
             for whose language there are no dedicated commands
         :type language_code: :obj:`str`
 
@@ -4861,22 +4861,22 @@ class TeleBot:
         """
         return apihelper.set_my_commands(self.token, commands, scope=scope, language_code=language_code)
 
-    
-    def delete_my_commands(self, scope: Optional[types.BotCommandScope]=None, 
+
+    def delete_my_commands(self, scope: Optional[types.BotCommandScope]=None,
             language_code: Optional[str]=None) -> bool:
         """
-        Use this method to delete the list of the bot's commands for the given scope and user language. 
-        After deletion, higher level commands will be shown to affected users. 
+        Use this method to delete the list of the bot's commands for the given scope and user language.
+        After deletion, higher level commands will be shown to affected users.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#deletemycommands
-        
-        :param scope: The scope of users for which the commands are relevant. 
+
+        :param scope: The scope of users for which the commands are relevant.
             Defaults to BotCommandScopeDefault.
         :type scope: :class:`telebot.types.BotCommandScope`
 
-        :param language_code: A two-letter ISO 639-1 language code. If empty, 
-            commands will be applied to all users from the given scope, 
+        :param language_code: A two-letter ISO 639-1 language code. If empty,
+            commands will be applied to all users from the given scope,
             for whose language there are no dedicated commands
         :type language_code: :obj:`str`
 
@@ -4930,7 +4930,7 @@ class TeleBot:
 
 
     def pin_chat_message(
-            self, chat_id: Union[int, str], message_id: int, 
+            self, chat_id: Union[int, str], message_id: int,
             disable_notification: Optional[bool]=False, business_connection_id: Optional[str]=None) -> bool:
         """
         Use this method to pin a message in a supergroup.
@@ -5005,10 +5005,10 @@ class TeleBot:
 
 
     def edit_message_text(
-            self, text: str, 
-            chat_id: Optional[Union[int, str]]=None, 
-            message_id: Optional[int]=None, 
-            inline_message_id: Optional[str]=None, 
+            self, text: str,
+            chat_id: Optional[Union[int, str]]=None,
+            message_id: Optional[int]=None,
+            inline_message_id: Optional[str]=None,
             parse_mode: Optional[str]=None,
             entities: Optional[List[types.MessageEntity]]=None,
             disable_web_page_preview: Optional[bool]=None,        # deprecated, for backward compatibility
@@ -5058,7 +5058,7 @@ class TeleBot:
         :rtype: :obj:`types.Message` or :obj:`bool`
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
-                
+
         if disable_web_page_preview is not None:
             # show a deprecation warning
             logger.warning("The parameter 'disable_web_page_preview' is deprecated. Use 'link_preview_options' instead.")
@@ -5089,9 +5089,9 @@ class TeleBot:
 
 
     def edit_message_media(
-            self, media: Any, chat_id: Optional[Union[int, str]]=None, 
+            self, media: Any, chat_id: Optional[Union[int, str]]=None,
             message_id: Optional[int]=None,
-            inline_message_id: Optional[str]=None, 
+            inline_message_id: Optional[str]=None,
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             business_connection_id: Optional[str]=None,
             timeout: Optional[int]=None) -> Union[types.Message, bool]:
@@ -5100,7 +5100,7 @@ class TeleBot:
         If a message is part of a message album, then it can be edited only to an audio for audio albums, only to a document for document albums and to a photo or a video otherwise.
         When an inline message is edited, a new file can't be uploaded; use a previously uploaded file via its file_id or specify a URL.
         On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
-        Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent. 
+        Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent.
 
         Telegram documentation: https://core.telegram.org/bots/api#editmessagemedia
 
@@ -5109,7 +5109,7 @@ class TeleBot:
         :param chat_id: Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
-        :param message_id: Required if inline_message_id is not specified. Identifier of the sent message 
+        :param message_id: Required if inline_message_id is not specified. Identifier of the sent message
         :type message_id: :obj:`int`
 
         :param inline_message_id: Required if chat_id and message_id are not specified. Identifier of the inline message
@@ -5137,9 +5137,9 @@ class TeleBot:
 
 
     def edit_message_reply_markup(
-            self, chat_id: Optional[Union[int, str]]=None, 
+            self, chat_id: Optional[Union[int, str]]=None,
             message_id: Optional[int]=None,
-            inline_message_id: Optional[str]=None, 
+            inline_message_id: Optional[str]=None,
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             business_connection_id: Optional[str]=None,
             timeout: Optional[int]=None) -> Union[types.Message, bool]:
@@ -5179,10 +5179,10 @@ class TeleBot:
 
 
     def send_game(
-            self, chat_id: Union[int, str], game_short_name: str, 
+            self, chat_id: Union[int, str], game_short_name: str,
             disable_notification: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             protect_content: Optional[bool]=None,
@@ -5273,10 +5273,10 @@ class TeleBot:
 
 
     def set_game_score(
-            self, user_id: Union[int, str], score: int, 
-            force: Optional[bool]=None, 
-            chat_id: Optional[Union[int, str]]=None, 
-            message_id: Optional[int]=None, 
+            self, user_id: Union[int, str], score: int,
+            force: Optional[bool]=None,
+            chat_id: Optional[Union[int, str]]=None,
+            message_id: Optional[int]=None,
             inline_message_id: Optional[str]=None,
             disable_edit_message: Optional[bool]=None) -> Union[types.Message, bool]:
         """
@@ -5319,7 +5319,7 @@ class TeleBot:
 
     def get_game_high_scores(
             self, user_id: int, chat_id: Optional[Union[int, str]]=None,
-            message_id: Optional[int]=None, 
+            message_id: Optional[int]=None,
             inline_message_id: Optional[str]=None) -> List[types.GameHighScore]:
         """
         Use this method to get data for high score tables. Will return the score of the specified user and several of
@@ -5352,20 +5352,20 @@ class TeleBot:
 
 
     def send_invoice(
-            self, chat_id: Union[int, str], title: str, description: str, 
-            invoice_payload: str, provider_token: Union[str, None], currency: str, 
-            prices: List[types.LabeledPrice], start_parameter: Optional[str]=None, 
-            photo_url: Optional[str]=None, photo_size: Optional[int]=None, 
+            self, chat_id: Union[int, str], title: str, description: str,
+            invoice_payload: str, provider_token: Union[str, None], currency: str,
+            prices: List[types.LabeledPrice], start_parameter: Optional[str]=None,
+            photo_url: Optional[str]=None, photo_size: Optional[int]=None,
             photo_width: Optional[int]=None, photo_height: Optional[int]=None,
-            need_name: Optional[bool]=None, need_phone_number: Optional[bool]=None, 
+            need_name: Optional[bool]=None, need_phone_number: Optional[bool]=None,
             need_email: Optional[bool]=None, need_shipping_address: Optional[bool]=None,
-            send_phone_number_to_provider: Optional[bool]=None, 
-            send_email_to_provider: Optional[bool]=None, 
+            send_phone_number_to_provider: Optional[bool]=None,
+            send_email_to_provider: Optional[bool]=None,
             is_flexible: Optional[bool]=None,
-            disable_notification: Optional[bool]=None, 
+            disable_notification: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            provider_data: Optional[str]=None, 
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
+            provider_data: Optional[str]=None,
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             max_tip_amount: Optional[int] = None,
@@ -5416,7 +5416,7 @@ class TeleBot:
         :param photo_size: Photo size in bytes
         :type photo_size: :obj:`int`
 
-        :param photo_width: Photo width 
+        :param photo_width: Photo width
         :type photo_width: :obj:`int`
 
         :param photo_height: Photo height
@@ -5530,9 +5530,9 @@ class TeleBot:
         )
 
     def create_invoice_link(self,
-            title: str, description: str, payload:str, provider_token: Union[str, None], 
+            title: str, description: str, payload:str, provider_token: Union[str, None],
             currency: str, prices: List[types.LabeledPrice],
-            max_tip_amount: Optional[int] = None, 
+            max_tip_amount: Optional[int] = None,
             suggested_tip_amounts: Optional[List[int]]=None,
             provider_data: Optional[str]=None,
             photo_url: Optional[str]=None,
@@ -5548,9 +5548,9 @@ class TeleBot:
             is_flexible: Optional[bool]=None,
             subscription_period: Optional[int]=None,
             business_connection_id: Optional[str]=None) -> str:
-            
+
         """
-        Use this method to create a link for an invoice. 
+        Use this method to create a link for an invoice.
         Returns the created invoice link as String on success.
 
         Telegram documentation:
@@ -5649,17 +5649,17 @@ class TeleBot:
     # noinspection PyShadowingBuiltins
     def send_poll(
             self, chat_id: Union[int, str], question: str, options: List[Union[str, types.InputPollOption]],
-            is_anonymous: Optional[bool]=None, type: Optional[str]=None, 
-            allows_multiple_answers: Optional[bool]=None, 
+            is_anonymous: Optional[bool]=None, type: Optional[str]=None,
+            allows_multiple_answers: Optional[bool]=None,
             correct_option_id: Optional[int]=None,
-            explanation: Optional[str]=None, 
-            explanation_parse_mode: Optional[str]=None, 
-            open_period: Optional[int]=None, 
-            close_date: Optional[Union[int, datetime]]=None, 
+            explanation: Optional[str]=None,
+            explanation_parse_mode: Optional[str]=None,
+            open_period: Optional[int]=None,
+            close_date: Optional[Union[int, datetime]]=None,
             is_closed: Optional[bool]=None,
             disable_notification: Optional[bool]=False,
             reply_to_message_id: Optional[int]=None,          # deprecated, for backward compatibility
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             allow_sending_without_reply: Optional[bool]=None, # deprecated, for backward compatibility
             timeout: Optional[int]=None,
             explanation_entities: Optional[List[types.MessageEntity]]=None,
@@ -5816,7 +5816,7 @@ class TeleBot:
 
 
     def stop_poll(
-            self, chat_id: Union[int, str], message_id: int, 
+            self, chat_id: Union[int, str], message_id: int,
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             business_connection_id: Optional[str]=None) -> types.Poll:
         """
@@ -5845,8 +5845,8 @@ class TeleBot:
 
 
     def answer_shipping_query(
-            self, shipping_query_id: str, ok: bool, 
-            shipping_options: Optional[List[types.ShippingOption]]=None, 
+            self, shipping_query_id: str, ok: bool,
+            shipping_options: Optional[List[types.ShippingOption]]=None,
             error_message: Optional[str]=None) -> bool:
         """
         Asks for an answer to a shipping question.
@@ -5874,7 +5874,7 @@ class TeleBot:
 
 
     def answer_pre_checkout_query(
-            self, pre_checkout_query_id: str, ok: bool, 
+            self, pre_checkout_query_id: str, ok: bool,
             error_message: Optional[str]=None) -> bool:
         """
         Once the user has confirmed their payment and shipping details, the Bot API sends the final confirmation in the form of an Update with the
@@ -5886,7 +5886,7 @@ class TeleBot:
 
         Telegram documentation: https://core.telegram.org/bots/api#answerprecheckoutquery
 
-        :param pre_checkout_query_id: Unique identifier for the query to be answered 
+        :param pre_checkout_query_id: Unique identifier for the query to be answered
         :type pre_checkout_query_id: :obj:`int`
 
         :param ok: Specify True if everything is alright (goods are available, etc.) and the bot is ready to proceed with the order. Use False if there are any problems.
@@ -5902,11 +5902,11 @@ class TeleBot:
         """
         return apihelper.answer_pre_checkout_query(
             self.token, pre_checkout_query_id, ok, error_message=error_message)
-    
+
     def get_my_star_balance(self) -> types.StarAmount:
         """
         Returns the bot's current Telegram Stars balance. On success, returns a StarAmount object.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#getmystarbalance
 
         :return: On success, returns a StarAmount object.
@@ -5933,8 +5933,8 @@ class TeleBot:
         return types.StarTransactions.de_json(
             apihelper.get_star_transactions(self.token, offset=offset, limit=limit)
         )
-    
-    
+
+
     def refund_star_payment(self, user_id: int, telegram_payment_charge_id: str) -> bool:
         """
         Refunds a successful payment in Telegram Stars. Returns True on success.
@@ -5973,10 +5973,10 @@ class TeleBot:
         return apihelper.edit_user_star_subscription(self.token, user_id, telegram_payment_charge_id, is_canceled)
 
     def edit_message_caption(
-            self, caption: str, chat_id: Optional[Union[int, str]]=None, 
-            message_id: Optional[int]=None, 
+            self, caption: str, chat_id: Optional[Union[int, str]]=None,
+            message_id: Optional[int]=None,
             inline_message_id: Optional[str]=None,
-            parse_mode: Optional[str]=None, 
+            parse_mode: Optional[str]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             show_caption_above_media: Optional[bool]=None,
@@ -6068,12 +6068,12 @@ class TeleBot:
 
 
     def answer_inline_query(
-            self, inline_query_id: str, 
-            results: List[Any], 
-            cache_time: Optional[int]=None, 
-            is_personal: Optional[bool]=None, 
+            self, inline_query_id: str,
+            results: List[Any],
+            cache_time: Optional[int]=None,
+            is_personal: Optional[bool]=None,
             next_offset: Optional[str]=None,
-            switch_pm_text: Optional[str]=None, 
+            switch_pm_text: Optional[str]=None,
             switch_pm_parameter: Optional[str]=None,
             button: Optional[types.InlineQueryResultsButton]=None) -> bool:
         """
@@ -6120,7 +6120,7 @@ class TeleBot:
         if not button and (switch_pm_text or switch_pm_parameter):
             logger.warning("switch_pm_text and switch_pm_parameter are deprecated for answer_inline_query. Use button instead.")
             button = types.InlineQueryResultsButton(text=switch_pm_text, start_parameter=switch_pm_parameter)
-        
+
         return apihelper.answer_inline_query(
             self.token, inline_query_id, results, cache_time=cache_time, is_personal=is_personal,
             next_offset=next_offset, button=button)
@@ -6128,7 +6128,7 @@ class TeleBot:
 
     def unpin_all_general_forum_topic_messages(self, chat_id: Union[int, str]) -> bool:
         """
-        Use this method to clear the list of pinned messages in a General forum topic. 
+        Use this method to clear the list of pinned messages in a General forum topic.
         The bot must be an administrator in the chat for this to work and must have the
         can_pin_messages administrator right in the supergroup.
         Returns True on success.
@@ -6145,8 +6145,8 @@ class TeleBot:
 
 
     def answer_callback_query(
-            self, callback_query_id: int, 
-            text: Optional[str]=None, show_alert: Optional[bool]=None, 
+            self, callback_query_id: int,
+            text: Optional[str]=None, show_alert: Optional[bool]=None,
             url: Optional[str]=None, cache_time: Optional[int]=None) -> bool:
         """
         Use this method to send answers to callback queries sent from inline keyboards. The answer will be displayed to
@@ -6176,7 +6176,7 @@ class TeleBot:
         return apihelper.answer_callback_query(
             self.token, callback_query_id, text=text, show_alert=show_alert, url=url, cache_time=cache_time)
 
-    
+
     def get_user_chat_boosts(self, chat_id: Union[int, str], user_id: int) -> types.UserChatBoosts:
         """
         Use this method to get the list of boosts added to a chat by a user. Requires administrator rights in the chat. Returns a UserChatBoosts object.
@@ -6199,7 +6199,7 @@ class TeleBot:
     # noinspection PyShadowingBuiltins
     def set_sticker_set_thumbnail(self, name: str, user_id: int, thumbnail: Union[Any, str]=None, format: Optional[str]=None) -> bool:
         """
-        Use this method to set the thumbnail of a sticker set. 
+        Use this method to set the thumbnail of a sticker set.
         Animated thumbnails can be set for animated sticker sets only. Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#setstickersetthumbnail
@@ -6230,11 +6230,11 @@ class TeleBot:
 
         return apihelper.set_sticker_set_thumbnail(self.token, name, user_id, thumbnail, format)
 
-    
+
     @util.deprecated(deprecation_text="Use set_sticker_set_thumbnail instead")
     def set_sticker_set_thumb(self, name: str, user_id: int, thumb: Union[Any, str]=None):
         """
-        Use this method to set the thumbnail of a sticker set. 
+        Use this method to set the thumbnail of a sticker set.
         Animated thumbnails can be set for animated sticker sets only. Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#setstickersetthumb
@@ -6258,7 +6258,7 @@ class TeleBot:
     def get_sticker_set(self, name: str) -> types.StickerSet:
         """
         Use this method to get a sticker set. On success, a StickerSet object is returned.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#getstickerset
 
         :param name: Sticker set name
@@ -6285,7 +6285,7 @@ class TeleBot:
         result = apihelper.get_custom_emoji_stickers(self.token, custom_emoji_ids)
         return [types.Sticker.de_json(sticker) for sticker in result]
 
-    
+
     def set_sticker_keywords(self, sticker: str, keywords: List[str]=None) -> bool:
         """
         Use this method to change search keywords assigned to a regular or custom emoji sticker.
@@ -6303,7 +6303,7 @@ class TeleBot:
         """
         return apihelper.set_sticker_keywords(self.token, sticker, keywords=keywords)
 
-    
+
     def set_sticker_mask_position(self, sticker: str, mask_position: types.MaskPosition=None) -> bool:
         """
         Use this method to change the mask position of a mask sticker.
@@ -6320,7 +6320,7 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.set_sticker_mask_position(self.token, sticker, mask_position=mask_position)
-    
+
 
     def set_custom_emoji_sticker_set_thumbnail(self, name: str, custom_emoji_id: Optional[str]=None) -> bool:
         """
@@ -6338,7 +6338,7 @@ class TeleBot:
         """
         return apihelper.set_custom_emoji_sticker_set_thumbnail(self.token, name, custom_emoji_id=custom_emoji_id)
 
-    
+
     def set_sticker_set_title(self, name: str, title: str) -> bool:
         """
         Use this method to set the title of a created sticker set.
@@ -6355,7 +6355,7 @@ class TeleBot:
         """
         return apihelper.set_sticker_set_title(self.token, name, title)
 
-    
+
     def delete_sticker_set(self, name:str) -> bool:
         """
         Use this method to delete a sticker set. Returns True on success.
@@ -6368,7 +6368,7 @@ class TeleBot:
         """
         return apihelper.delete_sticker_set(self.token, name)
 
-    def send_gift(self, user_id: Optional[Union[str, int]] = None, gift_id: str=None, text: Optional[str]=None, text_parse_mode: Optional[str]=None, 
+    def send_gift(self, user_id: Optional[Union[str, int]] = None, gift_id: str=None, text: Optional[str]=None, text_parse_mode: Optional[str]=None,
                   text_entities: Optional[List[types.MessageEntity]]=None, pay_for_upgrade: Optional[bool]=None,
                   chat_id: Optional[Union[str, int]] = None) -> bool:
         """
@@ -6403,13 +6403,13 @@ class TeleBot:
         """
         if user_id is None and chat_id is None:
             raise ValueError("Either user_id or chat_id must be specified.")
-        
+
         if gift_id is None:
             raise ValueError("gift_id must be specified.")
-        
+
         return apihelper.send_gift(self.token, gift_id, text=text, text_parse_mode=text_parse_mode, text_entities=text_entities,
                                       pay_for_upgrade=pay_for_upgrade, chat_id=chat_id, user_id=user_id)
-    
+
     def verify_user(self, user_id: int, custom_description: Optional[str]=None) -> bool:
         """
         Verifies a user on behalf of the organization which is represented by the bot. Returns True on success.
@@ -6585,12 +6585,12 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.set_business_account_gift_settings(self.token, business_connection_id, show_gift_button, accepted_gift_types)
-    
+
 
     def get_business_account_star_balance(self, business_connection_id: str) -> types.StarAmount:
         """
         Returns the amount of Telegram Stars owned by a managed business account. Requires the can_view_gifts_and_stars business bot right. Returns StarAmount on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#getbusinessaccountstarbalance
 
         :param business_connection_id: Unique identifier of the business connection
@@ -6602,7 +6602,7 @@ class TeleBot:
         return types.StarAmount.de_json(
             apihelper.get_business_account_star_balance(self.token, business_connection_id)
         )
-    
+
     def transfer_business_account_stars(self, business_connection_id: str, star_count: int) -> bool:
         """
         Transfers Telegram Stars from the business account balance to the bot's balance. Requires the can_transfer_stars business bot right. Returns True on success.
@@ -6619,7 +6619,7 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.transfer_business_account_stars(self.token, business_connection_id, star_count)
-    
+
     def get_business_account_gifts(
             self, business_connection_id: str,
             exclude_unsaved: Optional[bool]=None,
@@ -6632,7 +6632,7 @@ class TeleBot:
             limit: Optional[int]=None) -> types.OwnedGifts:
         """
         Returns the gifts received and owned by a managed business account. Requires the can_view_gifts_and_stars business bot right. Returns OwnedGifts on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#getbusinessaccountgifts
 
         :param business_connection_id: Unique identifier of the business connection
@@ -6695,7 +6695,7 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.convert_gift_to_stars(self.token, business_connection_id, owned_gift_id)
-    
+
     def upgrade_gift(
             self, business_connection_id: str, owned_gift_id: str,
             keep_original_details: Optional[bool]=None,
@@ -6759,7 +6759,7 @@ class TeleBot:
             new_owner_chat_id,
             star_count=star_count
         )
-    
+
     def post_story(
             self, business_connection_id: str, content: types.InputStoryContent,
             active_period: int, caption: Optional[str]=None,
@@ -6866,7 +6866,7 @@ class TeleBot:
     def delete_story(self, business_connection_id: str, story_id: int) -> bool:
         """
         Deletes a story previously posted by the bot on behalf of a managed business account. Requires the can_manage_stories business bot right. Returns True on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#deletestory
 
         :param business_connection_id: Unique identifier of the business connection
@@ -6915,7 +6915,7 @@ class TeleBot:
             text=text, text_parse_mode=text_parse_mode,
             text_entities=text_entities
         )
-    
+
     def set_business_account_profile_photo(
             self, business_connection_id: str, photo: types.InputProfilePhoto,
             is_public: Optional[bool]=None) -> bool:
@@ -6994,8 +6994,8 @@ class TeleBot:
         :rtype: :obj:`bool`
         """
         return apihelper.replace_sticker_in_set(self.token, user_id, name, old_sticker, sticker)
-    
-    
+
+
     def set_sticker_emoji_list(self, sticker: str, emoji_list: List[str]) -> bool:
         """
         Use this method to set the emoji list of a custom emoji sticker set.
@@ -7017,7 +7017,7 @@ class TeleBot:
         """
         Use this method to upload a .png file with a sticker for later use in createNewStickerSet and addStickerToSet
         methods (can be used multiple times). Returns the uploaded File on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#uploadstickerfile
 
         :param user_id: User identifier of sticker set owner
@@ -7031,7 +7031,7 @@ class TeleBot:
             See https://core.telegram.org/stickers for technical requirements. More information on Sending Files »
         :type sticker: :class:`telebot.types.InputFile`
 
-        :param sticker_format: One of "static", "animated", "video". 
+        :param sticker_format: One of "static", "animated", "video".
         :type sticker_format: :obj:`str`
 
         :return: On success, the sent file is returned.
@@ -7041,17 +7041,17 @@ class TeleBot:
             logger.warning('The parameter "png_sticker" is deprecated. Use "sticker" instead.')
             sticker = png_sticker
             sticker_format = "static"
-        
+
         return types.File.de_json(
             apihelper.upload_sticker_file(self.token, user_id, sticker, sticker_format)
         )
 
 
     def create_new_sticker_set(
-            self, user_id: int, name: str, title: str, 
-            emojis: Optional[List[str]]=None, 
-            png_sticker: Union[Any, str]=None, 
-            tgs_sticker: Union[Any, str]=None, 
+            self, user_id: int, name: str, title: str,
+            emojis: Optional[List[str]]=None,
+            png_sticker: Union[Any, str]=None,
+            tgs_sticker: Union[Any, str]=None,
             webm_sticker: Union[Any, str]=None,
             contains_masks: Optional[bool]=None,
             sticker_type: Optional[str]=None,
@@ -7060,7 +7060,7 @@ class TeleBot:
             stickers: List[types.InputSticker]=None,
             sticker_format: Optional[str]=None) -> bool:
         """
-        Use this method to create new sticker set owned by a user. 
+        Use this method to create new sticker set owned by a user.
         The bot will be able to edit the created sticker set.
         Returns True on success.
 
@@ -7124,7 +7124,7 @@ class TeleBot:
             sticker_format = 'video'
         elif png_sticker:
             sticker_format = 'static'
-        
+
         if contains_masks is not None:
             logger.warning('The parameter "contains_masks" is deprecated, use "sticker_type" instead')
             if sticker_type is None:
@@ -7145,8 +7145,8 @@ class TeleBot:
 
     def add_sticker_to_set(
             self, user_id: int, name: str, emojis: Union[List[str], str],
-            png_sticker: Optional[Union[Any, str]]=None, 
-            tgs_sticker: Optional[Union[Any, str]]=None,  
+            png_sticker: Optional[Union[Any, str]]=None,
+            tgs_sticker: Optional[Union[Any, str]]=None,
             webm_sticker: Optional[Union[Any, str]]=None,
             mask_position: Optional[types.MaskPosition]=None,
             sticker: Optional[types.InputSticker]=None) -> bool:
@@ -7210,7 +7210,7 @@ class TeleBot:
     def set_sticker_position_in_set(self, sticker: str, position: int) -> bool:
         """
         Use this method to move a sticker in a set created by the bot to a specific position . Returns True on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#setstickerpositioninset
 
         :param sticker: File identifier of the sticker
@@ -7228,7 +7228,7 @@ class TeleBot:
     def delete_sticker_from_set(self, sticker: str) -> bool:
         """
         Use this method to delete a sticker from a set created by the bot. Returns True on success.
-       
+
         Telegram documentation: https://core.telegram.org/bots/api#deletestickerfromset
 
         :param sticker: File identifier of the sticker
@@ -7388,9 +7388,9 @@ class TeleBot:
         Use this method to edit the name of the 'General' topic in a forum supergroup chat.
         The bot must be an administrator in the chat for this to work and must have can_manage_topics administrator rights.
         Returns True on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#editgeneralforumtopic
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -7473,7 +7473,7 @@ class TeleBot:
         """
         Use this method to set the result of an interaction with a Web App and
         send a corresponding message on behalf of the user to the chat from which
-        the query originated. 
+        the query originated.
         On success, a SentWebAppMessage object is returned.
 
         Telegram Documentation: https://core.telegram.org/bots/api#answerwebappquery
@@ -7541,7 +7541,7 @@ class TeleBot:
 
         :param args: Optional arguments for the callback function.
         :param kwargs: Optional keyword arguments for the callback function.
-        
+
         :return: None
         """
         self.register_for_reply_by_message_id(message.message_id, callback, *args, **kwargs)
@@ -7644,8 +7644,8 @@ class TeleBot:
 
             Added additional parameters to support topics, business connections, and message threads.
 
-        .. seealso:: 
-        
+        .. seealso::
+
             For more details, visit the `custom_states.py example <https://github.com/eternnoir/pyTelegramBotAPI/blob/master/examples/custom_states.py>`_.
 
         :param user_id: User's identifier
@@ -7677,7 +7677,7 @@ class TeleBot:
             bot_id=bot_id, business_connection_id=business_connection_id, message_thread_id=message_thread_id)
 
 
-    def reset_data(self, user_id: int, chat_id: Optional[int]=None, 
+    def reset_data(self, user_id: int, chat_id: Optional[int]=None,
                      business_connection_id: Optional[str]=None,
                      message_thread_id: Optional[int]=None, bot_id: Optional[int]=None) -> bool:
         """
@@ -7720,7 +7720,7 @@ class TeleBot:
 
         :param user_id: User's identifier
         :type user_id: :obj:`int`
-        
+
         :param chat_id: Chat's identifier
         :type chat_id: :obj:`int`
 
@@ -7775,7 +7775,7 @@ class TeleBot:
             bot_id=bot_id, business_connection_id=business_connection_id, message_thread_id=message_thread_id)
 
 
-    def get_state(self, user_id: int, chat_id: Optional[int]=None, 
+    def get_state(self, user_id: int, chat_id: Optional[int]=None,
                     business_connection_id: Optional[str]=None,
                     message_thread_id: Optional[int]=None, bot_id: Optional[int]=None) -> str:
         """
@@ -7813,9 +7813,9 @@ class TeleBot:
             bot_id=bot_id, business_connection_id=business_connection_id, message_thread_id=message_thread_id)
 
 
-    def add_data(self, user_id: int, chat_id: Optional[int]=None, 
+    def add_data(self, user_id: int, chat_id: Optional[int]=None,
                     business_connection_id: Optional[str]=None,
-                    message_thread_id: Optional[int]=None, 
+                    message_thread_id: Optional[int]=None,
                     bot_id: Optional[int]=None,
                     **kwargs) -> None:
         """
@@ -7862,7 +7862,7 @@ class TeleBot:
         :type callback: :obj:`Callable[[telebot.types.Message], None]`
 
         :param args: Args to pass in callback func
-        
+
         :param kwargs: Args to pass in callback func
 
         :return: None
@@ -8032,7 +8032,7 @@ class TeleBot:
         bot = TeleBot('TOKEN')
 
         bot.register_middleware_handler(print_channel_post_text, update_types=['channel_post', 'edited_channel_post'])
- 
+
         :param callback: Function that will be used as a middleware handler.
         :type callback: :obj:`function`
 
@@ -8212,7 +8212,7 @@ class TeleBot:
             logger.warning("register_message_handler: 'content_types' filter should be List of strings (content types), not string.")
             content_types = [content_types]
 
-        
+
 
         handler_dict = self._build_handler_dict(callback,
                                                 chat_types=chat_types,
@@ -8284,7 +8284,7 @@ class TeleBot:
         """
         Adds the edit message handler
         Note that you should use register_edited_message_handler to add edited_message_handler to the bot.
-        
+
         :meta private:
 
         :param handler_dict:
@@ -8406,7 +8406,7 @@ class TeleBot:
         Note that you should use register_channel_post_handler to add channel_post_handler to the bot.
 
         :meta private:
-        
+
         :param handler_dict:
         :return:
         """
@@ -8626,7 +8626,7 @@ class TeleBot:
 
         :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
         :type pass_bot: :obj:`bool`
-        
+
         :param kwargs: Optional keyword arguments(custom filters)
 
         :return: None
@@ -8654,7 +8654,7 @@ class TeleBot:
 
         return decorator
 
-    
+
     def add_message_reaction_count_handler(self, handler_dict):
         """
         Adds message reaction count handler
@@ -8680,7 +8680,7 @@ class TeleBot:
 
         :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
         :type pass_bot: :obj:`bool`
-        
+
         :param kwargs: Optional keyword arguments(custom filters)
 
         :return: None
@@ -8689,7 +8689,7 @@ class TeleBot:
         self.add_message_reaction_count_handler(handler_dict)
 
 
-    def inline_handler(self, func, **kwargs):
+    def inline_handler(self, func=None, **kwargs):
         """
         Handles new incoming inline query.
         As a parameter to the decorator function, it passes :class:`telebot.types.InlineQuery` object.
@@ -8751,7 +8751,7 @@ class TeleBot:
 
         :param func: Function executed as a filter
         :type func: :obj:`function`
-        
+
         :param kwargs: Optional keyword arguments(custom filters)
 
         :return: None
@@ -8807,7 +8807,7 @@ class TeleBot:
         :type func: :obj:`function`
 
         :param kwargs: Optional keyword arguments(custom filters)
-        
+
         :return: None
         """
         def decorator(handler):
@@ -8861,7 +8861,7 @@ class TeleBot:
         :type func: :obj:`function`
 
         :param kwargs: Optional keyword arguments(custom filters)
-        
+
         :return: None
         """
         def decorator(handler):
@@ -8938,7 +8938,7 @@ class TeleBot:
         """
         self.pre_checkout_query_handlers.append(handler_dict)
 
-    
+
     def register_pre_checkout_query_handler(self, callback: Callable, func: Callable, pass_bot: Optional[bool]=False, **kwargs):
         """
         Registers pre-checkout request handler.
@@ -8973,9 +8973,9 @@ class TeleBot:
             handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
             self.add_purchased_paid_media_handler(handler_dict)
             return handler
-        
+
         return decorator
-    
+
     def add_purchased_paid_media_handler(self, handler_dict):
         """
         Adds a purchased paid media handler
@@ -8994,7 +8994,7 @@ class TeleBot:
 
         :param callback: function to be called
         :type callback: :obj:`function`
-        
+
         :param func: Function executed as a filter
         :type func: :obj:`function`
 
@@ -9071,7 +9071,7 @@ class TeleBot:
         :type func: :obj:`function`
 
         :param kwargs: Optional keyword arguments(custom filters)
-        
+
         :return: None
         """
         def decorator(handler):
@@ -9238,7 +9238,7 @@ class TeleBot:
         :type func: :obj:`function`
 
         :param kwargs: Optional keyword arguments(custom filters)
-        
+
         :return: None
         """
         def decorator(handler):
@@ -9286,7 +9286,7 @@ class TeleBot:
 
     def chat_boost_handler(self, func=None, **kwargs):
         """
-        Handles new incoming chat boost state. 
+        Handles new incoming chat boost state.
         it passes :class:`telebot.types.ChatBoostUpdated` object.
 
         :param func: Function executed as a filter
@@ -9323,7 +9323,7 @@ class TeleBot:
 
         :param callback: function to be called
         :type callback: :obj:`function`
-        
+
         :param func: Function executed as a filter
         :type func: :obj:`function`
 
@@ -9339,7 +9339,7 @@ class TeleBot:
 
     def removed_chat_boost_handler(self, func=None, **kwargs):
         """
-        Handles new incoming chat boost state. 
+        Handles new incoming chat boost state.
         it passes :class:`telebot.types.ChatBoostRemoved` object.
 
         :param func: Function executed as a filter
@@ -9355,7 +9355,7 @@ class TeleBot:
 
         return decorator
 
-    
+
     def add_removed_chat_boost_handler(self, handler_dict):
         """
         Adds a removed_chat_boost handler.
@@ -9376,7 +9376,7 @@ class TeleBot:
 
         :param callback: function to be called
         :type callback: :obj:`function`
-        
+
         :param func: Function executed as a filter
         :type func: :obj:`function`
 
@@ -9404,7 +9404,7 @@ class TeleBot:
             handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
             self.add_business_connection_handler(handler_dict)
             return handler
-        
+
         return decorator
 
 
@@ -9572,7 +9572,7 @@ class TeleBot:
 
         :return: None
         """
-        handler_dict = self._build_handler_dict(callback, content_types=content_types, commands=commands, regexp=regexp, func=func, 
+        handler_dict = self._build_handler_dict(callback, content_types=content_types, commands=commands, regexp=regexp, func=func,
                                                 pass_bot=pass_bot, **kwargs)
         self.add_business_message_handler(handler_dict)
 
@@ -9632,7 +9632,7 @@ class TeleBot:
         """
         Adds the edit message handler
         Note that you should use register_edited_business_message_handler to add edited_business_message_handler to the bot.
-        
+
         :meta private:
 
         :param handler_dict:
@@ -9709,7 +9709,7 @@ class TeleBot:
 
             self.add_deleted_business_messages_handler(handler_dict)
             return handler
-        
+
         return decorator
 
 
@@ -9829,7 +9829,7 @@ class TeleBot:
         :return:
         """
         middlewares = None
-        if self.middlewares: 
+        if self.middlewares:
             middlewares = [i for i in self.middlewares if update_type in i.update_types]
         return middlewares
 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -26,7 +26,7 @@ from telebot import asyncio_filters
 logger = logging.getLogger('TeleBot')
 
 REPLY_MARKUP_TYPES = Union[
-    types.InlineKeyboardMarkup, types.ReplyKeyboardMarkup, 
+    types.InlineKeyboardMarkup, types.ReplyKeyboardMarkup,
     types.ReplyKeyboardRemove, types.ForceReply]
 
 
@@ -76,7 +76,7 @@ class AsyncTeleBot:
 
         from telebot.async_telebot import AsyncTeleBot
         bot = AsyncTeleBot('token') # get token from @BotFather
-        # now you can register other handlers/update listeners, 
+        # now you can register other handlers/update listeners,
         # and use bot methods.
         # Remember to use async/await keywords when necessary.
 
@@ -114,7 +114,7 @@ class AsyncTeleBot:
 
     :param allow_sending_without_reply: Deprecated - Use reply_parameters instead. Default value for allow_sending_without_reply, defaults to None
     :type allow_sending_without_reply: :obj:`bool`, optional
-    
+
     :param colorful_logs: Outputs colorful logs
     :type colorful_logs: :obj:`bool`, optional
 
@@ -134,7 +134,7 @@ class AsyncTeleBot:
                 allow_sending_without_reply: Optional[bool]=None,
                 colorful_logs: Optional[bool]=False,
                 validate_token: Optional[bool]=True) -> None:
-        
+
         # update-related
         self.token = token
         self.offset = offset
@@ -148,7 +148,7 @@ class AsyncTeleBot:
                 raise ImportError(
                     'Install coloredlogs module to use colorful_logs option.'
                 )
-                
+
         # properties
         self.parse_mode = parse_mode
         self.disable_web_page_preview = disable_web_page_preview
@@ -194,9 +194,9 @@ class AsyncTeleBot:
 
         if validate_token:
             util.validate_token(self.token)
-        
+
         self.bot_id: Union[int, None] = util.extract_bot_id(self.token) # subject to change, unspecified
-            
+
 
     @property
     def user(self):
@@ -237,7 +237,7 @@ class AsyncTeleBot:
 
         :return: An Array of Update objects is returned.
         :rtype: :obj:`list` of :class:`telebot.types.Update`
-        """       
+        """
         json_updates = await asyncio_helper.get_updates(self.token, offset, limit, timeout, allowed_updates, request_timeout)
         return [types.Update.de_json(ju) for ju in json_updates]
 
@@ -255,7 +255,7 @@ class AsyncTeleBot:
         if path is None:
             # Make it possible to specify --path argument to the script
             path = sys.argv[sys.argv.index('--path') + 1] if '--path' in sys.argv else '.'
-            
+
         self.event_observer = Observer()
         self.event_observer.schedule(self.event_handler, path, recursive=True)
         self.event_observer.start()
@@ -268,7 +268,7 @@ class AsyncTeleBot:
         This allows the bot to retrieve Updates automagically and notify listeners and message handlers accordingly.
 
         Warning: Do not call this function more than once!
-        
+
         Always gets updates.
 
         .. note::
@@ -277,7 +277,7 @@ class AsyncTeleBot:
 
         :param non_stop: Do not stop polling when an ApiException occurs.
         :type non_stop: :obj:`bool`
-        
+
         :param skip_pending: skip old updates
         :type skip_pending: :obj:`bool`
 
@@ -286,17 +286,17 @@ class AsyncTeleBot:
 
         :param timeout: Request connection timeout
         :type timeout: :obj:`int`
-        
+
         :param request_timeout: Timeout in seconds for get_updates(Defaults to None)
         :type request_timeout: :obj:`int`
 
         :param allowed_updates: A list of the update types you want your bot to receive.
-            For example, specify [“message”, “edited_channel_post”, “callback_query”] to only receive updates of these types. 
-            See util.update_types for a complete list of available update types. 
-            Specify an empty list to receive all update types except chat_member (default). 
+            For example, specify [“message”, “edited_channel_post”, “callback_query”] to only receive updates of these types.
+            See util.update_types for a complete list of available update types.
+            Specify an empty list to receive all update types except chat_member (default).
             If not specified, the previous setting will be used.
-            
-            Please note that this parameter doesn't affect updates created before the call to the get_updates, 
+
+            Please note that this parameter doesn't affect updates created before the call to the get_updates,
             so unwanted updates may be received for a short period of time.
         :type allowed_updates: :obj:`list` of :obj:`str`
 
@@ -308,7 +308,7 @@ class AsyncTeleBot:
 
         :param path_to_watch: Path to watch for changes. Defaults to current directory
         :type path_to_watch: :obj:`str`
-        
+
         :return:
         """
         if none_stop is not None:
@@ -346,12 +346,12 @@ class AsyncTeleBot:
         :type logger_level: :obj:`int`
 
         :param allowed_updates: A list of the update types you want your bot to receive.
-            For example, specify [“message”, “edited_channel_post”, “callback_query”] to only receive updates of these types. 
-            See util.update_types for a complete list of available update types. 
-            Specify an empty list to receive all update types except chat_member (default). 
+            For example, specify [“message”, “edited_channel_post”, “callback_query”] to only receive updates of these types.
+            See util.update_types for a complete list of available update types.
+            Specify an empty list to receive all update types except chat_member (default).
             If not specified, the previous setting will be used.
-            
-            Please note that this parameter doesn't affect updates created before the call to the get_updates, 
+
+            Please note that this parameter doesn't affect updates created before the call to the get_updates,
             so unwanted updates may be received for a short period of time.
         :type allowed_updates: :obj:`list` of :obj:`str`
 
@@ -402,7 +402,7 @@ class AsyncTeleBot:
             return message.replace(code, "*" * len(code))
         else:
             return message
-        
+
     async def _handle_error_interval(self, error_interval: float):
         logger.debug('Waiting for %s seconds before retrying', error_interval)
         await asyncio.sleep(error_interval)
@@ -439,7 +439,7 @@ class AsyncTeleBot:
             logger.warning("Setting non_stop to False will stop polling on API and system exceptions.")
 
         self._user = await self.get_me()
-            
+
         logger.info('Starting your bot with username: [@%s]', self.user.username)
 
         self._polling = True
@@ -469,7 +469,7 @@ class AsyncTeleBot:
 
                     if non_stop:
                         error_interval = await self._handle_error_interval(error_interval)
-                        
+
                     if non_stop or handled:
                         continue
                     else:
@@ -837,7 +837,7 @@ class AsyncTeleBot:
         :meta private:
         """
         await self._process_updates(self.poll_answer_handlers, poll_answers, 'poll_answer')
-    
+
     async def process_new_my_chat_member(self, my_chat_members):
         """
         :meta private:
@@ -885,7 +885,7 @@ class AsyncTeleBot:
         :meta private:
         """
         await self._process_updates(self.edited_business_message_handlers, new_edited_business_messages, 'edited_business_message')
-        
+
     async def process_new_deleted_business_messages(self, new_deleted_business_messages):
         """
         :meta private:
@@ -906,7 +906,7 @@ class AsyncTeleBot:
             middlewares = [middleware for middleware in self.middlewares if update_type in middleware.update_types]
             return middlewares
         return None
-    
+
     async def __notify_update(self, new_messages):
         if len(self.update_listener) == 0:
             return
@@ -945,7 +945,7 @@ class AsyncTeleBot:
                     print(message.text) # Prints message text
 
             bot.set_update_listener(update_listener)
-        
+
         :return: None
         """
         self.update_listener.append(func)
@@ -1033,7 +1033,7 @@ class AsyncTeleBot:
 
         :param middleware: Middleware-class.
         :type middleware: :class:`telebot.asyncio_handler_backends.BaseMiddleware`
-    
+
         :return: None
         """
         if not hasattr(middleware, 'update_types'):
@@ -1106,7 +1106,7 @@ class AsyncTeleBot:
 
         :param func: Optional lambda function. The lambda receives the message to test as the first parameter.
             It must return True if the command should handle the message.
-        
+
 
         :param content_types: Supported message content types. Must be a list. Defaults to ['text'].
         :type content_types: :obj:`list` of :obj:`str`
@@ -1147,7 +1147,7 @@ class AsyncTeleBot:
         """
         Adds a message handler.
         Note that you should use register_message_handler to add message_handler.
-        
+
         :meta private:
 
         :param handler_dict:
@@ -1371,7 +1371,7 @@ class AsyncTeleBot:
         :return:
         """
         self.channel_post_handlers.append(handler_dict)
-    
+
     def register_channel_post_handler(self, callback: Callable[[Any], Awaitable], content_types: Optional[List[str]]=None, commands: Optional[List[str]]=None,
             regexp: Optional[str]=None, func: Optional[Callable]=None, pass_bot: Optional[bool]=False, **kwargs):
         """
@@ -1535,7 +1535,7 @@ class AsyncTeleBot:
             return handler
 
         return decorator
-    
+
     def add_message_reaction_handler(self, handler_dict):
         """
         Adds message reaction handler.
@@ -1560,7 +1560,7 @@ class AsyncTeleBot:
 
         :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
         :type pass_bot: :obj:`bool`
-        
+
         :param kwargs: Optional keyword arguments(custom filters)
 
         :return: None
@@ -1587,7 +1587,7 @@ class AsyncTeleBot:
             return handler
 
         return decorator
-    
+
     def add_message_reaction_count_handler(self, handler_dict):
         """
         Adds message reaction count handler
@@ -1612,7 +1612,7 @@ class AsyncTeleBot:
 
         :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
         :type pass_bot: :obj:`bool`
-        
+
         :param kwargs: Optional keyword arguments(custom filters)
 
         :return: None
@@ -1621,7 +1621,7 @@ class AsyncTeleBot:
         self.add_message_reaction_count_handler(handler_dict)
 
 
-    def inline_handler(self, func, **kwargs):
+    def inline_handler(self, func=None, **kwargs):
         """
         Handles new incoming inline query.
         As a parameter to the decorator function, it passes :class:`telebot.types.InlineQuery` object.
@@ -1681,7 +1681,7 @@ class AsyncTeleBot:
 
         :param func: Function executed as a filter
         :type func: :obj:`function`
-        
+
         :param kwargs: Optional keyword arguments(custom filters)
 
         :return: None
@@ -1735,7 +1735,7 @@ class AsyncTeleBot:
         :type func: :obj:`function`
 
         :param kwargs: Optional keyword arguments(custom filters)
-        
+
         :return: None
         """
 
@@ -1787,7 +1787,7 @@ class AsyncTeleBot:
         :type func: :obj:`function`
 
         :param kwargs: Optional keyword arguments(custom filters)
-        
+
         :return: None
         """
 
@@ -1861,7 +1861,7 @@ class AsyncTeleBot:
         :return:
         """
         self.pre_checkout_query_handlers.append(handler_dict)
-    
+
     def register_pre_checkout_query_handler(self, callback: Callable[[Any], Awaitable], func: Callable, pass_bot: Optional[bool]=False, **kwargs):
         """
         Registers pre-checkout request handler.
@@ -1896,9 +1896,9 @@ class AsyncTeleBot:
             handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
             self.add_purchased_paid_media_handler(handler_dict)
             return handler
-        
+
         return decorator
-    
+
     def add_purchased_paid_media_handler(self, handler_dict):
         """
         Adds a purchased paid media handler
@@ -1917,7 +1917,7 @@ class AsyncTeleBot:
 
         :param callback: function to be called
         :type callback: :obj:`function`
-        
+
         :param func: Function executed as a filter
         :type func: :obj:`function`
 
@@ -1992,7 +1992,7 @@ class AsyncTeleBot:
         :type func: :obj:`function`
 
         :param kwargs: Optional keyword arguments(custom filters)
-        
+
         :return: None
         """
 
@@ -2152,7 +2152,7 @@ class AsyncTeleBot:
         :type func: :obj:`function`
 
         :param kwargs: Optional keyword arguments(custom filters)
-        
+
         :return: None
         """
 
@@ -2198,7 +2198,7 @@ class AsyncTeleBot:
 
     def chat_boost_handler(self, func=None, **kwargs):
         """
-        Handles new incoming chat boost state. 
+        Handles new incoming chat boost state.
         it passes :class:`telebot.types.ChatBoostUpdated` object.
 
         :param func: Function executed as a filter
@@ -2213,7 +2213,7 @@ class AsyncTeleBot:
             return handler
 
         return decorator
-    
+
     def add_chat_boost_handler(self, handler_dict):
         """
         Adds a chat_boost handler.
@@ -2232,7 +2232,7 @@ class AsyncTeleBot:
 
         :param callback: function to be called
         :type callback: :obj:`function`
-        
+
         :param func: Function executed as a filter
         :type func: :obj:`function`
 
@@ -2247,7 +2247,7 @@ class AsyncTeleBot:
 
     def removed_chat_boost_handler(self, func=None, **kwargs):
         """
-        Handles new incoming chat boost state. 
+        Handles new incoming chat boost state.
         it passes :class:`telebot.types.ChatBoostRemoved` object.
 
         :param func: Function executed as a filter
@@ -2262,7 +2262,7 @@ class AsyncTeleBot:
             return handler
 
         return decorator
-    
+
     def add_removed_chat_boost_handler(self, handler_dict):
         """
         Adds a removed_chat_boost handler.
@@ -2281,7 +2281,7 @@ class AsyncTeleBot:
 
         :param callback: function to be called
         :type callback: :obj:`function`
-        
+
         :param func: Function executed as a filter
         :type func: :obj:`function`
 
@@ -2309,9 +2309,9 @@ class AsyncTeleBot:
             handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
             self.add_business_connection_handler(handler_dict)
             return handler
-        
+
         return decorator
-    
+
     def add_business_connection_handler(self, handler_dict):
         """
         Adds a business_connection handler.
@@ -2426,7 +2426,7 @@ class AsyncTeleBot:
             return handler
 
         return decorator
-    
+
     def add_business_message_handler(self, handler_dict):
         """
         Adds a business_message handler.
@@ -2476,8 +2476,8 @@ class AsyncTeleBot:
                                                 pass_bot=pass_bot,**kwargs)
         self.add_business_message_handler(handler_dict)
 
-    
-    
+
+
 
     def edited_business_message_handler(self, commands=None, regexp=None, func=None, content_types=None, **kwargs):
         """
@@ -2534,7 +2534,7 @@ class AsyncTeleBot:
         """
         Adds the edit message handler
         Note that you should use register_edited_business_message_handler to add edited_business_message_handler to the bot.
-        
+
         :meta private:
 
         :param handler_dict:
@@ -2594,7 +2594,7 @@ class AsyncTeleBot:
                                                 **kwargs)
         self.add_edited_business_message_handler(handler_dict)
 
-    
+
     def deleted_business_messages_handler(self, func=None, **kwargs):
         """
         Handles new incoming deleted messages state.
@@ -2611,9 +2611,9 @@ class AsyncTeleBot:
 
             self.add_deleted_business_messages_handler(handler_dict)
             return handler
-        
+
         return decorator
-    
+
     def add_deleted_business_messages_handler(self, handler_dict):
         """
         Adds a deleted_business_messages handler.
@@ -2670,7 +2670,7 @@ class AsyncTeleBot:
         return True
 
     # all methods begin here
-    
+
     async def get_me(self) -> types.User:
         """
         Returns basic information about the bot in form of a User object.
@@ -2683,9 +2683,9 @@ class AsyncTeleBot:
     async def get_file(self, file_id: Optional[str]) -> types.File:
         """
         Use this method to get basic info about a file and prepare it for downloading.
-        For the moment, bots can download files of up to 20MB in size. 
-        On success, a File object is returned. 
-        It is guaranteed that the link will be valid for at least 1 hour. 
+        For the moment, bots can download files of up to 20MB in size.
+        On success, a File object is returned.
+        It is guaranteed that the link will be valid for at least 1 hour.
         When the link expires, a new one can be requested by calling get_file again.
 
         Telegram documentation: https://core.telegram.org/bots/api#getfile
@@ -2715,7 +2715,7 @@ class AsyncTeleBot:
 
         :param file_path: Path where the file should be downloaded.
         :type file_path: str
-        
+
         :return: bytes
         :rtype: :obj:`bytes`
         """
@@ -2723,11 +2723,11 @@ class AsyncTeleBot:
 
     async def log_out(self) -> bool:
         """
-        Use this method to log out from the cloud Bot API server before launching the bot locally. 
+        Use this method to log out from the cloud Bot API server before launching the bot locally.
         You MUST log out the bot before running it locally, otherwise there is no guarantee
         that the bot will receive updates.
-        After a successful call, you can immediately log in on a local server, 
-        but will not be able to log in back to the cloud Bot API server for 10 minutes. 
+        After a successful call, you can immediately log in on a local server,
+        but will not be able to log in back to the cloud Bot API server for 10 minutes.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#logout
@@ -2736,13 +2736,13 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.log_out(self.token)
-    
+
     async def close(self) -> bool:
         """
-        Use this method to close the bot instance before moving it from one local server to another. 
+        Use this method to close the bot instance before moving it from one local server to another.
         You need to delete the webhook before calling this method to ensure that the bot isn't launched again
         after server restart.
-        The method will return error 429 in the first 10 minutes after the bot is launched. 
+        The method will return error 429 in the first 10 minutes after the bot is launched.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#close
@@ -2790,15 +2790,15 @@ class AsyncTeleBot:
             Defaults to 40. Use lower values to limit the load on your bot's server, and higher values to increase your bot's throughput,
             defaults to None
         :type max_connections: :obj:`int`, optional
-        
+
         :param allowed_updates: A JSON-serialized list of the update types you want your bot to receive. For example,
             specify [“message”, “edited_channel_post”, “callback_query”] to only receive updates of these types. See Update
             for a complete list of available update types. Specify an empty list to receive all update types except chat_member (default).
             If not specified, the previous setting will be used.
-            
+
             Please note that this parameter doesn't affect updates created before the call to the setWebhook, so unwanted updates may be received
             for a short period of time. Defaults to None
-        
+
         :type allowed_updates: :obj:`list`, optional
 
         :param ip_address: The fixed IP address which will be used to send webhook requests instead of the IP address
@@ -2941,7 +2941,7 @@ class AsyncTeleBot:
 
     async def set_message_reaction(self, chat_id: Union[int, str], message_id: int, reaction: Optional[List[types.ReactionType]]=None, is_big: Optional[bool]=None) -> bool:
         """
-        Use this method to change the chosen reactions on a message. 
+        Use this method to change the chosen reactions on a message.
         Service messages can't be reacted to. Automatically forwarded messages from a channel to its discussion group have the same
         available reactions as messages in the channel. Returns True on success.
 
@@ -2965,7 +2965,7 @@ class AsyncTeleBot:
         result = await asyncio_helper.set_message_reaction(self.token, chat_id, message_id, reaction, is_big)
         return result
 
-    async def get_user_profile_photos(self, user_id: int, offset: Optional[int]=None, 
+    async def get_user_profile_photos(self, user_id: int, offset: Optional[int]=None,
             limit: Optional[int]=None) -> types.UserProfilePhotos:
         """
         Use this method to get a list of profile pictures for a user.
@@ -2988,7 +2988,7 @@ class AsyncTeleBot:
         """
         result = await asyncio_helper.get_user_profile_photos(self.token, user_id, offset, limit)
         return types.UserProfilePhotos.de_json(result)
-    
+
     async def set_user_emoji_status(self, user_id: int, emoji_status_custom_emoji_id: Optional[str]=None, emoji_status_expiration_date: Optional[int]=None) -> bool:
         """
         Use this method to change the emoji status for a given user that previously allowed the bot to manage their emoji status via the Mini App method requestEmojiStatusAccess.
@@ -3045,7 +3045,7 @@ class AsyncTeleBot:
         On success, returns an Array of ChatMember objects that contains
         information about all chat administrators except other bots.
 
-        Telegram documentation: https://core.telegram.org/bots/api#getchatadministrators    
+        Telegram documentation: https://core.telegram.org/bots/api#getchatadministrators
 
         :param chat_id: Unique identifier for the target chat or username
             of the target supergroup or channel (in the format @channelusername)
@@ -3075,7 +3075,7 @@ class AsyncTeleBot:
         """
         result = await asyncio_helper.get_chat_member_count(self.token, chat_id)
         return result
-    
+
     async def get_chat_member_count(self, chat_id: Union[int, str]) -> int:
         """
         Use this method to get the number of members in a chat.
@@ -3096,7 +3096,7 @@ class AsyncTeleBot:
         Use this method to set a new group sticker set for a supergroup. The bot must be an administrator in the chat
         for this to work and must have the appropriate administrator rights. Use the field can_set_sticker_set optionally returned
         in getChat requests to check if the bot can use this method. Returns True on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#setchatstickerset
 
         :param chat_id: Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
@@ -3116,7 +3116,7 @@ class AsyncTeleBot:
         Use this method to delete a group sticker set from a supergroup. The bot must be an administrator in the chat
         for this to work and must have the appropriate admin rights. Use the field can_set_sticker_set
         optionally returned in getChat requests to check if the bot can use this method. Returns True on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#deletechatstickerset
 
         :param chat_id:	Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
@@ -3132,7 +3132,7 @@ class AsyncTeleBot:
         """
         Use this method to set the result of an interaction with a Web App and
         send a corresponding message on behalf of the user to the chat from which
-        the query originated. 
+        the query originated.
         On success, a SentWebAppMessage object is returned.
 
         Telegram Documentation: https://core.telegram.org/bots/api#answerwebappquery
@@ -3182,7 +3182,7 @@ class AsyncTeleBot:
     async def get_chat_member(self, chat_id: Union[int, str], user_id: int) -> types.ChatMember:
         """
         Use this method to get information about a member of a chat. Returns a ChatMember object on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#getchatmember
 
         :param chat_id: Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
@@ -3198,13 +3198,13 @@ class AsyncTeleBot:
         return types.ChatMember.de_json(result)
 
     async def send_message(
-            self, chat_id: Union[int, str], text: str, 
-            parse_mode: Optional[str]=None, 
+            self, chat_id: Union[int, str], text: str,
+            parse_mode: Optional[str]=None,
             entities: Optional[List[types.MessageEntity]]=None,
-            disable_web_page_preview: Optional[bool]=None, 
-            disable_notification: Optional[bool]=None, 
+            disable_web_page_preview: Optional[bool]=None,
+            disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            reply_to_message_id: Optional[int]=None, 
+            reply_to_message_id: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
@@ -3218,7 +3218,7 @@ class AsyncTeleBot:
         Use this method to send text messages.
 
         Warning: Do not send more than about 4096 characters each message, otherwise you'll risk an HTTP 414 error.
-        If you must send more than 4096 characters, 
+        If you must send more than 4096 characters,
         use the `split_string` or `smart_split` function in util.py.
 
         Telegram documentation: https://core.telegram.org/bots/api#sendmessage
@@ -3283,11 +3283,11 @@ class AsyncTeleBot:
         disable_web_page_preview = self.disable_web_page_preview if (disable_web_page_preview is None) else disable_web_page_preview
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -3308,7 +3308,7 @@ class AsyncTeleBot:
         if disable_web_page_preview is not None:
             # show a deprecation warning
             logger.warning("The parameter 'disable_web_page_preview' is deprecated. Use 'link_preview_options' instead.")
-            
+
             if link_preview_options:
                 # show a conflict warning
                 logger.warning("Both 'link_preview_options' and 'disable_web_page_preview' parameters are set: conflicting, 'disable_web_page_preview' is deprecated")
@@ -3334,7 +3334,7 @@ class AsyncTeleBot:
                 message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast))
 
     async def forward_message(
-            self, chat_id: Union[int, str], from_chat_id: Union[int, str], 
+            self, chat_id: Union[int, str], from_chat_id: Union[int, str],
             message_id: int, disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             timeout: Optional[int]=None,
@@ -3359,7 +3359,7 @@ class AsyncTeleBot:
 
         :param video_start_timestamp: New start timestamp for the forwarded video in the message
         :type video_start_timestamp: :obj:`int`
-        
+
         :param protect_content: Protects the contents of the forwarded message from forwarding and saving
         :type protect_content: :obj:`bool`
 
@@ -3381,17 +3381,17 @@ class AsyncTeleBot:
                                                     timeout=timeout, message_thread_id=message_thread_id, video_start_timestamp=video_start_timestamp))
 
     async def copy_message(
-            self, chat_id: Union[int, str], 
-            from_chat_id: Union[int, str], 
-            message_id: int, 
-            caption: Optional[str]=None, 
-            parse_mode: Optional[str]=None, 
+            self, chat_id: Union[int, str],
+            from_chat_id: Union[int, str],
+            message_id: int,
+            caption: Optional[str]=None,
+            parse_mode: Optional[str]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
-            disable_notification: Optional[bool]=None, 
+            disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            reply_to_message_id: Optional[int]=None, 
+            reply_to_message_id: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
             reply_parameters: Optional[types.ReplyParameters]=None,
@@ -3450,7 +3450,7 @@ class AsyncTeleBot:
 
         :param message_thread_id: Identifier of a message thread, in which the message will be sent
         :type message_thread_id: :obj:`int`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -3460,7 +3460,7 @@ class AsyncTeleBot:
         :param allow_paid_broadcast: Pass True to allow up to 1000 messages per second, ignoring broadcasting limits for a fee
             of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
         :type allow_paid_broadcast: :obj:`bool`
-        
+
         :return: On success, the MessageId of the sent message is returned.
         :rtype: :class:`telebot.types.MessageID`
         """
@@ -3470,7 +3470,7 @@ class AsyncTeleBot:
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -3496,7 +3496,7 @@ class AsyncTeleBot:
                                                     message_thread_id=message_thread_id, show_caption_above_media=show_caption_above_media,
                                                     allow_paid_broadcast=allow_paid_broadcast, video_start_timestamp=video_start_timestamp))
 
-    async def delete_message(self, chat_id: Union[int, str], message_id: int, 
+    async def delete_message(self, chat_id: Union[int, str], message_id: int,
             timeout: Optional[int]=None) -> bool:
         """
         Use this method to delete a message, including service messages, with the following limitations:
@@ -3524,10 +3524,10 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.delete_message(self.token, chat_id, message_id, timeout)
-    
+
     async def delete_messages(self, chat_id: Union[int, str], message_ids: List[int]):
         """
-        Use this method to delete multiple messages simultaneously. 
+        Use this method to delete multiple messages simultaneously.
         If some of the specified messages can't be found, they are skipped. Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#deletemessages
@@ -3542,7 +3542,7 @@ class AsyncTeleBot:
 
         """
         return await asyncio_helper.delete_messages(self.token, chat_id, message_ids)
-    
+
     async def forward_messages(self, chat_id: Union[str, int], from_chat_id: Union[str, int], message_ids: List[int], disable_notification: Optional[bool]=None,
                          message_thread_id: Optional[int]=None, protect_content: Optional[bool]=None) -> List[types.MessageID]:
         """
@@ -3578,7 +3578,7 @@ class AsyncTeleBot:
         protect_content = self.protect_content if (protect_content is None) else protect_content
         result = await asyncio_helper.forward_messages(self.token, chat_id, from_chat_id, message_ids, disable_notification, message_thread_id, protect_content)
         return [types.MessageID.de_json(message_id) for message_id in result]
-    
+
     async def copy_messages(self, chat_id: Union[str, int], from_chat_id: Union[str, int], message_ids: List[int],
                         disable_notification: Optional[bool] = None, message_thread_id: Optional[int] = None,
                         protect_content: Optional[bool] = None, remove_caption: Optional[bool] = None) -> List[types.MessageID]:
@@ -3619,7 +3619,7 @@ class AsyncTeleBot:
         result = await asyncio_helper.copy_messages(self.token, chat_id, from_chat_id, message_ids, disable_notification, message_thread_id,
                                         protect_content, remove_caption)
         return [types.MessageID.de_json(message_id) for message_id in result]
-    
+
     async def send_checklist(
             self, business_connection_id: str, chat_id: Union[int, str],
             checklist: types.InputChecklist,
@@ -3663,7 +3663,7 @@ class AsyncTeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
         if reply_parameters and (reply_parameters.allow_sending_without_reply is None):
             reply_parameters.allow_sending_without_reply = self.allow_sending_without_reply
 
@@ -3672,7 +3672,7 @@ class AsyncTeleBot:
                 self.token, business_connection_id, chat_id, checklist, disable_notification=disable_notification,
                 protect_content=protect_content, message_effect_id=message_effect_id,
                 reply_parameters=reply_parameters, reply_markup=reply_markup))
-    
+
     async def edit_message_checklist(
             self, business_connection_id: str, chat_id: Union[int, str],
             message_id: int, checklist: types.InputChecklist,
@@ -3707,9 +3707,9 @@ class AsyncTeleBot:
 
     async def send_dice(
             self, chat_id: Union[int, str],
-            emoji: Optional[str]=None, disable_notification: Optional[bool]=None, 
+            emoji: Optional[str]=None, disable_notification: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None,
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
@@ -3752,7 +3752,7 @@ class AsyncTeleBot:
 
         :param message_thread_id: The identifier of a message thread, unique within the chat to which the message with the thread identifier belongs
         :type message_thread_id: :obj:`int`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -3771,11 +3771,11 @@ class AsyncTeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -3798,15 +3798,15 @@ class AsyncTeleBot:
                 self.token, chat_id, emoji, disable_notification,
                 reply_markup, timeout, protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id,
                 allow_paid_broadcast=allow_paid_broadcast))
-        
+
 
     async def send_photo(
-            self, chat_id: Union[int, str], photo: Union[Any, str], 
+            self, chat_id: Union[int, str], photo: Union[Any, str],
             caption: Optional[str]=None, parse_mode: Optional[str]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            reply_to_message_id: Optional[int]=None, 
+            reply_to_message_id: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
@@ -3821,7 +3821,7 @@ class AsyncTeleBot:
         Use this method to send photos. On success, the sent Message is returned.
 
         Telegram documentation: https://core.telegram.org/bots/api#sendphoto
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -3864,7 +3864,7 @@ class AsyncTeleBot:
 
         :param has_spoiler: Pass True, if the photo should be sent as a spoiler
         :type has_spoiler: :obj:`bool`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -3880,18 +3880,18 @@ class AsyncTeleBot:
         :param allow_paid_broadcast: Pass True to allow up to 1000 messages per second, ignoring broadcasting limits for a fee
             of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
         :type allow_paid_broadcast: :obj:`bool`
-        
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -3917,14 +3917,14 @@ class AsyncTeleBot:
                 show_caption_above_media=show_caption_above_media, allow_paid_broadcast=allow_paid_broadcast))
 
     async def send_audio(
-            self, chat_id: Union[int, str], audio: Union[Any, str], 
-            caption: Optional[str]=None, duration: Optional[int]=None, 
+            self, chat_id: Union[int, str], audio: Union[Any, str],
+            caption: Optional[str]=None, duration: Optional[int]=None,
             performer: Optional[str]=None, title: Optional[str]=None,
-            reply_to_message_id: Optional[int]=None, 
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            parse_mode: Optional[str]=None, 
+            reply_to_message_id: Optional[int]=None,
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
+            parse_mode: Optional[str]=None,
             disable_notification: Optional[bool]=None,
-            timeout: Optional[int]=None, 
+            timeout: Optional[int]=None,
             thumbnail: Optional[Union[Any, str]]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             allow_sending_without_reply: Optional[bool]=None,
@@ -3943,7 +3943,7 @@ class AsyncTeleBot:
         For sending voice messages, use the send_voice method instead.
 
         Telegram documentation: https://core.telegram.org/bots/api#sendaudio
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -4000,7 +4000,7 @@ class AsyncTeleBot:
 
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -4020,7 +4020,7 @@ class AsyncTeleBot:
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if thumb is not None and thumbnail is None:
             thumbnail = thumb
@@ -4028,7 +4028,7 @@ class AsyncTeleBot:
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -4053,12 +4053,12 @@ class AsyncTeleBot:
                 caption_entities, protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast))
 
     async def send_voice(
-            self, chat_id: Union[int, str], voice: Union[Any, str], 
-            caption: Optional[str]=None, duration: Optional[int]=None, 
-            reply_to_message_id: Optional[int]=None, 
+            self, chat_id: Union[int, str], voice: Union[Any, str],
+            caption: Optional[str]=None, duration: Optional[int]=None,
+            reply_to_message_id: Optional[int]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
-            parse_mode: Optional[str]=None, 
-            disable_notification: Optional[bool]=None, 
+            parse_mode: Optional[str]=None,
+            disable_notification: Optional[bool]=None,
             timeout: Optional[int]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             allow_sending_without_reply: Optional[bool]=None,
@@ -4072,7 +4072,7 @@ class AsyncTeleBot:
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .OGG file encoded with OPUS, or in .MP3 format, or in .M4A format (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
 
         Telegram documentation: https://core.telegram.org/bots/api#sendvoice
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -4114,7 +4114,7 @@ class AsyncTeleBot:
 
         :param message_thread_id: Identifier of a message thread, in which the message will be sent
         :type message_thread_id: :obj:`int`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -4133,11 +4133,11 @@ class AsyncTeleBot:
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -4164,12 +4164,12 @@ class AsyncTeleBot:
 
     async def send_document(
             self, chat_id: Union[int, str], document: Union[Any, str],
-            reply_to_message_id: Optional[int]=None, 
-            caption: Optional[str]=None, 
+            reply_to_message_id: Optional[int]=None,
+            caption: Optional[str]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
-            parse_mode: Optional[str]=None, 
-            disable_notification: Optional[bool]=None, 
-            timeout: Optional[int]=None, 
+            parse_mode: Optional[str]=None,
+            disable_notification: Optional[bool]=None,
+            timeout: Optional[int]=None,
             thumbnail: Optional[Union[Any, str]]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             allow_sending_without_reply: Optional[bool]=None,
@@ -4187,7 +4187,7 @@ class AsyncTeleBot:
         Use this method to send general files.
 
         Telegram documentation: https://core.telegram.org/bots/api#senddocument
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -4241,7 +4241,7 @@ class AsyncTeleBot:
 
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -4261,7 +4261,7 @@ class AsyncTeleBot:
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if data and not(document):
             # function typo miss compatibility
@@ -4274,7 +4274,7 @@ class AsyncTeleBot:
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -4295,7 +4295,7 @@ class AsyncTeleBot:
         if isinstance(document, types.InputFile) and visible_file_name:
             # inputfile name ignored, warn
             logger.warning('Cannot use both InputFile and visible_file_name. InputFile name will be ignored.')
-            
+
         return types.Message.de_json(
             await asyncio_helper.send_data(
                 self.token, chat_id, document, 'document',
@@ -4306,10 +4306,10 @@ class AsyncTeleBot:
                 message_thread_id = message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast))
 
     async def send_sticker(
-            self, chat_id: Union[int, str], sticker: Union[Any, str], 
-            reply_to_message_id: Optional[int]=None, 
+            self, chat_id: Union[int, str], sticker: Union[Any, str],
+            reply_to_message_id: Optional[int]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
-            disable_notification: Optional[bool]=None, 
+            disable_notification: Optional[bool]=None,
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
@@ -4361,7 +4361,7 @@ class AsyncTeleBot:
 
         :param emoji: Emoji associated with the sticker; only for just uploaded stickers
         :type emoji: :obj:`str`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -4380,7 +4380,7 @@ class AsyncTeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if data and not(sticker):
             # function typo miss compatibility
@@ -4389,7 +4389,7 @@ class AsyncTeleBot:
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -4411,23 +4411,23 @@ class AsyncTeleBot:
             await asyncio_helper.send_data(
                 self.token, chat_id, sticker, 'sticker',
                 reply_markup=reply_markup,
-                disable_notification=disable_notification, timeout=timeout, 
+                disable_notification=disable_notification, timeout=timeout,
                 protect_content=protect_content,
                 message_thread_id=message_thread_id, emoji=emoji, reply_parameters=reply_parameters, business_connection_id=business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast))
 
     async def send_video(
-            self, chat_id: Union[int, str], video: Union[Any, str], 
+            self, chat_id: Union[int, str], video: Union[Any, str],
             duration: Optional[int]=None,
             width: Optional[int]=None,
             height: Optional[int]=None,
-            thumbnail: Optional[Union[Any, str]]=None, 
-            caption: Optional[str]=None, 
-            parse_mode: Optional[str]=None, 
+            thumbnail: Optional[Union[Any, str]]=None,
+            caption: Optional[str]=None,
+            parse_mode: Optional[str]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
-            supports_streaming: Optional[bool]=None, 
+            supports_streaming: Optional[bool]=None,
             disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            reply_to_message_id: Optional[int]=None, 
+            reply_to_message_id: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
@@ -4444,7 +4444,7 @@ class AsyncTeleBot:
             start_timestamp: Optional[int]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#sendvideo
 
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -4472,7 +4472,7 @@ class AsyncTeleBot:
 
         :param start_timestamp: Start timestamp for the video in the message
         :type start_timestamp: :obj:`int`
-        
+
         :param caption: Video caption (may also be used when resending videos by file_id), 0-1024 characters after entities parsing
         :type caption: :obj:`str`
 
@@ -4516,7 +4516,7 @@ class AsyncTeleBot:
 
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -4539,11 +4539,11 @@ class AsyncTeleBot:
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -4578,19 +4578,19 @@ class AsyncTeleBot:
                 show_caption_above_media=show_caption_above_media, allow_paid_broadcast=allow_paid_broadcast, cover=cover, start_timestamp=start_timestamp))
 
     async def send_animation(
-            self, chat_id: Union[int, str], animation: Union[Any, str], 
+            self, chat_id: Union[int, str], animation: Union[Any, str],
             duration: Optional[int]=None,
             width: Optional[int]=None,
             height: Optional[int]=None,
             thumbnail: Optional[Union[Any, str]]=None,
-            caption: Optional[str]=None, 
+            caption: Optional[str]=None,
             parse_mode: Optional[str]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             reply_to_message_id: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             message_thread_id: Optional[int]=None,
             has_spoiler: Optional[bool]=None,
@@ -4603,7 +4603,7 @@ class AsyncTeleBot:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#sendanimation
 
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -4621,7 +4621,7 @@ class AsyncTeleBot:
 
         :param height: Animation height
         :type height: :obj:`int`
-        
+
         :param thumbnail: Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side.
             The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320.
             Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file,
@@ -4665,7 +4665,7 @@ class AsyncTeleBot:
 
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -4688,11 +4688,11 @@ class AsyncTeleBot:
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -4722,13 +4722,13 @@ class AsyncTeleBot:
                 message_effect_id=message_effect_id, show_caption_above_media=show_caption_above_media, allow_paid_broadcast=allow_paid_broadcast))
 
     async def send_video_note(
-            self, chat_id: Union[int, str], data: Union[Any, str], 
-            duration: Optional[int]=None, 
+            self, chat_id: Union[int, str], data: Union[Any, str],
+            duration: Optional[int]=None,
             length: Optional[int]=None,
-            reply_to_message_id: Optional[int]=None, 
+            reply_to_message_id: Optional[int]=None,
             reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
-            disable_notification: Optional[bool]=None, 
-            timeout: Optional[int]=None, 
+            disable_notification: Optional[bool]=None,
+            timeout: Optional[int]=None,
             thumbnail: Optional[Union[Any, str]]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
@@ -4743,10 +4743,10 @@ class AsyncTeleBot:
         Use this method to send video messages. On success, the sent Message is returned.
 
         Telegram documentation: https://core.telegram.org/bots/api#sendvideonote
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
-        
+
         :param data: Video note to send. Pass a file_id as String to send a video note that exists on the Telegram servers (recommended)
             or upload a new video using multipart/form-data. Sending video notes by a URL is currently unsupported
         :type data: :obj:`str` or :class:`telebot.types.InputFile`
@@ -4774,7 +4774,7 @@ class AsyncTeleBot:
         :param thumbnail: Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side.
             The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320.
             Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file,
-            so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. 
+            so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>.
         :type thumbnail: :obj:`str` or :class:`telebot.types.InputFile`
 
         :param allow_sending_without_reply: Deprecated - Use reply_parameters instead. Pass True, if the message should be sent even if the specified replied-to message is not found
@@ -4788,7 +4788,7 @@ class AsyncTeleBot:
 
         :param thumb: Deprecated. Use thumbnail instead
         :type thumb: :obj:`str` or :class:`telebot.types.InputFile`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -4807,11 +4807,11 @@ class AsyncTeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -4906,13 +4906,13 @@ class AsyncTeleBot:
                 payload=payload, allow_paid_broadcast=allow_paid_broadcast))
 
     async def send_media_group(
-            self, chat_id: Union[int, str], 
+            self, chat_id: Union[int, str],
             media: List[Union[
-                types.InputMediaAudio, types.InputMediaDocument, 
+                types.InputMediaAudio, types.InputMediaDocument,
                 types.InputMediaPhoto, types.InputMediaVideo]],
-            disable_notification: Optional[bool]=None, 
+            disable_notification: Optional[bool]=None,
             protect_content: Optional[bool]=None,
-            reply_to_message_id: Optional[int]=None, 
+            reply_to_message_id: Optional[int]=None,
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
@@ -4923,7 +4923,7 @@ class AsyncTeleBot:
         """
         Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files
         can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#sendmediagroup
 
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -4949,7 +4949,7 @@ class AsyncTeleBot:
 
         :param message_thread_id: Identifier of a message thread, in which the messages will be sent
         :type message_thread_id: :obj:`int`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -4973,11 +4973,11 @@ class AsyncTeleBot:
                     media_item.parse_mode = self.parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -5001,16 +5001,16 @@ class AsyncTeleBot:
         return [types.Message.de_json(msg) for msg in result]
 
     async def send_location(
-            self, chat_id: Union[int, str], 
-            latitude: float, longitude: float, 
-            live_period: Optional[int]=None, 
-            reply_to_message_id: Optional[int]=None, 
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            disable_notification: Optional[bool]=None, 
+            self, chat_id: Union[int, str],
+            latitude: float, longitude: float,
+            live_period: Optional[int]=None,
+            reply_to_message_id: Optional[int]=None,
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
+            disable_notification: Optional[bool]=None,
             timeout: Optional[int]=None,
-            horizontal_accuracy: Optional[float]=None, 
-            heading: Optional[int]=None, 
-            proximity_alert_radius: Optional[int]=None, 
+            horizontal_accuracy: Optional[float]=None,
+            heading: Optional[int]=None,
+            proximity_alert_radius: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
             message_thread_id: Optional[int]=None,
@@ -5060,13 +5060,13 @@ class AsyncTeleBot:
 
         :param allow_sending_without_reply: Deprecated - Use reply_parameters instead. Pass True, if the message should be sent even if the specified replied-to message is not found
         :type allow_sending_without_reply: :obj:`bool`
-        
+
         :param protect_content: Protects the contents of the sent message from forwarding and saving
         :type protect_content: :obj:`bool`
 
         :param message_thread_id: Identifier of a message thread, in which the message will be sent
         :type message_thread_id: :obj:`int`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -5085,11 +5085,11 @@ class AsyncTeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -5109,20 +5109,20 @@ class AsyncTeleBot:
 
         return types.Message.de_json(
             await asyncio_helper.send_location(
-                self.token, chat_id, latitude, longitude, live_period, 
-                reply_markup, disable_notification, timeout, 
-                horizontal_accuracy, heading, proximity_alert_radius, 
+                self.token, chat_id, latitude, longitude, live_period,
+                reply_markup, disable_notification, timeout,
+                horizontal_accuracy, heading, proximity_alert_radius,
                 protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast))
 
     async def edit_message_live_location(
-            self, latitude: float, longitude: float, 
-            chat_id: Optional[Union[int, str]]=None, 
+            self, latitude: float, longitude: float,
+            chat_id: Optional[Union[int, str]]=None,
             message_id: Optional[int]=None,
-            inline_message_id: Optional[str]=None, 
+            inline_message_id: Optional[str]=None,
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             timeout: Optional[int]=None,
-            horizontal_accuracy: Optional[float]=None, 
-            heading: Optional[int]=None, 
+            horizontal_accuracy: Optional[float]=None,
+            heading: Optional[int]=None,
             proximity_alert_radius: Optional[int]=None,
             live_period: Optional[int]=None,
             business_connection_id: Optional[str]=None
@@ -5182,9 +5182,9 @@ class AsyncTeleBot:
         )
 
     async def stop_message_live_location(
-            self, chat_id: Optional[Union[int, str]]=None, 
+            self, chat_id: Optional[Union[int, str]]=None,
             message_id: Optional[int]=None,
-            inline_message_id: Optional[str]=None, 
+            inline_message_id: Optional[str]=None,
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             timeout: Optional[int]=None,
             business_connection_id: Optional[str]=None) -> types.Message:
@@ -5193,7 +5193,7 @@ class AsyncTeleBot:
         On success, if the message is not an inline message, the edited Message is returned, otherwise True is returned.
 
         Telegram documentation: https://core.telegram.org/bots/api#stopmessagelivelocation
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -5221,14 +5221,14 @@ class AsyncTeleBot:
                 self.token, chat_id, message_id, inline_message_id, reply_markup, timeout, business_connection_id))
 
     async def send_venue(
-            self, chat_id: Union[int, str], 
-            latitude: float, longitude: float, 
-            title: str, address: str, 
-            foursquare_id: Optional[str]=None, 
+            self, chat_id: Union[int, str],
+            latitude: float, longitude: float,
+            title: str, address: str,
+            foursquare_id: Optional[str]=None,
             foursquare_type: Optional[str]=None,
-            disable_notification: Optional[bool]=None, 
-            reply_to_message_id: Optional[int]=None, 
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            disable_notification: Optional[bool]=None,
+            reply_to_message_id: Optional[int]=None,
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             google_place_id: Optional[str]=None,
@@ -5241,12 +5241,12 @@ class AsyncTeleBot:
             allow_paid_broadcast: Optional[bool]=None) -> types.Message:
         """
         Use this method to send information about a venue. On success, the sent Message is returned.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#sendvenue
 
         :param chat_id: Unique identifier for the target chat or username of the target channel
         :type chat_id: :obj:`int` or :obj:`str`
-        
+
         :param latitude: Latitude of the venue
         :type latitude: :obj:`float`
 
@@ -5295,7 +5295,7 @@ class AsyncTeleBot:
 
         :param message_thread_id: The thread to which the message will be sent
         :type message_thread_id: :obj:`int`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -5304,7 +5304,7 @@ class AsyncTeleBot:
 
         :param message_effect_id: Unique identifier of the message effect
         :type message_effect_id: :obj:`str`
-        
+
         :param allow_paid_broadcast: Pass True to allow up to 1000 messages per second, ignoring broadcasting limits for a fee
             of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
         :type allow_paid_broadcast: :obj:`bool`
@@ -5314,11 +5314,11 @@ class AsyncTeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -5342,15 +5342,15 @@ class AsyncTeleBot:
                 disable_notification, reply_markup, timeout,
                 google_place_id, google_place_type, protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id,
                 allow_paid_broadcast=allow_paid_broadcast))
-        
+
 
     async def send_contact(
-            self, chat_id: Union[int, str], phone_number: str, 
-            first_name: str, last_name: Optional[str]=None, 
+            self, chat_id: Union[int, str], phone_number: str,
+            first_name: str, last_name: Optional[str]=None,
             vcard: Optional[str]=None,
-            disable_notification: Optional[bool]=None, 
-            reply_to_message_id: Optional[int]=None, 
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            disable_notification: Optional[bool]=None,
+            reply_to_message_id: Optional[int]=None,
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
@@ -5402,7 +5402,7 @@ class AsyncTeleBot:
 
         :param message_thread_id: The thread to which the message will be sent
         :type message_thread_id: :obj:`int`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -5421,11 +5421,11 @@ class AsyncTeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -5448,7 +5448,7 @@ class AsyncTeleBot:
                 self.token, chat_id, phone_number, first_name, last_name, vcard,
                 disable_notification, reply_markup, timeout,
                 protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast))
-        
+
 
     async def send_chat_action(
             self, chat_id: Union[int, str], action: str, timeout: Optional[int]=None, message_thread_id: Optional[int]=None,
@@ -5465,7 +5465,7 @@ class AsyncTeleBot:
 
         :param chat_id: Unique identifier for the target chat or username of the target channel
         :type chat_id: :obj:`int` or :obj:`str`
-        
+
         :param action: Type of action to broadcast. Choose one, depending on what the user is about
             to receive: typing for text messages, upload_photo for photos, record_video or upload_video
             for videos, record_voice or upload_voice for voice notes, upload_document for general files,
@@ -5487,8 +5487,8 @@ class AsyncTeleBot:
         return await asyncio_helper.send_chat_action(self.token, chat_id, action, timeout, message_thread_id, business_connection_id)
 
     async def kick_chat_member(
-            self, chat_id: Union[int, str], user_id: int, 
-            until_date:Optional[Union[int, datetime]]=None, 
+            self, chat_id: Union[int, str], user_id: int,
+            until_date:Optional[Union[int, datetime]]=None,
             revoke_messages: Optional[bool]=None) -> bool:
         """
         This function is deprecated. Use `ban_chat_member` instead
@@ -5497,13 +5497,13 @@ class AsyncTeleBot:
         return await asyncio_helper.ban_chat_member(self.token, chat_id, user_id, until_date, revoke_messages)
 
     async def ban_chat_member(
-            self, chat_id: Union[int, str], user_id: int, 
-            until_date:Optional[Union[int, datetime]]=None, 
+            self, chat_id: Union[int, str], user_id: int,
+            until_date:Optional[Union[int, datetime]]=None,
             revoke_messages: Optional[bool]=None) -> bool:
         """
-        Use this method to ban a user in a group, a supergroup or a channel. 
-        In the case of supergroups and channels, the user will not be able to return to the chat on their 
-        own using invite links, etc., unless unbanned first. 
+        Use this method to ban a user in a group, a supergroup or a channel.
+        In the case of supergroups and channels, the user will not be able to return to the chat on their
+        own using invite links, etc., unless unbanned first.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#banchatmember
@@ -5520,17 +5520,17 @@ class AsyncTeleBot:
         :type until_date: :obj:`int` or :obj:`datetime`
 
         :param revoke_messages: Bool: Pass True to delete all messages from the chat for the user that is being removed.
-            If False, the user will be able to see messages in the group that were sent before the user was removed. 
+            If False, the user will be able to see messages in the group that were sent before the user was removed.
             Always True for supergroups and channels.
         :type revoke_messages: :obj:`bool`
-        
+
         :return: Returns True on success.
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.ban_chat_member(self.token, chat_id, user_id, until_date, revoke_messages)
 
     async def unban_chat_member(
-            self, chat_id: Union[int, str], user_id: int, 
+            self, chat_id: Union[int, str], user_id: int,
             only_if_banned: Optional[bool]=False) -> bool:
         """
         Use this method to unban a previously kicked user in a supergroup or channel.
@@ -5557,15 +5557,15 @@ class AsyncTeleBot:
         return await asyncio_helper.unban_chat_member(self.token, chat_id, user_id, only_if_banned)
 
     async def restrict_chat_member(
-            self, chat_id: Union[int, str], user_id: int, 
+            self, chat_id: Union[int, str], user_id: int,
             until_date: Optional[Union[int, datetime]]=None,
-            can_send_messages: Optional[bool]=None, 
+            can_send_messages: Optional[bool]=None,
             can_send_media_messages: Optional[bool]=None,
-            can_send_polls: Optional[bool]=None, 
+            can_send_polls: Optional[bool]=None,
             can_send_other_messages: Optional[bool]=None,
-            can_add_web_page_previews: Optional[bool]=None, 
+            can_add_web_page_previews: Optional[bool]=None,
             can_change_info: Optional[bool]=None,
-            can_invite_users: Optional[bool]=None, 
+            can_invite_users: Optional[bool]=None,
             can_pin_messages: Optional[bool]=None,
             permissions: Optional[types.ChatPermissions]=None,
             use_independent_chat_permissions: Optional[bool]=None) -> bool:
@@ -5593,10 +5593,10 @@ class AsyncTeleBot:
 
         :param can_send_messages: deprecated
         :type can_send_messages: :obj:`bool`
-        
+
         :param can_send_media_messages: deprecated
         :type can_send_media_messages: :obj:`bool`
-        
+
         :param can_send_polls: deprecated
         :type can_send_polls: :obj:`bool`
 
@@ -5644,17 +5644,17 @@ class AsyncTeleBot:
             self.token, chat_id, user_id, permissions, until_date, use_independent_chat_permissions)
 
     async def promote_chat_member(
-            self, chat_id: Union[int, str], user_id: int, 
-            can_change_info: Optional[bool]=None, 
+            self, chat_id: Union[int, str], user_id: int,
+            can_change_info: Optional[bool]=None,
             can_post_messages: Optional[bool]=None,
-            can_edit_messages: Optional[bool]=None, 
-            can_delete_messages: Optional[bool]=None, 
+            can_edit_messages: Optional[bool]=None,
+            can_delete_messages: Optional[bool]=None,
             can_invite_users: Optional[bool]=None,
-            can_restrict_members: Optional[bool]=None, 
-            can_pin_messages: Optional[bool]=None, 
+            can_restrict_members: Optional[bool]=None,
+            can_pin_messages: Optional[bool]=None,
             can_promote_members: Optional[bool]=None,
-            is_anonymous: Optional[bool]=None, 
-            can_manage_chat: Optional[bool]=None, 
+            is_anonymous: Optional[bool]=None,
+            can_manage_chat: Optional[bool]=None,
             can_manage_video_chats: Optional[bool]=None,
             can_manage_voice_chats: Optional[bool]=None,
             can_manage_topics: Optional[bool]=None,
@@ -5704,9 +5704,9 @@ class AsyncTeleBot:
         :param is_anonymous: Pass True, if the administrator's presence in the chat is hidden
         :type is_anonymous: :obj:`bool`
 
-        :param can_manage_chat: Pass True, if the administrator can access the chat event log, chat statistics, 
-            message statistics in channels, see channel members, 
-            see anonymous administrators in supergroups and ignore slow mode. 
+        :param can_manage_chat: Pass True, if the administrator can access the chat event log, chat statistics,
+            message statistics in channels, see channel members,
+            see anonymous administrators in supergroups and ignore slow mode.
             Implied by any other administrator privilege
         :type can_manage_chat: :obj:`bool`
 
@@ -5774,10 +5774,10 @@ class AsyncTeleBot:
     async def ban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str]) -> bool:
         """
         Use this method to ban a channel chat in a supergroup or a channel.
-        The owner of the chat will not be able to send messages and join live 
-        streams on behalf of the chat, unless it is unbanned first. 
-        The bot must be an administrator in the supergroup or channel 
-        for this to work and must have the appropriate administrator rights. 
+        The owner of the chat will not be able to send messages and join live
+        streams on behalf of the chat, unless it is unbanned first.
+        The bot must be an administrator in the supergroup or channel
+        for this to work and must have the appropriate administrator rights.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#banchatsenderchat
@@ -5795,8 +5795,8 @@ class AsyncTeleBot:
 
     async def unban_chat_sender_chat(self, chat_id: Union[int, str], sender_chat_id: Union[int, str]) -> bool:
         """
-        Use this method to unban a previously banned channel chat in a supergroup or channel. 
-        The bot must be an administrator for this to work and must have the appropriate 
+        Use this method to unban a previously banned channel chat in a supergroup or channel.
+        The bot must be an administrator for this to work and must have the appropriate
         administrator rights.
         Returns True on success.
 
@@ -5844,7 +5844,7 @@ class AsyncTeleBot:
     async def create_chat_invite_link(
             self, chat_id: Union[int, str],
             name: Optional[str]=None,
-            expire_date: Optional[Union[int, datetime]]=None, 
+            expire_date: Optional[Union[int, datetime]]=None,
             member_limit: Optional[int]=None,
             creates_join_request: Optional[bool]=None) -> types.ChatInviteLink:
         """
@@ -5916,7 +5916,7 @@ class AsyncTeleBot:
         return types.ChatInviteLink.de_json(
             await asyncio_helper.edit_chat_invite_link(self.token, chat_id, invite_link, name, expire_date, member_limit, creates_join_request)
         )
-    
+
     async def create_chat_subscription_invite_link(
             self, chat_id: Union[int, str], subscription_period: int, subscription_price: int,
             name: Optional[str]=None) -> types.ChatInviteLink:
@@ -5930,7 +5930,7 @@ class AsyncTeleBot:
         :param chat_id: Unique identifier for the target channel chat or username of the target channel
             (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
-        
+
         :param name: Invite link name; 0-32 characters
         :type name: :obj:`str`
 
@@ -5978,7 +5978,7 @@ class AsyncTeleBot:
             self, chat_id: Union[int, str], invite_link: str) -> types.ChatInviteLink:
         """
         Use this method to revoke an invite link created by the bot.
-        Note: If the primary link is revoked, a new link is automatically generated The bot must be an administrator 
+        Note: If the primary link is revoked, a new link is automatically generated The bot must be an administrator
         in the chat for this to work and must have the appropriate admin rights.
 
         Telegram documentation: https://core.telegram.org/bots/api#revokechatinvitelink
@@ -6016,7 +6016,7 @@ class AsyncTeleBot:
 
     async def approve_chat_join_request(self, chat_id: Union[str, int], user_id: Union[int, str]) -> bool:
         """
-        Use this method to approve a chat join request. 
+        Use this method to approve a chat join request.
         The bot must be an administrator in the chat for this to work and must have
         the can_invite_users administrator right. Returns True on success.
 
@@ -6036,7 +6036,7 @@ class AsyncTeleBot:
 
     async def decline_chat_join_request(self, chat_id: Union[str, int], user_id: Union[int, str]) -> bool:
         """
-        Use this method to decline a chat join request. 
+        Use this method to decline a chat join request.
         The bot must be an administrator in the chat for this to work and must have
         the can_invite_users administrator right. Returns True on success.
 
@@ -6092,7 +6092,7 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.delete_chat_photo(self.token, chat_id)
-    
+
     async def set_my_description(self, description: Optional[str]=None, language_code: Optional[str]=None):
         """
         Use this method to change the bot's description, which is shown in
@@ -6123,11 +6123,11 @@ class AsyncTeleBot:
         """
         result = await asyncio_helper.get_my_description(self.token, language_code)
         return types.BotDescription.de_json(result)
-    
+
     async def set_my_short_description(self, short_description:Optional[str]=None, language_code:Optional[str]=None):
         """
         Use this method to change the bot's short description, which is shown on the bot's profile page and
-        is sent together with the link when users share the bot. 
+        is sent together with the link when users share the bot.
         Returns True on success.
 
         :param short_description: New short description for the bot; 0-120 characters. Pass an empty string to remove the dedicated short description for the given language.
@@ -6141,7 +6141,7 @@ class AsyncTeleBot:
         """
 
         return await asyncio_helper.set_my_short_description(self.token, short_description, language_code)
-    
+
     async def get_my_short_description(self, language_code: Optional[str]=None):
         """
         Use this method to get the current bot short description for the given user language.
@@ -6154,21 +6154,21 @@ class AsyncTeleBot:
         """
         result = await asyncio_helper.get_my_short_description(self.token, language_code)
         return types.BotShortDescription.de_json(result)
-    
-    async def get_my_commands(self, scope: Optional[types.BotCommandScope], 
+
+    async def get_my_commands(self, scope: Optional[types.BotCommandScope],
             language_code: Optional[str]) -> List[types.BotCommand]:
         """
-        Use this method to get the current list of the bot's commands. 
+        Use this method to get the current list of the bot's commands.
         Returns List of BotCommand on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#getmycommands
 
-        :param scope: The scope of users for which the commands are relevant. 
+        :param scope: The scope of users for which the commands are relevant.
             Defaults to BotCommandScopeDefault.
         :type scope: :class:`telebot.types.BotCommandScope`
 
-        :param language_code: A two-letter ISO 639-1 language code. If empty, 
-            commands will be applied to all users from the given scope, 
+        :param language_code: A two-letter ISO 639-1 language code. If empty,
+            commands will be applied to all users from the given scope,
             for whose language there are no dedicated commands
         :type language_code: :obj:`str`
 
@@ -6212,16 +6212,16 @@ class AsyncTeleBot:
         result = await asyncio_helper.get_my_name(self.token, language_code)
         return types.BotName.de_json(result)
 
-    async def set_chat_menu_button(self, chat_id: Union[int, str]=None, 
+    async def set_chat_menu_button(self, chat_id: Union[int, str]=None,
                 menu_button: types.MenuButton=None) -> bool:
         """
-        Use this method to change the bot's menu button in a private chat, 
-        or the default menu button. 
+        Use this method to change the bot's menu button in a private chat,
+        or the default menu button.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#setchatmenubutton
 
-        :param chat_id: Unique identifier for the target private chat. 
+        :param chat_id: Unique identifier for the target private chat.
             If not specified, default bot's menu button will be changed.
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -6252,13 +6252,13 @@ class AsyncTeleBot:
         return types.MenuButton.de_json(await asyncio_helper.get_chat_menu_button(self.token, chat_id))
 
 
-    async def set_my_default_administrator_rights(self, rights: types.ChatAdministratorRights=None, 
+    async def set_my_default_administrator_rights(self, rights: types.ChatAdministratorRights=None,
                                     for_channels: bool=None) -> bool:
         """
         Use this method to change the default administrator rights requested by the bot
         when it's added as an administrator to groups or channels.
         These rights will be suggested to users, but they are are free to modify
-        the list before adding the bot. 
+        the list before adding the bot.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#setmydefaultadministratorrights
@@ -6276,7 +6276,7 @@ class AsyncTeleBot:
         """
 
         return await asyncio_helper.set_my_default_administrator_rights(self.token, rights, for_channels)
-        
+
 
     async def get_my_default_administrator_rights(self, for_channels: bool=None) -> types.ChatAdministratorRights:
         """
@@ -6291,9 +6291,9 @@ class AsyncTeleBot:
         :return: Returns ChatAdministratorRights on success.
         :rtype: :class:`telebot.types.ChatAdministratorRights`
         """
-        
+
         return types.ChatAdministratorRights.de_json(await asyncio_helper.get_my_default_administrator_rights(self.token, for_channels))
-    
+
     async def get_business_connection(self, business_connection_id: str) -> types.BusinessConnection:
         """
         Use this method to get information about the connection of the bot with a business account.
@@ -6312,9 +6312,9 @@ class AsyncTeleBot:
         return types.BusinessConnection.de_json(
             result
         )
-    
 
-    async def set_my_commands(self, commands: List[types.BotCommand], 
+
+    async def set_my_commands(self, commands: List[types.BotCommand],
             scope: Optional[types.BotCommandScope]=None,
             language_code: Optional[str]=None) -> bool:
         """
@@ -6325,12 +6325,12 @@ class AsyncTeleBot:
         :param commands: List of BotCommand. At most 100 commands can be specified.
         :type commands: :obj:`list` of :class:`telebot.types.BotCommand`
 
-        :param scope: The scope of users for which the commands are relevant. 
+        :param scope: The scope of users for which the commands are relevant.
             Defaults to BotCommandScopeDefault.
         :type scope: :class:`telebot.types.BotCommandScope`
 
-        :param language_code: A two-letter ISO 639-1 language code. If empty, 
-            commands will be applied to all users from the given scope, 
+        :param language_code: A two-letter ISO 639-1 language code. If empty,
+            commands will be applied to all users from the given scope,
             for whose language there are no dedicated commands
         :type language_code: :obj:`str`
 
@@ -6338,22 +6338,22 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.set_my_commands(self.token, commands, scope, language_code)
-    
-    async def delete_my_commands(self, scope: Optional[types.BotCommandScope]=None, 
+
+    async def delete_my_commands(self, scope: Optional[types.BotCommandScope]=None,
             language_code: Optional[int]=None) -> bool:
         """
-        Use this method to delete the list of the bot's commands for the given scope and user language. 
-        After deletion, higher level commands will be shown to affected users. 
+        Use this method to delete the list of the bot's commands for the given scope and user language.
+        After deletion, higher level commands will be shown to affected users.
         Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#deletemycommands
-        
-        :param scope: The scope of users for which the commands are relevant. 
+
+        :param scope: The scope of users for which the commands are relevant.
             Defaults to BotCommandScopeDefault.
         :type scope: :class:`telebot.types.BotCommandScope`
 
-        :param language_code: A two-letter ISO 639-1 language code. If empty, 
-            commands will be applied to all users from the given scope, 
+        :param language_code: A two-letter ISO 639-1 language code. If empty,
+            commands will be applied to all users from the given scope,
             for whose language there are no dedicated commands
         :type language_code: :obj:`str`
 
@@ -6404,7 +6404,7 @@ class AsyncTeleBot:
         return await asyncio_helper.set_chat_description(self.token, chat_id, description)
 
     async def pin_chat_message(
-            self, chat_id: Union[int, str], message_id: int, 
+            self, chat_id: Union[int, str], message_id: int,
             disable_notification: Optional[bool]=False, business_connection_id: Optional[str]=None) -> bool:
         """
         Use this method to pin a message in a supergroup.
@@ -6475,10 +6475,10 @@ class AsyncTeleBot:
         return await asyncio_helper.unpin_all_chat_messages(self.token, chat_id)
 
     async def edit_message_text(
-            self, text: str, 
-            chat_id: Optional[Union[int, str]]=None, 
-            message_id: Optional[int]=None, 
-            inline_message_id: Optional[str]=None, 
+            self, text: str,
+            chat_id: Optional[Union[int, str]]=None,
+            message_id: Optional[int]=None,
+            inline_message_id: Optional[str]=None,
             parse_mode: Optional[str]=None,
             entities: Optional[List[types.MessageEntity]]=None,
             disable_web_page_preview: Optional[bool]=None,
@@ -6556,9 +6556,9 @@ class AsyncTeleBot:
         return types.Message.de_json(result)
 
     async def edit_message_media(
-            self, media: Any, chat_id: Optional[Union[int, str]]=None, 
+            self, media: Any, chat_id: Optional[Union[int, str]]=None,
             message_id: Optional[int]=None,
-            inline_message_id: Optional[str]=None, 
+            inline_message_id: Optional[str]=None,
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             business_connection_id: Optional[str]=None,
             timeout: Optional[int]=None) -> Union[types.Message, bool]:
@@ -6567,7 +6567,7 @@ class AsyncTeleBot:
         If a message is part of a message album, then it can be edited only to an audio for audio albums, only to a document for document albums and to a photo or a video otherwise.
         When an inline message is edited, a new file can't be uploaded; use a previously uploaded file via its file_id or specify a URL.
         On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
-        Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent. 
+        Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent.
 
         Telegram documentation: https://core.telegram.org/bots/api#editmessagemedia
 
@@ -6576,7 +6576,7 @@ class AsyncTeleBot:
         :param chat_id: Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
-        :param message_id: Required if inline_message_id is not specified. Identifier of the sent message 
+        :param message_id: Required if inline_message_id is not specified. Identifier of the sent message
         :type message_id: :obj:`int`
 
         :param inline_message_id: Required if chat_id and message_id are not specified. Identifier of the inline message
@@ -6601,9 +6601,9 @@ class AsyncTeleBot:
         return types.Message.de_json(result)
 
     async def edit_message_reply_markup(
-            self, chat_id: Optional[Union[int, str]]=None, 
+            self, chat_id: Optional[Union[int, str]]=None,
             message_id: Optional[int]=None,
-            inline_message_id: Optional[str]=None, 
+            inline_message_id: Optional[str]=None,
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             business_connection_id: Optional[str]=None,
             timeout: Optional[int]=None) -> Union[types.Message, bool]:
@@ -6640,10 +6640,10 @@ class AsyncTeleBot:
         return types.Message.de_json(result)
 
     async def send_game(
-            self, chat_id: Union[int, str], game_short_name: str, 
+            self, chat_id: Union[int, str], game_short_name: str,
             disable_notification: Optional[bool]=None,
-            reply_to_message_id: Optional[int]=None, 
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
+            reply_to_message_id: Optional[int]=None,
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             protect_content: Optional[bool]=None,
@@ -6666,7 +6666,7 @@ class AsyncTeleBot:
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`bool`
 
-        :param reply_to_message_id: Deprecated - Use reply_parameters instead. If the message is a reply, ID of the original message 
+        :param reply_to_message_id: Deprecated - Use reply_parameters instead. If the message is a reply, ID of the original message
         :type reply_to_message_id: :obj:`int`
 
         :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
@@ -6683,7 +6683,7 @@ class AsyncTeleBot:
 
         :param message_thread_id: Identifier of the thread to which the message will be sent.
         :type message_thread_id: :obj:`int`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -6702,11 +6702,11 @@ class AsyncTeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -6726,15 +6726,15 @@ class AsyncTeleBot:
 
         result = await asyncio_helper.send_game(
             self.token, chat_id, game_short_name, disable_notification,
-            reply_markup, timeout, 
+            reply_markup, timeout,
             protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast)
         return types.Message.de_json(result)
 
     async def set_game_score(
-            self, user_id: Union[int, str], score: int, 
-            force: Optional[bool]=None, 
-            chat_id: Optional[Union[int, str]]=None, 
-            message_id: Optional[int]=None, 
+            self, user_id: Union[int, str], score: int,
+            force: Optional[bool]=None,
+            chat_id: Optional[Union[int, str]]=None,
+            message_id: Optional[int]=None,
             inline_message_id: Optional[str]=None,
             disable_edit_message: Optional[bool]=None) -> Union[types.Message, bool]:
         """
@@ -6774,7 +6774,7 @@ class AsyncTeleBot:
 
     async def get_game_high_scores(
             self, user_id: int, chat_id: Optional[Union[int, str]]=None,
-            message_id: Optional[int]=None, 
+            message_id: Optional[int]=None,
             inline_message_id: Optional[str]=None) -> List[types.GameHighScore]:
         """
         Use this method to get data for high score tables. Will return the score of the specified user and several of
@@ -6805,20 +6805,20 @@ class AsyncTeleBot:
         return [types.GameHighScore.de_json(r) for r in result]
 
     async def send_invoice(
-            self, chat_id: Union[int, str], title: str, description: str, 
-            invoice_payload: str, provider_token: Union[str, None], currency: str, 
-            prices: List[types.LabeledPrice], start_parameter: Optional[str]=None, 
-            photo_url: Optional[str]=None, photo_size: Optional[int]=None, 
+            self, chat_id: Union[int, str], title: str, description: str,
+            invoice_payload: str, provider_token: Union[str, None], currency: str,
+            prices: List[types.LabeledPrice], start_parameter: Optional[str]=None,
+            photo_url: Optional[str]=None, photo_size: Optional[int]=None,
             photo_width: Optional[int]=None, photo_height: Optional[int]=None,
-            need_name: Optional[bool]=None, need_phone_number: Optional[bool]=None, 
+            need_name: Optional[bool]=None, need_phone_number: Optional[bool]=None,
             need_email: Optional[bool]=None, need_shipping_address: Optional[bool]=None,
-            send_phone_number_to_provider: Optional[bool]=None, 
-            send_email_to_provider: Optional[bool]=None, 
+            send_phone_number_to_provider: Optional[bool]=None,
+            send_email_to_provider: Optional[bool]=None,
             is_flexible: Optional[bool]=None,
-            disable_notification: Optional[bool]=None, 
-            reply_to_message_id: Optional[int]=None, 
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            provider_data: Optional[str]=None, 
+            disable_notification: Optional[bool]=None,
+            reply_to_message_id: Optional[int]=None,
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
+            provider_data: Optional[str]=None,
             timeout: Optional[int]=None,
             allow_sending_without_reply: Optional[bool]=None,
             max_tip_amount: Optional[int] = None,
@@ -6869,7 +6869,7 @@ class AsyncTeleBot:
         :param photo_size: Photo size in bytes
         :type photo_size: :obj:`int`
 
-        :param photo_width: Photo width 
+        :param photo_width: Photo width
         :type photo_width: :obj:`int`
 
         :param photo_height: Photo height
@@ -6929,7 +6929,7 @@ class AsyncTeleBot:
 
         :param message_thread_id: The identifier of a message thread, in which the invoice message will be sent
         :type message_thread_id: :obj:`int`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -6945,11 +6945,11 @@ class AsyncTeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -6979,9 +6979,9 @@ class AsyncTeleBot:
 
 
     async def create_invoice_link(self,
-            title: str, description: str, payload:str, provider_token: Union[str, None], 
+            title: str, description: str, payload:str, provider_token: Union[str, None],
             currency: str, prices: List[types.LabeledPrice],
-            max_tip_amount: Optional[int] = None, 
+            max_tip_amount: Optional[int] = None,
             suggested_tip_amounts: Optional[List[int]]=None,
             provider_data: Optional[str]=None,
             photo_url: Optional[str]=None,
@@ -6997,14 +6997,14 @@ class AsyncTeleBot:
             is_flexible: Optional[bool]=None,
             subscription_period: Optional[int]=None,
             business_connection_id: Optional[str]=None) -> str:
-            
+
         """
-        Use this method to create a link for an invoice. 
+        Use this method to create a link for an invoice.
         Returns the created invoice link as String on success.
 
         Telegram documentation:
         https://core.telegram.org/bots/api#createinvoicelink
-    
+
         :param business_connection_id: Unique identifier of the business connection on behalf of which the link will be created
         :type business_connection_id: :obj:`str`
 
@@ -7095,18 +7095,18 @@ class AsyncTeleBot:
     # noinspection PyShadowingBuiltins
     async def send_poll(
             self, chat_id: Union[int, str], question: str, options: List[Union[str, types.InputPollOption]],
-            is_anonymous: Optional[bool]=None, type: Optional[str]=None, 
-            allows_multiple_answers: Optional[bool]=None, 
+            is_anonymous: Optional[bool]=None, type: Optional[str]=None,
+            allows_multiple_answers: Optional[bool]=None,
             correct_option_id: Optional[int]=None,
-            explanation: Optional[str]=None, 
-            explanation_parse_mode: Optional[str]=None, 
-            open_period: Optional[int]=None, 
-            close_date: Optional[Union[int, datetime]]=None, 
+            explanation: Optional[str]=None,
+            explanation_parse_mode: Optional[str]=None,
+            open_period: Optional[int]=None,
+            close_date: Optional[Union[int, datetime]]=None,
             is_closed: Optional[bool]=None,
             disable_notification: Optional[bool]=False,
-            reply_to_message_id: Optional[int]=None, 
-            reply_markup: Optional[REPLY_MARKUP_TYPES]=None, 
-            allow_sending_without_reply: Optional[bool]=None, 
+            reply_to_message_id: Optional[int]=None,
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None,
+            allow_sending_without_reply: Optional[bool]=None,
             timeout: Optional[int]=None,
             explanation_entities: Optional[List[types.MessageEntity]]=None,
             protect_content: Optional[bool]=None,
@@ -7186,7 +7186,7 @@ class AsyncTeleBot:
 
         :param message_thread_id: The identifier of a message thread, in which the poll will be sent
         :type message_thread_id: :obj:`int`
-        
+
         :param reply_parameters: Reply parameters.
         :type reply_parameters: :class:`telebot.types.ReplyParameters`
 
@@ -7211,13 +7211,13 @@ class AsyncTeleBot:
         """
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
         protect_content = self.protect_content if (protect_content is None) else protect_content
-        
+
         explanation_parse_mode = self.parse_mode if (explanation_parse_mode is None) else explanation_parse_mode
         question_parse_mode = self.parse_mode if (question_parse_mode is None) else question_parse_mode
 
         if allow_sending_without_reply is not None:
             logger.warning("The parameter 'allow_sending_without_reply' is deprecated. Use 'reply_parameters' instead.")
-        
+
         if reply_to_message_id:
             # show a deprecation warning
             logger.warning("The parameter 'reply_to_message_id' is deprecated. Use 'reply_parameters' instead.")
@@ -7261,7 +7261,7 @@ class AsyncTeleBot:
                 message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast))
 
     async def stop_poll(
-            self, chat_id: Union[int, str], message_id: int, 
+            self, chat_id: Union[int, str], message_id: int,
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             business_connection_id: Optional[str]=None) -> types.Poll:
         """
@@ -7287,8 +7287,8 @@ class AsyncTeleBot:
         return types.Poll.de_json(await asyncio_helper.stop_poll(self.token, chat_id, message_id, reply_markup, business_connection_id))
 
     async def answer_shipping_query(
-            self, shipping_query_id: str, ok: bool, 
-            shipping_options: Optional[List[types.ShippingOption]]=None, 
+            self, shipping_query_id: str, ok: bool,
+            shipping_options: Optional[List[types.ShippingOption]]=None,
             error_message: Optional[str]=None) -> bool:
         """
         Asks for an answer to a shipping question.
@@ -7314,7 +7314,7 @@ class AsyncTeleBot:
         return await asyncio_helper.answer_shipping_query(self.token, shipping_query_id, ok, shipping_options, error_message)
 
     async def answer_pre_checkout_query(
-            self, pre_checkout_query_id: str, ok: bool, 
+            self, pre_checkout_query_id: str, ok: bool,
             error_message: Optional[str]=None) -> bool:
         """
         Once the user has confirmed their payment and shipping details, the Bot API sends the final confirmation in the form of an Update with the
@@ -7326,7 +7326,7 @@ class AsyncTeleBot:
 
         Telegram documentation: https://core.telegram.org/bots/api#answerprecheckoutquery
 
-        :param pre_checkout_query_id: Unique identifier for the query to be answered 
+        :param pre_checkout_query_id: Unique identifier for the query to be answered
         :type pre_checkout_query_id: :obj:`int`
 
         :param ok: Specify True if everything is alright (goods are available, etc.) and the bot is ready to proceed with the order. Use False if there are any problems.
@@ -7349,7 +7349,7 @@ class AsyncTeleBot:
         On success, returns a StarAmount object.
         """
         return types.StarAmount.de_json(await asyncio_helper.get_my_star_balance(self.token))
-    
+
     async def get_star_transactions(self, offset: Optional[int]=None, limit: Optional[int]=None) -> types.StarTransactions:
         """
         Returns the bot's Telegram Star transactions in chronological order.
@@ -7367,7 +7367,7 @@ class AsyncTeleBot:
         """
 
         return types.StarTransactions.de_json(await asyncio_helper.get_star_transactions(self.token, offset, limit))
-    
+
     async def refund_star_payment(self, user_id: int, telegram_payment_charge_id: str) -> bool:
         """
         Refunds a successful payment in Telegram Stars. Returns True on success.
@@ -7406,10 +7406,10 @@ class AsyncTeleBot:
         return await asyncio_helper.edit_user_star_subscription(self.token, user_id, telegram_payment_charge_id, is_canceled)
 
     async def edit_message_caption(
-            self, caption: str, chat_id: Optional[Union[int, str]]=None, 
-            message_id: Optional[int]=None, 
+            self, caption: str, chat_id: Optional[Union[int, str]]=None,
+            message_id: Optional[int]=None,
             inline_message_id: Optional[str]=None,
-            parse_mode: Optional[str]=None, 
+            parse_mode: Optional[str]=None,
             caption_entities: Optional[List[types.MessageEntity]]=None,
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             show_caption_above_media: Optional[bool]=None,
@@ -7466,7 +7466,7 @@ class AsyncTeleBot:
     async def reply_to(self, message: types.Message, text: str, **kwargs) -> types.Message:
         """
         Convenience function for `send_message(message.chat.id, text, reply_parameters=(message.message_id...), **kwargs)`
-        
+
         :param message: Instance of :class:`telebot.types.Message`
         :type message: :obj:`types.Message`
 
@@ -7497,12 +7497,12 @@ class AsyncTeleBot:
         return await self.send_message(message.chat.id, text, reply_parameters=reply_parameters, **kwargs)
 
     async def answer_inline_query(
-            self, inline_query_id: str, 
-            results: List[Any], 
-            cache_time: Optional[int]=None, 
-            is_personal: Optional[bool]=None, 
+            self, inline_query_id: str,
+            results: List[Any],
+            cache_time: Optional[int]=None,
+            is_personal: Optional[bool]=None,
             next_offset: Optional[str]=None,
-            switch_pm_text: Optional[str]=None, 
+            switch_pm_text: Optional[str]=None,
             switch_pm_parameter: Optional[str]=None,
             button: Optional[types.InlineQueryResultsButton]=None) -> bool:
         """
@@ -7555,7 +7555,7 @@ class AsyncTeleBot:
 
     async def unpin_all_general_forum_topic_messages(self, chat_id: Union[int, str]) -> bool:
         """
-        Use this method to clear the list of pinned messages in a General forum topic. 
+        Use this method to clear the list of pinned messages in a General forum topic.
         The bot must be an administrator in the chat for this to work and must have the
         can_pin_messages administrator right in the supergroup.
         Returns True on success.
@@ -7572,8 +7572,8 @@ class AsyncTeleBot:
         return await asyncio_helper.unpin_all_general_forum_topic_messages(self.token, chat_id)
 
     async def answer_callback_query(
-            self, callback_query_id: int, 
-            text: Optional[str]=None, show_alert: Optional[bool]=None, 
+            self, callback_query_id: int,
+            text: Optional[str]=None, show_alert: Optional[bool]=None,
             url: Optional[str]=None, cache_time: Optional[int]=None) -> bool:
         """
         Use this method to send answers to callback queries sent from inline keyboards. The answer will be displayed to
@@ -7601,14 +7601,14 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.answer_callback_query(self.token, callback_query_id, text, show_alert, url, cache_time)
-    
+
 # getUserChatBoosts
 # Use this method to get the list of boosts added to a chat by a user. Requires administrator rights in the chat. Returns a UserChatBoosts object.
 
 # Parameter	Type	Required	Description
 # chat_id	Integer or String	Yes	Unique identifier for the chat or username of the channel (in the format @channelusername)
 # user_id	Integer	Yes	Unique identifier of the target user
-    
+
     async def get_user_chat_boosts(self, chat_id: Union[int, str], user_id: int) -> types.UserChatBoosts:
         """
         Use this method to get the list of boosts added to a chat by a user. Requires administrator rights in the chat. Returns a UserChatBoosts object.
@@ -7627,11 +7627,11 @@ class AsyncTeleBot:
 
         result = await asyncio_helper.get_user_chat_boosts(self.token, chat_id, user_id)
         return types.UserChatBoosts.de_json(result)
-    
+
 
     async def set_sticker_set_thumbnail(self, name: str, user_id: int, thumbnail: Union[Any, str]=None, format: Optional[str]=None) -> bool:
         """
-        Use this method to set the thumbnail of a sticker set. 
+        Use this method to set the thumbnail of a sticker set.
         Animated thumbnails can be set for animated sticker sets only. Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#setstickersetthumbnail
@@ -7657,11 +7657,11 @@ class AsyncTeleBot:
             logger.warning("Deprecation warning. 'format' parameter is required in set_sticker_set_thumbnail. Setting format to 'static'.")
             format = "static"
         return await asyncio_helper.set_sticker_set_thumbnail(self.token, name, user_id, thumbnail, format)
-    
+
     @util.deprecated(deprecation_text="Use set_sticker_set_thumbnail instead")
     async def set_sticker_set_thumb(self, name: str, user_id: int, thumb: Union[Any, str]=None):
         """
-        Use this method to set the thumbnail of a sticker set. 
+        Use this method to set the thumbnail of a sticker set.
         Animated thumbnails can be set for animated sticker sets only. Returns True on success.
 
         Telegram documentation: https://core.telegram.org/bots/api#setstickersetthumb
@@ -7684,7 +7684,7 @@ class AsyncTeleBot:
     async def get_sticker_set(self, name: str) -> types.StickerSet:
         """
         Use this method to get a sticker set. On success, a StickerSet object is returned.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#getstickerset
 
         :param name: Sticker set name
@@ -7695,7 +7695,7 @@ class AsyncTeleBot:
         """
         result = await asyncio_helper.get_sticker_set(self.token, name)
         return types.StickerSet.de_json(result)
-    
+
     async def set_sticker_keywords(self, sticker: str, keywords: List[str]=None) -> bool:
         """
         Use this method to change search keywords assigned to a regular or custom emoji sticker.
@@ -7712,7 +7712,7 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.set_sticker_keywords(self.token, sticker, keywords)
-    
+
     async def set_sticker_mask_position(self, sticker: str, mask_position: types.MaskPosition=None) -> bool:
         """
         Use this method to change the mask position of a mask sticker.
@@ -7748,7 +7748,7 @@ class AsyncTeleBot:
         """
         Use this method to upload a .png file with a sticker for later use in createNewStickerSet and addStickerToSet
         methods (can be used multiple times). Returns the uploaded File on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#uploadstickerfile
 
         :param user_id: User identifier of sticker set owner
@@ -7762,7 +7762,7 @@ class AsyncTeleBot:
             See https://core.telegram.org/stickers for technical requirements. More information on Sending Files »
         :type sticker: :class:`telebot.types.InputFile`
 
-        :param sticker_format: One of "static", "animated", "video". 
+        :param sticker_format: One of "static", "animated", "video".
         :type sticker_format: :obj:`str`
 
         :return: On success, the sent file is returned.
@@ -7772,10 +7772,10 @@ class AsyncTeleBot:
             logger.warning('The parameter "png_sticker" is deprecated. Use "sticker" instead.')
             sticker = png_sticker
             sticker_format = "static"
-        
+
         result = await asyncio_helper.upload_sticker_file(self.token, user_id, sticker, sticker_format)
         return types.File.de_json(result)
-    
+
     async def set_custom_emoji_sticker_set_thumbnail(self, name: str, custom_emoji_id: Optional[str]=None) -> bool:
         """
         Use this method to set the thumbnail of a custom emoji sticker set.
@@ -7791,7 +7791,7 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.set_custom_emoji_sticker_set_thumbnail(self.token, name, custom_emoji_id)
-    
+
     async def set_sticker_set_title(self, name: str, title: str) -> bool:
         """
         Use this method to set the title of a created sticker set.
@@ -7857,13 +7857,13 @@ class AsyncTeleBot:
         """
         if user_id is None and chat_id is None:
             raise ValueError("Either user_id or chat_id must be specified.")
-        
+
         if gift_id is None:
             raise ValueError("gift_id must be specified.")
-        
+
         return await asyncio_helper.send_gift(self.token, gift_id, text, text_parse_mode, text_entities, pay_for_upgrade=pay_for_upgrade,
                                                 chat_id=chat_id, user_id=user_id)
-    
+
     async def verify_user(self, user_id: int, custom_description: Optional[str]=None) -> bool:
         """
         Verifies a user on behalf of the organization which is represented by the bot. Returns True on success.
@@ -7927,7 +7927,7 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.remove_chat_verification(self.token, chat_id)
-    
+
     async def read_business_message(self, business_connection_id: str, chat_id: Union[int, str], message_id: int) -> bool:
         """
         Marks incoming message as read on behalf of a business account. Requires the can_read_messages business bot right. Returns True on success.
@@ -8019,7 +8019,7 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.set_business_account_bio(self.token, business_connection_id, bio=bio)
-    
+
     async def set_business_account_gift_settings(
             self, business_connection_id: str, show_gift_button: bool, accepted_gift_types: types.AcceptedGiftTypes) -> bool:
         """
@@ -8040,11 +8040,11 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.set_business_account_gift_settings(self.token, business_connection_id, show_gift_button, accepted_gift_types)
-    
+
     async def get_business_account_star_balance(self, business_connection_id: str) -> types.StarAmount:
         """
         Returns the amount of Telegram Stars owned by a managed business account. Requires the can_view_gifts_and_stars business bot right. Returns StarAmount on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#getbusinessaccountstarbalance
 
         :param business_connection_id: Unique identifier of the business connection
@@ -8056,7 +8056,7 @@ class AsyncTeleBot:
         return types.StarAmount.de_json(
             await asyncio_helper.get_business_account_star_balance(self.token, business_connection_id)
         )
-    
+
     async def transfer_business_account_stars(self, business_connection_id: str, star_count: int) -> bool:
         """
         Transfers Telegram Stars from the business account balance to the bot's balance. Requires the can_transfer_stars business bot right. Returns True on success.
@@ -8073,7 +8073,7 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.transfer_business_account_stars(self.token, business_connection_id, star_count)
-    
+
     async def get_business_account_gifts(
             self, business_connection_id: str,
             exclude_unsaved: Optional[bool]=None,
@@ -8086,7 +8086,7 @@ class AsyncTeleBot:
             limit: Optional[int]=None) -> types.OwnedGifts:
         """
         Returns the gifts received and owned by a managed business account. Requires the can_view_gifts_and_stars business bot right. Returns OwnedGifts on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#getbusinessaccountgifts
 
         :param business_connection_id: Unique identifier of the business connection
@@ -8132,7 +8132,7 @@ class AsyncTeleBot:
                 limit=limit
             )
         )
-    
+
     async def convert_gift_to_stars(self, business_connection_id: str, owned_gift_id: str) -> bool:
         """
         Converts a given regular gift to Telegram Stars. Requires the can_convert_gifts_to_stars business bot right. Returns True on success.
@@ -8149,7 +8149,7 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.convert_gift_to_stars(self.token, business_connection_id, owned_gift_id)
-    
+
     async def upgrade_gift(
             self, business_connection_id: str, owned_gift_id: str,
             keep_original_details: Optional[bool]=None,
@@ -8213,7 +8213,7 @@ class AsyncTeleBot:
             new_owner_chat_id,
             star_count=star_count
         )
-    
+
     async def post_story(
             self, business_connection_id: str, content: types.InputStoryContent,
             active_period: int, caption: Optional[str]=None,
@@ -8320,7 +8320,7 @@ class AsyncTeleBot:
     async def delete_story(self, business_connection_id: str, story_id: int) -> bool:
         """
         Deletes a story previously posted by the bot on behalf of a managed business account. Requires the can_manage_stories business bot right. Returns True on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#deletestory
 
         :param business_connection_id: Unique identifier of the business connection
@@ -8333,7 +8333,7 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.delete_story(self.token, business_connection_id, story_id)
-    
+
     async def set_business_account_profile_photo(
             self, business_connection_id: str, photo: types.InputProfilePhoto,
             is_public: Optional[bool]=None) -> bool:
@@ -8375,7 +8375,7 @@ class AsyncTeleBot:
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.remove_business_account_profile_photo(self.token, business_connection_id, is_public=is_public)
-    
+
     async def gift_premium_subscription(
             self, user_id: int, month_count: int, star_count: int,
             text: Optional[str]=None, text_parse_mode: Optional[str]=None,
@@ -8424,7 +8424,7 @@ class AsyncTeleBot:
 
         return types.Gifts.de_json(await asyncio_helper.get_available_gifts(self.token))
 
-    
+
     async def replace_sticker_in_set(self, user_id: int, name: str, old_sticker: str, sticker: types.InputSticker) -> bool:
         """
         Use this method to replace an existing sticker in a sticker set with a new one. The method is equivalent to calling deleteStickerFromSet, then addStickerToSet,
@@ -8469,10 +8469,10 @@ class AsyncTeleBot:
 
 
     async def create_new_sticker_set(
-            self, user_id: int, name: str, title: str, 
+            self, user_id: int, name: str, title: str,
             emojis: Optional[List[str]]=None,
-            png_sticker: Union[Any, str]=None, 
-            tgs_sticker: Union[Any, str]=None, 
+            png_sticker: Union[Any, str]=None,
+            tgs_sticker: Union[Any, str]=None,
             webm_sticker: Union[Any, str]=None,
             contains_masks: Optional[bool]=None,
             sticker_type: Optional[str]=None,
@@ -8481,7 +8481,7 @@ class AsyncTeleBot:
             stickers: List[types.InputSticker]=None,
             sticker_format: Optional[str]=None) -> bool:
         """
-        Use this method to create new sticker set owned by a user. 
+        Use this method to create new sticker set owned by a user.
         The bot will be able to edit the created sticker set.
         Returns True on success.
 
@@ -8545,7 +8545,7 @@ class AsyncTeleBot:
             sticker_format = 'video'
         elif png_sticker:
             sticker_format = 'static'
-        
+
         if contains_masks is not None:
             logger.warning('The parameter "contains_masks" is deprecated, use "sticker_type" instead')
             if sticker_type is None:
@@ -8556,7 +8556,7 @@ class AsyncTeleBot:
             if stickers is None:
                 raise ValueError('You must pass at least one sticker')
             stickers = [types.InputSticker(sticker=stickers, emoji_list=emojis, mask_position=mask_position)]
-            
+
         if sticker_format:
             logger.warning('The parameter "sticker_format" is deprecated since Bot API 7.2. Stickers can now be mixed')
 
@@ -8566,8 +8566,8 @@ class AsyncTeleBot:
 
     async def add_sticker_to_set(
             self, user_id: int, name: str, emojis: Union[List[str], str]=None,
-            png_sticker: Optional[Union[Any, str]]=None, 
-            tgs_sticker: Optional[Union[Any, str]]=None,  
+            png_sticker: Optional[Union[Any, str]]=None,
+            tgs_sticker: Optional[Union[Any, str]]=None,
             webm_sticker: Optional[Union[Any, str]]=None,
             mask_position: Optional[types.MaskPosition]=None,
             sticker: Optional[types.InputSticker]=None) -> bool:
@@ -8631,7 +8631,7 @@ class AsyncTeleBot:
     async def set_sticker_position_in_set(self, sticker: str, position: int) -> bool:
         """
         Use this method to move a sticker in a set created by the bot to a specific position . Returns True on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#setstickerpositioninset
 
         :param sticker: File identifier of the sticker
@@ -8648,7 +8648,7 @@ class AsyncTeleBot:
     async def delete_sticker_from_set(self, sticker: str) -> bool:
         """
         Use this method to delete a sticker from a set created by the bot. Returns True on success.
-       
+
         Telegram documentation: https://core.telegram.org/bots/api#deletestickerfromset
 
         :param sticker: File identifier of the sticker
@@ -8799,9 +8799,9 @@ class AsyncTeleBot:
         Use this method to edit the name of the 'General' topic in a forum supergroup chat.
         The bot must be an administrator in the chat for this to work and must have can_manage_topics administrator rights.
         Returns True on success.
-        
+
         Telegram documentation: https://core.telegram.org/bots/api#editgeneralforumtopic
-        
+
         :param chat_id: Unique identifier for the target chat or username of the target channel (in the format @channelusername)
         :type chat_id: :obj:`int` or :obj:`str`
 
@@ -8892,7 +8892,7 @@ class AsyncTeleBot:
 
             Added additional parameters to support topics, business connections, and message threads.
 
-        .. seealso:: 
+        .. seealso::
 
             For more details, visit the `custom_states.py example <https://github.com/eternnoir/pyTelegramBotAPI/blob/master/examples/asynchronous_telebot/custom_states.py>`_.
 
@@ -8925,7 +8925,7 @@ class AsyncTeleBot:
             bot_id=bot_id, business_connection_id=business_connection_id, message_thread_id=message_thread_id)
 
 
-    async def reset_data(self, user_id: int, chat_id: Optional[int]=None, 
+    async def reset_data(self, user_id: int, chat_id: Optional[int]=None,
                      business_connection_id: Optional[str]=None,
                      message_thread_id: Optional[int]=None, bot_id: Optional[int]=None) -> bool:
         """
@@ -8964,7 +8964,7 @@ class AsyncTeleBot:
 
         :param user_id: User's identifier
         :type user_id: :obj:`int`
-        
+
         :param chat_id: Chat's identifier
         :type chat_id: :obj:`int`
 
@@ -9018,7 +9018,7 @@ class AsyncTeleBot:
             bot_id=bot_id, business_connection_id=business_connection_id, message_thread_id=message_thread_id)
 
 
-    async def get_state(self, user_id: int, chat_id: Optional[int]=None, 
+    async def get_state(self, user_id: int, chat_id: Optional[int]=None,
                     business_connection_id: Optional[str]=None,
                     message_thread_id: Optional[int]=None, bot_id: Optional[int]=None) -> str:
         """
@@ -9026,7 +9026,7 @@ class AsyncTeleBot:
         Not recommended to use this method. But it is ok for debugging.
 
         .. warning::
-        
+
             Even if you are using :class:`telebot.types.State`, this method will return a string.
             When comparing(not recommended), you should compare this string with :class:`telebot.types.State`.name
 
@@ -9056,9 +9056,9 @@ class AsyncTeleBot:
             bot_id=bot_id, business_connection_id=business_connection_id, message_thread_id=message_thread_id)
 
 
-    async def add_data(self, user_id: int, chat_id: Optional[int]=None, 
+    async def add_data(self, user_id: int, chat_id: Optional[int]=None,
                     business_connection_id: Optional[str]=None,
-                    message_thread_id: Optional[int]=None, 
+                    message_thread_id: Optional[int]=None,
                     bot_id: Optional[int]=None,
                     **kwargs) -> None:
         """

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -7401,7 +7401,7 @@ class PollAnswer(JsonSerializable, JsonDeserializable, Dictionaryable):
     def __init__(self, poll_id: str, option_ids: List[int], user: Optional[User] = None, voter_chat: Optional[Chat] = None, **kwargs):
         self.poll_id: str = poll_id
         self.user: Optional[User] = user
-        self.option_ids: [List[int]] = option_ids
+        self.option_ids: List[int] = option_ids
         self.voter_chat: Optional[Chat] = voter_chat
 
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -95,7 +95,7 @@ class JsonDeserializable(object):
         If it is not, it is converted to a dict by means of json.loads(json_type)
 
         :meta private:
-        
+
         :param json_type: input json or parsed dict
         :param dict_copy: if dict is passed and it is changed outside - should be True!
         :return: Dictionary parsed from json or original dict
@@ -121,9 +121,9 @@ class Update(JsonDeserializable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#update
 
-    :param update_id: The update's unique identifier. Update identifiers start from a certain positive number and 
-        increase sequentially. This ID becomes especially handy if you're using webhooks, since it allows you to ignore 
-        repeated updates or to restore the correct update sequence, should they get out of order. If there are no new updates 
+    :param update_id: The update's unique identifier. Update identifiers start from a certain positive number and
+        increase sequentially. This ID becomes especially handy if you're using webhooks, since it allows you to ignore
+        repeated updates or to restore the correct update sequence, should they get out of order. If there are no new updates
         for at least a week, then identifier of the next update will be chosen randomly instead of sequentially.
     :type update_id: :obj:`int`
 
@@ -150,8 +150,8 @@ class Update(JsonDeserializable):
     :param inline_query: Optional. New incoming inline query
     :type inline_query: :class:`telebot.types.InlineQuery`
 
-    :param chosen_inline_result: Optional. The result of an inline query that was chosen by a user and sent to their chat 
-        partner. Please see our documentation on the feedback collecting for details on how to enable these updates for your 
+    :param chosen_inline_result: Optional. The result of an inline query that was chosen by a user and sent to their chat
+        partner. Please see our documentation on the feedback collecting for details on how to enable these updates for your
         bot.
     :type chosen_inline_result: :class:`telebot.types.ChosenInlineResult`
 
@@ -161,30 +161,30 @@ class Update(JsonDeserializable):
     :param shipping_query: Optional. New incoming shipping query. Only for invoices with flexible price
     :type shipping_query: :class:`telebot.types.ShippingQuery`
 
-    :param pre_checkout_query: Optional. New incoming pre-checkout query. Contains full information about 
+    :param pre_checkout_query: Optional. New incoming pre-checkout query. Contains full information about
         checkout
     :type pre_checkout_query: :class:`telebot.types.PreCheckoutQuery`
 
     :purchased_paid_media: Optional. A user purchased paid media with a non-empty payload sent by the bot in a non-channel chat
     :type purchased_paid_media: :class:`telebot.types.PaidMediaPurchased`
 
-    :param poll: Optional. New poll state. Bots receive only updates about stopped polls and polls, which are sent by the 
+    :param poll: Optional. New poll state. Bots receive only updates about stopped polls and polls, which are sent by the
         bot
     :type poll: :class:`telebot.types.Poll`
 
-    :param poll_answer: Optional. A user changed their answer in a non-anonymous poll. Bots receive new votes only in 
+    :param poll_answer: Optional. A user changed their answer in a non-anonymous poll. Bots receive new votes only in
         polls that were sent by the bot itself.
     :type poll_answer: :class:`telebot.types.PollAnswer`
 
-    :param my_chat_member: Optional. The bot's chat member status was updated in a chat. For private chats, this update 
+    :param my_chat_member: Optional. The bot's chat member status was updated in a chat. For private chats, this update
         is received only when the bot is blocked or unblocked by the user.
     :type my_chat_member: :class:`telebot.types.ChatMemberUpdated`
 
-    :param chat_member: Optional. A chat member's status was updated in a chat. The bot must be an administrator in the 
+    :param chat_member: Optional. A chat member's status was updated in a chat. The bot must be an administrator in the
         chat and must explicitly specify “chat_member” in the list of allowed_updates to receive these updates.
     :type chat_member: :class:`telebot.types.ChatMemberUpdated`
 
-    :param chat_join_request: Optional. A request to join the chat has been sent. The bot must have the 
+    :param chat_join_request: Optional. A request to join the chat has been sent. The bot must have the
         can_invite_users administrator right in the chat to receive these updates.
     :type chat_join_request: :class:`telebot.types.ChatJoinRequest`
 
@@ -276,7 +276,6 @@ class Update(JsonDeserializable):
         self.purchased_paid_media: Optional[PaidMediaPurchased] = purchased_paid_media
 
 
-
 class ChatMemberUpdated(JsonDeserializable):
     """
     This object represents changes in the status of a chat member.
@@ -298,7 +297,7 @@ class ChatMemberUpdated(JsonDeserializable):
     :param new_chat_member: New information about the chat member
     :type new_chat_member: :class:`telebot.types.ChatMember`
 
-    :param invite_link: Optional. Chat invite link, which was used by the user to join the chat; for joining by invite 
+    :param invite_link: Optional. Chat invite link, which was used by the user to join the chat; for joining by invite
         link events only.
     :type invite_link: :class:`telebot.types.ChatInviteLink`
 
@@ -321,7 +320,7 @@ class ChatMemberUpdated(JsonDeserializable):
         obj['new_chat_member'] = ChatMember.de_json(obj['new_chat_member'])
         obj['invite_link'] = ChatInviteLink.de_json(obj.get('invite_link'))
         return cls(**obj)
-    
+
     def __init__(self, chat, from_user, date, old_chat_member, new_chat_member, invite_link=None,
                  via_join_request=None, via_chat_folder_invite_link=None,
                  **kwargs):
@@ -353,7 +352,7 @@ class ChatMemberUpdated(JsonDeserializable):
             if new[key] != old[key]:
                 dif[key] = [old[key], new[key]]
         return dif
-    
+
 
 class ChatJoinRequest(JsonDeserializable):
     """
@@ -394,7 +393,7 @@ class ChatJoinRequest(JsonDeserializable):
         obj['from_user'] = User.de_json(obj['from'])
         obj['invite_link'] = ChatInviteLink.de_json(obj.get('invite_link'))
         return cls(**obj)
-    
+
     def __init__(self, chat, from_user, user_chat_id, date, bio=None, invite_link=None, **kwargs):
         self.chat: Chat = chat
         self.from_user: User = from_user
@@ -402,6 +401,7 @@ class ChatJoinRequest(JsonDeserializable):
         self.bio: Optional[str] = bio
         self.invite_link: Optional[ChatInviteLink] = invite_link
         self.user_chat_id: int = user_chat_id
+
 
 class WebhookInfo(JsonDeserializable):
     """
@@ -421,23 +421,23 @@ class WebhookInfo(JsonDeserializable):
     :param ip_address: Optional. Currently used webhook IP address
     :type ip_address: :obj:`str`
 
-    :param last_error_date: Optional. Unix time for the most recent error that happened when trying to deliver an 
+    :param last_error_date: Optional. Unix time for the most recent error that happened when trying to deliver an
         update via webhook
     :type last_error_date: :obj:`int`
 
-    :param last_error_message: Optional. Error message in human-readable format for the most recent error that 
+    :param last_error_message: Optional. Error message in human-readable format for the most recent error that
         happened when trying to deliver an update via webhook
     :type last_error_message: :obj:`str`
 
-    :param last_synchronization_error_date: Optional. Unix time of the most recent error that happened when trying 
+    :param last_synchronization_error_date: Optional. Unix time of the most recent error that happened when trying
         to synchronize available updates with Telegram datacenters
     :type last_synchronization_error_date: :obj:`int`
 
-    :param max_connections: Optional. The maximum allowed number of simultaneous HTTPS connections to the webhook 
+    :param max_connections: Optional. The maximum allowed number of simultaneous HTTPS connections to the webhook
         for update delivery
     :type max_connections: :obj:`int`
 
-    :param allowed_updates: Optional. A list of update types the bot is subscribed to. Defaults to all update types 
+    :param allowed_updates: Optional. A list of update types the bot is subscribed to. Defaults to all update types
         except chat_member
     :type allowed_updates: :obj:`list` of :obj:`str`
 
@@ -450,7 +450,7 @@ class WebhookInfo(JsonDeserializable):
         obj = cls.check_json(json_string, dict_copy=False)
         return cls(**obj)
 
-    def __init__(self, url, has_custom_certificate, pending_update_count, ip_address=None, 
+    def __init__(self, url, has_custom_certificate, pending_update_count, ip_address=None,
                  last_error_date=None, last_error_message=None, last_synchronization_error_date=None,
                  max_connections=None, allowed_updates=None, **kwargs):
         self.url: str = url
@@ -470,8 +470,8 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#user
 
-    :param id: Unique identifier for this user or bot. This number may have more than 32 significant bits and some 
-        programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant 
+    :param id: Unique identifier for this user or bot. This number may have more than 32 significant bits and some
+        programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant
         bits, so a 64-bit integer or double-precision float type are safe for storing this identifier.
     :type id: :obj:`int`
 
@@ -499,7 +499,7 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
     :param can_join_groups: Optional. True, if the bot can be invited to groups. Returned only in getMe.
     :type can_join_groups: :obj:`bool`
 
-    :param can_read_all_group_messages: Optional. True, if privacy mode is disabled for the bot. Returned only in 
+    :param can_read_all_group_messages: Optional. True, if privacy mode is disabled for the bot. Returned only in
         getMe.
     :type can_read_all_group_messages: :obj:`bool`
 
@@ -523,8 +523,8 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
 
     # noinspection PyShadowingBuiltins
     def __init__(self, id, is_bot, first_name, last_name=None, username=None, language_code=None,
-                 can_join_groups=None, can_read_all_group_messages=None, supports_inline_queries=None, 
-                 is_premium=None, added_to_attachment_menu=None, can_connect_to_business=None, 
+                 can_join_groups=None, can_read_all_group_messages=None, supports_inline_queries=None,
+                 is_premium=None, added_to_attachment_menu=None, can_connect_to_business=None,
                  has_main_web_app=None, **kwargs):
         self.id: int = id
         self.is_bot: bool = is_bot
@@ -592,8 +592,8 @@ class ChatFullInfo(JsonDeserializable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#chat
 
-    :param id: Unique identifier for this chat. This number may have more than 32 significant bits and some programming 
-        languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 
+    :param id: Unique identifier for this chat. This number may have more than 32 significant bits and some programming
+        languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed
         64-bit integer or double-precision float type are safe for storing this identifier.
     :type id: :obj:`int`
 
@@ -729,9 +729,9 @@ class ChatFullInfo(JsonDeserializable):
         Custom emoji from this set can be used by all users and bots in the group. Returned only in getChat.
     :param custom_emoji_sticker_set_name: :obj:`str`
 
-    :param linked_chat_id: Optional. Unique identifier for the linked chat, i.e. the discussion group identifier for 
-        a channel and vice versa; for supergroups and channel chats. This identifier may be greater than 32 bits and some 
-        programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a 
+    :param linked_chat_id: Optional. Unique identifier for the linked chat, i.e. the discussion group identifier for
+        a channel and vice versa; for supergroups and channel chats. This identifier may be greater than 32 bits and some
+        programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a
         signed 64 bit integer or double-precision float type are safe for storing this identifier. Returned only in getChat.
     :type linked_chat_id: :obj:`int`
 
@@ -771,17 +771,17 @@ class ChatFullInfo(JsonDeserializable):
 
     def __init__(self, id, type, title=None, username=None, first_name=None,
                  last_name=None, photo=None, bio=None, has_private_forwards=None,
-                 description=None, invite_link=None, pinned_message=None, 
+                 description=None, invite_link=None, pinned_message=None,
                  permissions=None, slow_mode_delay=None,
                  message_auto_delete_time=None, has_protected_content=None, sticker_set_name=None,
-                 can_set_sticker_set=None, linked_chat_id=None, location=None, 
-                 join_to_send_messages=None, join_by_request=None, has_restricted_voice_and_video_messages=None, 
+                 can_set_sticker_set=None, linked_chat_id=None, location=None,
+                 join_to_send_messages=None, join_by_request=None, has_restricted_voice_and_video_messages=None,
                  is_forum=None, max_reaction_count=None, active_usernames=None, emoji_status_custom_emoji_id=None,
-                 has_hidden_members=None, has_aggressive_anti_spam_enabled=None, emoji_status_expiration_date=None, 
+                 has_hidden_members=None, has_aggressive_anti_spam_enabled=None, emoji_status_expiration_date=None,
                  available_reactions=None, accent_color_id=None, background_custom_emoji_id=None, profile_accent_color_id=None,
-                 profile_background_custom_emoji_id=None, has_visible_history=None, 
+                 profile_background_custom_emoji_id=None, has_visible_history=None,
                  unrestrict_boost_count=None, custom_emoji_sticker_set_name=None, business_intro=None, business_location=None,
-                    business_opening_hours=None, personal_chat=None, birthdate=None, 
+                    business_opening_hours=None, personal_chat=None, birthdate=None,
                     can_send_paid_media=None,
                     accepted_gift_types=None, **kwargs):
         self.id: int = id
@@ -885,7 +885,7 @@ class WebAppData(JsonDeserializable, Dictionaryable):
     :param data: The data. Be aware that a bad client can send arbitrary data in this field.
     :type data: :obj:`str`
 
-    :param button_text: Text of the web_app keyboard button from which the Web App was opened. Be aware that a bad client 
+    :param button_text: Text of the web_app keyboard button from which the Web App was opened. Be aware that a bad client
         can send arbitrary data in this field.
     :type button_text: :obj:`str`
 
@@ -1484,7 +1484,7 @@ class Message(JsonDeserializable):
         if 'direct_message_price_changed' in obj:
             opts['direct_message_price_changed'] = DirectMessagePriceChanged.de_json(obj['direct_message_price_changed'])
             content_type = 'direct_message_price_changed'
-            
+
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
     @classmethod
@@ -1838,7 +1838,7 @@ class PhotoSize(JsonDeserializable):
     :param file_id: Identifier for this file, which can be used to download or reuse the file
     :type file_id: :obj:`str`
 
-    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different 
+    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different
         bots. Can't be used to download or reuse the file.
     :type file_unique_id: :obj:`str`
 
@@ -1877,7 +1877,7 @@ class Audio(JsonDeserializable):
     :param file_id: Identifier for this file, which can be used to download or reuse the file
     :type file_id: :obj:`str`
 
-    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different 
+    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different
         bots. Can't be used to download or reuse the file.
     :type file_unique_id: :obj:`str`
 
@@ -1896,8 +1896,8 @@ class Audio(JsonDeserializable):
     :param mime_type: Optional. MIME type of the file as defined by sender
     :type mime_type: :obj:`str`
 
-    :param file_size: Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have 
-        difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or 
+    :param file_size: Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have
+        difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or
         double-precision float type are safe for storing this value.
     :type file_size: :obj:`int`
 
@@ -1913,11 +1913,11 @@ class Audio(JsonDeserializable):
         obj = cls.check_json(json_string)
         if 'thumbnail' in obj and 'file_id' in obj['thumbnail']:
             obj['thumbnail'] = PhotoSize.de_json(obj['thumbnail'])
-        else: 
+        else:
             obj['thumbnail'] = None
         return cls(**obj)
 
-    def __init__(self, file_id, file_unique_id, duration, performer=None, title=None, file_name=None, mime_type=None, 
+    def __init__(self, file_id, file_unique_id, duration, performer=None, title=None, file_name=None, mime_type=None,
                  file_size=None, thumbnail=None, **kwargs):
         self.file_id: str = file_id
         self.file_unique_id: str = file_unique_id
@@ -1944,7 +1944,7 @@ class Voice(JsonDeserializable):
     :param file_id: Identifier for this file, which can be used to download or reuse the file
     :type file_id: :obj:`str`
 
-    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different 
+    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different
         bots. Can't be used to download or reuse the file.
     :type file_unique_id: :obj:`str`
 
@@ -1954,8 +1954,8 @@ class Voice(JsonDeserializable):
     :param mime_type: Optional. MIME type of the file as defined by sender
     :type mime_type: :obj:`str`
 
-    :param file_size: Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have 
-        difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or 
+    :param file_size: Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have
+        difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or
         double-precision float type are safe for storing this value.
     :type file_size: :obj:`int`
 
@@ -1985,7 +1985,7 @@ class Document(JsonDeserializable):
     :param file_id: Identifier for this file, which can be used to download or reuse the file
     :type file_id: :obj:`str`
 
-    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different 
+    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different
         bots. Can't be used to download or reuse the file.
     :type file_unique_id: :obj:`str`
 
@@ -1998,8 +1998,8 @@ class Document(JsonDeserializable):
     :param mime_type: Optional. MIME type of the file as defined by sender
     :type mime_type: :obj:`str`
 
-    :param file_size: Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have 
-        difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or 
+    :param file_size: Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have
+        difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or
         double-precision float type are safe for storing this value.
     :type file_size: :obj:`int`
 
@@ -2012,7 +2012,7 @@ class Document(JsonDeserializable):
         obj = cls.check_json(json_string)
         if 'thumbnail' in obj and 'file_id' in obj['thumbnail']:
             obj['thumbnail'] = PhotoSize.de_json(obj['thumbnail'])
-        else: 
+        else:
             obj['thumbnail'] = None
         return cls(**obj)
 
@@ -2039,7 +2039,7 @@ class Video(JsonDeserializable):
     :param file_id: Identifier for this file, which can be used to download or reuse the file
     :type file_id: :obj:`str`
 
-    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different 
+    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different
         bots. Can't be used to download or reuse the file.
     :type file_unique_id: :obj:`str`
 
@@ -2067,8 +2067,8 @@ class Video(JsonDeserializable):
     :param mime_type: Optional. MIME type of the file as defined by sender
     :type mime_type: :obj:`str`
 
-    :param file_size: Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have 
-        difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or 
+    :param file_size: Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have
+        difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or
         double-precision float type are safe for storing this value.
     :type file_size: :obj:`int`
 
@@ -2114,7 +2114,7 @@ class VideoNote(JsonDeserializable):
     :param file_id: Identifier for this file, which can be used to download or reuse the file
     :type file_id: :obj:`str`
 
-    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different 
+    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different
         bots. Can't be used to download or reuse the file.
     :type file_unique_id: :obj:`str`
 
@@ -2170,8 +2170,8 @@ class Contact(JsonDeserializable):
     :param last_name: Optional. Contact's last name
     :type last_name: :obj:`str`
 
-    :param user_id: Optional. Contact's user identifier in Telegram. This number may have more than 32 significant bits 
-        and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 
+    :param user_id: Optional. Contact's user identifier in Telegram. This number may have more than 32 significant bits
+        and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52
         significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier.
     :type user_id: :obj:`int`
 
@@ -2210,14 +2210,14 @@ class Location(JsonDeserializable, JsonSerializable, Dictionaryable):
     :param horizontal_accuracy: Optional. The radius of uncertainty for the location, measured in meters; 0-1500
     :type horizontal_accuracy: :obj:`float` number
 
-    :param live_period: Optional. Time relative to the message sending date, during which the location can be updated; 
+    :param live_period: Optional. Time relative to the message sending date, during which the location can be updated;
         in seconds. For active live locations only.
     :type live_period: :obj:`int`
 
     :param heading: Optional. The direction in which user is moving, in degrees; 1-360. For active live locations only.
     :type heading: :obj:`int`
 
-    :param proximity_alert_radius: Optional. The maximum distance for proximity alerts about approaching another 
+    :param proximity_alert_radius: Optional. The maximum distance for proximity alerts about approaching another
         chat member, in meters. For sent live locations only.
     :type proximity_alert_radius: :obj:`int`
 
@@ -2238,10 +2238,10 @@ class Location(JsonDeserializable, JsonSerializable, Dictionaryable):
         self.live_period: Optional[int] = live_period
         self.heading: Optional[int] = heading
         self.proximity_alert_radius: Optional[int] = proximity_alert_radius
-    
+
     def to_json(self):
         return json.dumps(self.to_dict())
-    
+
     def to_dict(self):
         return {
             "longitude": self.longitude,
@@ -2271,7 +2271,7 @@ class Venue(JsonDeserializable):
     :param foursquare_id: Optional. Foursquare identifier of the venue
     :type foursquare_id: :obj:`str`
 
-    :param foursquare_type: Optional. Foursquare type of the venue. (For example, “arts_entertainment/default”, 
+    :param foursquare_type: Optional. Foursquare type of the venue. (For example, “arts_entertainment/default”,
         “arts_entertainment/aquarium” or “food/icecream”.)
     :type foursquare_type: :obj:`str`
 
@@ -2291,7 +2291,7 @@ class Venue(JsonDeserializable):
         obj['location'] = Location.de_json(obj['location'])
         return cls(**obj)
 
-    def __init__(self, location, title, address, foursquare_id=None, foursquare_type=None, 
+    def __init__(self, location, title, address, foursquare_id=None, foursquare_type=None,
                  google_place_id=None, google_place_type=None, **kwargs):
         self.location: Location = location
         self.title: str = title
@@ -2340,16 +2340,16 @@ class File(JsonDeserializable):
     :param file_id: Identifier for this file, which can be used to download or reuse the file
     :type file_id: :obj:`str`
 
-    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different 
+    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different
         bots. Can't be used to download or reuse the file.
     :type file_unique_id: :obj:`str`
 
-    :param file_size: Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have 
-        difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or 
+    :param file_size: Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have
+        difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or
         double-precision float type are safe for storing this value.
     :type file_size: :obj:`int`
 
-    :param file_path: Optional. File path. Use https://api.telegram.org/file/bot<token>/<file_path> to get the 
+    :param file_path: Optional. File path. Use https://api.telegram.org/file/bot<token>/<file_path> to get the
         file.
     :type file_path: :obj:`str`
 
@@ -2376,11 +2376,11 @@ class ForceReply(JsonSerializable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#forcereply
 
-    :param force_reply: Shows reply interface to the user, as if they manually selected the bot's message and tapped 
+    :param force_reply: Shows reply interface to the user, as if they manually selected the bot's message and tapped
         'Reply'
     :type force_reply: :obj:`bool`
 
-    :param input_field_placeholder: Optional. The placeholder to be shown in the input field when the reply is active; 
+    :param input_field_placeholder: Optional. The placeholder to be shown in the input field when the reply is active;
         1-64 characters
     :type input_field_placeholder: :obj:`str`
 
@@ -2412,16 +2412,16 @@ class ReplyKeyboardRemove(JsonSerializable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#replykeyboardremove
 
-    :param remove_keyboard: Requests clients to remove the custom keyboard (user will not be able to summon this 
-        keyboard; if you want to hide the keyboard from sight but keep it accessible, use one_time_keyboard in 
+    :param remove_keyboard: Requests clients to remove the custom keyboard (user will not be able to summon this
+        keyboard; if you want to hide the keyboard from sight but keep it accessible, use one_time_keyboard in
         ReplyKeyboardMarkup)
         Note that this parameter is set to True by default by the library. You cannot modify it.
     :type remove_keyboard: :obj:`bool`
 
-    :param selective: Optional. Use this parameter if you want to remove the keyboard for specific users only. Targets: 
-        1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has 
-        reply_to_message_id), sender of the original message.Example: A user votes in a poll, bot returns confirmation 
-        message in reply to the vote and removes the keyboard for that user, while still showing the keyboard with poll options 
+    :param selective: Optional. Use this parameter if you want to remove the keyboard for specific users only. Targets:
+        1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has
+        reply_to_message_id), sender of the original message.Example: A user votes in a poll, bot returns confirmation
+        message in reply to the vote and removes the keyboard for that user, while still showing the keyboard with poll options
         to users who haven't voted yet.
     :type selective: :obj:`bool`
 
@@ -2483,21 +2483,21 @@ class ReplyKeyboardMarkup(JsonSerializable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#replykeyboardmarkup
 
-    :param keyboard: :obj:`list` of button rows, each represented by an :obj:`list` of 
+    :param keyboard: :obj:`list` of button rows, each represented by an :obj:`list` of
         :class:`telebot.types.KeyboardButton` objects
     :type keyboard: :obj:`list` of :obj:`list` of :class:`telebot.types.KeyboardButton`
 
-    :param resize_keyboard: Optional. Requests clients to resize the keyboard vertically for optimal fit (e.g., make 
-        the keyboard smaller if there are just two rows of buttons). Defaults to false, in which case the custom keyboard is 
+    :param resize_keyboard: Optional. Requests clients to resize the keyboard vertically for optimal fit (e.g., make
+        the keyboard smaller if there are just two rows of buttons). Defaults to false, in which case the custom keyboard is
         always of the same height as the app's standard keyboard.
     :type resize_keyboard: :obj:`bool`
 
-    :param one_time_keyboard: Optional. Requests clients to hide the keyboard as soon as it's been used. The keyboard 
-        will still be available, but clients will automatically display the usual letter-keyboard in the chat - the user can 
+    :param one_time_keyboard: Optional. Requests clients to hide the keyboard as soon as it's been used. The keyboard
+        will still be available, but clients will automatically display the usual letter-keyboard in the chat - the user can
         press a special button in the input field to see the custom keyboard again. Defaults to false.
     :type one_time_keyboard: :obj:`bool`
 
-    :param input_field_placeholder: Optional. The placeholder to be shown in the input field when the keyboard is 
+    :param input_field_placeholder: Optional. The placeholder to be shown in the input field when the keyboard is
         active; 1-64 characters
     :type input_field_placeholder: :obj:`str`
 
@@ -2511,7 +2511,7 @@ class ReplyKeyboardMarkup(JsonSerializable):
     :param is_persistent: Optional. Use this parameter if you want to show the keyboard to specific users only.
         Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a
         reply (has reply_to_message_id), sender of the original message.
-        
+
         Example: A user requests to change the bot's language, bot replies to the request with a keyboard to
         select the new language. Other users in the group don't see the keyboard.
 
@@ -2520,7 +2520,7 @@ class ReplyKeyboardMarkup(JsonSerializable):
     """
     max_row_keys = 12
 
-    def __init__(self, resize_keyboard: Optional[bool]=None, one_time_keyboard: Optional[bool]=None, 
+    def __init__(self, resize_keyboard: Optional[bool]=None, one_time_keyboard: Optional[bool]=None,
             selective: Optional[bool]=None, row_width: int=3, input_field_placeholder: Optional[str]=None,
             is_persistent: Optional[bool]=None):
         if row_width > self.max_row_keys:
@@ -2562,7 +2562,7 @@ class ReplyKeyboardMarkup(JsonSerializable):
             if not DISABLE_KEYLEN_ERROR:
                 logger.error('Telegram does not support reply keyboard row width over %d.' % self.max_row_keys)
             row_width = self.max_row_keys
-        
+
         for row in service_utils.chunks(args, row_width):
             button_array = []
             for button in row:
@@ -2624,8 +2624,8 @@ class KeyboardButtonPollType(Dictionaryable):
 
     def to_dict(self):
         return {'type': self.type}
-    
- 
+
+
 class KeyboardButtonRequestUsers(Dictionaryable):
     """
     This object defines the criteria used to request a suitable user.
@@ -2795,23 +2795,23 @@ class KeyboardButton(Dictionaryable, JsonSerializable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#keyboardbutton
 
-    :param text: Text of the button. If none of the optional fields are used, it will be sent as a message when the button is 
+    :param text: Text of the button. If none of the optional fields are used, it will be sent as a message when the button is
         pressed
     :type text: :obj:`str`
 
-    :param request_contact: Optional. If True, the user's phone number will be sent as a contact when the button is 
+    :param request_contact: Optional. If True, the user's phone number will be sent as a contact when the button is
         pressed. Available in private chats only.
     :type request_contact: :obj:`bool`
 
-    :param request_location: Optional. If True, the user's current location will be sent when the button is pressed. 
+    :param request_location: Optional. If True, the user's current location will be sent when the button is pressed.
         Available in private chats only.
     :type request_location: :obj:`bool`
 
-    :param request_poll: Optional. If specified, the user will be asked to create a poll and send it to the bot when the 
+    :param request_poll: Optional. If specified, the user will be asked to create a poll and send it to the bot when the
         button is pressed. Available in private chats only.
     :type request_poll: :class:`telebot.types.KeyboardButtonPollType`
 
-    :param web_app: Optional. If specified, the described Web App will be launched when the button is pressed. The Web App 
+    :param web_app: Optional. If specified, the described Web App will be launched when the button is pressed. The Web App
         will be able to send a “web_app_data” service message. Available in private chats only.
     :type web_app: :class:`telebot.types.WebAppInfo`
 
@@ -2829,7 +2829,7 @@ class KeyboardButton(Dictionaryable, JsonSerializable):
     :return: Instance of the class
     :rtype: :class:`telebot.types.KeyboardButton`
     """
-    def __init__(self, text: str, request_contact: Optional[bool]=None, 
+    def __init__(self, text: str, request_contact: Optional[bool]=None,
             request_location: Optional[bool]=None, request_poll: Optional[KeyboardButtonPollType]=None,
             web_app: Optional[WebAppInfo]=None, request_user: Optional[KeyboardButtonRequestUser]=None,
             request_chat: Optional[KeyboardButtonRequestChat]=None, request_users: Optional[KeyboardButtonRequestUsers]=None):
@@ -2889,7 +2889,7 @@ class InlineKeyboardMarkup(Dictionaryable, JsonSerializable, JsonDeserializable)
 
     Telegram Documentation: https://core.telegram.org/bots/api#inlinekeyboardmarkup
 
-    :param keyboard: :obj:`list` of button rows, each represented by an :obj:`list` of 
+    :param keyboard: :obj:`list` of button rows, each represented by an :obj:`list` of
         :class:`telebot.types.InlineKeyboardButton` objects
     :type keyboard: :obj:`list` of :obj:`list` of :class:`telebot.types.InlineKeyboardButton`
 
@@ -2900,7 +2900,7 @@ class InlineKeyboardMarkup(Dictionaryable, JsonSerializable, JsonDeserializable)
     :rtype: :class:`telebot.types.InlineKeyboardMarkup`
     """
     max_row_keys = 8
-    
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
@@ -2913,7 +2913,7 @@ class InlineKeyboardMarkup(Dictionaryable, JsonSerializable, JsonDeserializable)
             # Todo: Will be replaced with Exception in future releases
             logger.error('Telegram does not support inline keyboard row width over %d.' % self.max_row_keys)
             row_width = self.max_row_keys
-        
+
         self.row_width: int = row_width
         self.keyboard: List[List[InlineKeyboardButton]] = keyboard or []
 
@@ -2927,7 +2927,7 @@ class InlineKeyboardMarkup(Dictionaryable, JsonSerializable, JsonDeserializable)
         When row_width is set to 2, the result:
         {keyboard: [["A", "B"], ["C"]]}
         See https://core.telegram.org/bots/api#inlinekeyboardmarkup
-        
+
         :param args: Array of InlineKeyboardButton to append to the keyboard
         :type args: :obj:`list` of :class:`telebot.types.InlineKeyboardButton`
 
@@ -2939,18 +2939,18 @@ class InlineKeyboardMarkup(Dictionaryable, JsonSerializable, JsonDeserializable)
         """
         if row_width is None:
             row_width = self.row_width
-        
+
         if row_width > self.max_row_keys:
             # Todo: Will be replaced with Exception in future releases
             logger.error('Telegram does not support inline keyboard row width over %d.' % self.max_row_keys)
             row_width = self.max_row_keys
-        
+
         for row in service_utils.chunks(args, row_width):
             button_array = [button for button in row]
             self.keyboard.append(button_array)
-        
+
         return self
-        
+
     def row(self, *args) -> 'InlineKeyboardMarkup':
         """
         Adds a list of InlineKeyboardButton to the keyboard.
@@ -2959,14 +2959,14 @@ class InlineKeyboardMarkup(Dictionaryable, JsonSerializable, JsonDeserializable)
         InlineKeyboardMarkup.row("A").row("B", "C").to_json() outputs:
         '{keyboard: [["A"], ["B", "C"]]}'
         See https://core.telegram.org/bots/api#inlinekeyboardmarkup
-        
+
         :param args: Array of InlineKeyboardButton to append to the keyboard
         :type args: :obj:`list` of :class:`telebot.types.InlineKeyboardButton`
 
         :return: self, to allow function chaining.
         :rtype: :class:`telebot.types.InlineKeyboardMarkup`
         """
-         
+
         return self.add(*args, row_width=self.max_row_keys)
 
     def to_json(self):
@@ -2987,32 +2987,32 @@ class InlineKeyboardButton(Dictionaryable, JsonSerializable, JsonDeserializable)
     :param text: Label text on the button
     :type text: :obj:`str`
 
-    :param url: Optional. HTTP or tg:// URL to be opened when the button is pressed. Links tg://user?id=<user_id> can be 
+    :param url: Optional. HTTP or tg:// URL to be opened when the button is pressed. Links tg://user?id=<user_id> can be
         used to mention a user by their ID without using a username, if this is allowed by their privacy settings.
     :type url: :obj:`str`
 
     :param callback_data: Optional. Data to be sent in a callback query to the bot when button is pressed, 1-64 bytes
     :type callback_data: :obj:`str`
 
-    :param web_app: Optional. Description of the Web App that will be launched when the user presses the button. The Web 
-        App will be able to send an arbitrary message on behalf of the user using the method answerWebAppQuery. Available only 
+    :param web_app: Optional. Description of the Web App that will be launched when the user presses the button. The Web
+        App will be able to send an arbitrary message on behalf of the user using the method answerWebAppQuery. Available only
         in private chats between a user and the bot.
     :type web_app: :class:`telebot.types.WebAppInfo`
 
-    :param login_url: Optional. An HTTPS URL used to automatically authorize the user. Can be used as a replacement for 
+    :param login_url: Optional. An HTTPS URL used to automatically authorize the user. Can be used as a replacement for
         the Telegram Login Widget.
     :type login_url: :class:`telebot.types.LoginUrl`
 
-    :param switch_inline_query: Optional. If set, pressing the button will prompt the user to select one of their chats, 
-        open that chat and insert the bot's username and the specified inline query in the input field. May be empty, in which 
-        case just the bot's username will be inserted.Note: This offers an easy way for users to start using your bot in inline 
-        mode when they are currently in a private chat with it. Especially useful when combined with switch_pm… actions - in 
+    :param switch_inline_query: Optional. If set, pressing the button will prompt the user to select one of their chats,
+        open that chat and insert the bot's username and the specified inline query in the input field. May be empty, in which
+        case just the bot's username will be inserted.Note: This offers an easy way for users to start using your bot in inline
+        mode when they are currently in a private chat with it. Especially useful when combined with switch_pm… actions - in
         this case the user will be automatically returned to the chat they switched from, skipping the chat selection screen.
     :type switch_inline_query: :obj:`str`
 
-    :param switch_inline_query_current_chat: Optional. If set, pressing the button will insert the bot's username 
-        and the specified inline query in the current chat's input field. May be empty, in which case only the bot's username 
-        will be inserted.This offers a quick way for the user to open your bot in inline mode in the same chat - good for selecting 
+    :param switch_inline_query_current_chat: Optional. If set, pressing the button will insert the bot's username
+        and the specified inline query in the current chat's input field. May be empty, in which case only the bot's username
+        will be inserted.This offers a quick way for the user to open your bot in inline mode in the same chat - good for selecting
         something from multiple options.
     :type switch_inline_query_current_chat: :obj:`str`
 
@@ -3020,11 +3020,11 @@ class InlineKeyboardButton(Dictionaryable, JsonSerializable, JsonDeserializable)
         specified type, open that chat and insert the bot's username and the specified inline query in the input field
     :type switch_inline_query_chosen_chat: :class:`telebot.types.SwitchInlineQueryChosenChat`
 
-    :param callback_game: Optional. Description of the game that will be launched when the user presses the 
+    :param callback_game: Optional. Description of the game that will be launched when the user presses the
         button. NOTE: This type of button must always be the first button in the first row.
     :type callback_game: :class:`telebot.types.CallbackGame`
 
-    :param pay: Optional. Specify True, to send a Pay button. NOTE: This type of button must always be the first button in 
+    :param pay: Optional. Specify True, to send a Pay button. NOTE: This type of button must always be the first button in
         the first row and can only be used in invoice messages.
     :type pay: :obj:`bool`
 
@@ -3046,7 +3046,7 @@ class InlineKeyboardButton(Dictionaryable, JsonSerializable, JsonDeserializable)
             obj['switch_inline_query_chosen_chat'] = SwitchInlineQueryChosenChat.de_json(obj.get('switch_inline_query_chosen_chat'))
         if 'copy_text' in obj:
             obj['copy_text'] = CopyTextButton.de_json(obj.get('copy_text'))
-        
+
         return cls(**obj)
 
     def __init__(self, text: str, url: Optional[str]=None, callback_data: Optional[str]=None, web_app: Optional[WebAppInfo]=None,
@@ -3099,22 +3099,22 @@ class LoginUrl(Dictionaryable, JsonSerializable, JsonDeserializable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#loginurl
 
-    :param url: An HTTPS URL to be opened with user authorization data added to the query string when the button is pressed. 
-        If the user refuses to provide authorization data, the original URL without information about the user will be 
-        opened. The data added is the same as described in Receiving authorization data. NOTE: You must always check the hash 
-        of the received data to verify the authentication and the integrity of the data as described in Checking 
+    :param url: An HTTPS URL to be opened with user authorization data added to the query string when the button is pressed.
+        If the user refuses to provide authorization data, the original URL without information about the user will be
+        opened. The data added is the same as described in Receiving authorization data. NOTE: You must always check the hash
+        of the received data to verify the authentication and the integrity of the data as described in Checking
         authorization.
     :type url: :obj:`str`
 
     :param forward_text: Optional. New text of the button in forwarded messages.
     :type forward_text: :obj:`str`
 
-    :param bot_username: Optional. Username of a bot, which will be used for user authorization. See Setting up a bot for 
-        more details. If not specified, the current bot's username will be assumed. The url's domain must be the same as the 
+    :param bot_username: Optional. Username of a bot, which will be used for user authorization. See Setting up a bot for
+        more details. If not specified, the current bot's username will be assumed. The url's domain must be the same as the
         domain linked with the bot. See Linking your domain to the bot for more details.
     :type bot_username: :obj:`str`
 
-    :param request_write_access: Optional. Pass True to request the permission for your bot to send messages to the 
+    :param request_write_access: Optional. Pass True to request the permission for your bot to send messages to the
         user.
     :type request_write_access: :obj:`bool`
 
@@ -3164,15 +3164,15 @@ class CallbackQuery(JsonDeserializable):
     :param message: Optional. Message sent by the bot with the callback button that originated the query
     :type message: :class:`telebot.types.Message` or :class:`telebot.types.InaccessibleMessage`
 
-    :param inline_message_id: Optional. Identifier of the message sent via the bot in inline mode, that originated the 
+    :param inline_message_id: Optional. Identifier of the message sent via the bot in inline mode, that originated the
         query.
     :type inline_message_id: :obj:`str`
 
-    :param chat_instance: Global identifier, uniquely corresponding to the chat to which the message with the callback 
+    :param chat_instance: Global identifier, uniquely corresponding to the chat to which the message with the callback
         button was sent. Useful for high scores in games.
     :type chat_instance: :obj:`str`
 
-    :param data: Optional. Data associated with the callback button. Be aware that the message originated the query can 
+    :param data: Optional. Data associated with the callback button. Be aware that the message originated the query can
         contain no callback buttons with this data.
     :type data: :obj:`str`
 
@@ -3211,27 +3211,27 @@ class CallbackQuery(JsonDeserializable):
         self.data: Optional[str] = data
         self.game_short_name: Optional[str] = game_short_name
         self.json = json_string
-        
-        
+
+
 class ChatPhoto(JsonDeserializable):
     """
     This object represents a chat photo.
 
     Telegram Documentation: https://core.telegram.org/bots/api#chatphoto
 
-    :param small_file_id: File identifier of small (160x160) chat photo. This file_id can be used only for photo 
+    :param small_file_id: File identifier of small (160x160) chat photo. This file_id can be used only for photo
         download and only for as long as the photo is not changed.
     :type small_file_id: :obj:`str`
 
-    :param small_file_unique_id: Unique file identifier of small (160x160) chat photo, which is supposed to be the same 
+    :param small_file_unique_id: Unique file identifier of small (160x160) chat photo, which is supposed to be the same
         over time and for different bots. Can't be used to download or reuse the file.
     :type small_file_unique_id: :obj:`str`
 
-    :param big_file_id: File identifier of big (640x640) chat photo. This file_id can be used only for photo download and 
+    :param big_file_id: File identifier of big (640x640) chat photo. This file_id can be used only for photo download and
         only for as long as the photo is not changed.
     :type big_file_id: :obj:`str`
 
-    :param big_file_unique_id: Unique file identifier of big (640x640) chat photo, which is supposed to be the same over 
+    :param big_file_unique_id: Unique file identifier of big (640x640) chat photo, which is supposed to be the same over
         time and for different bots. Can't be used to download or reuse the file.
     :type big_file_unique_id: :obj:`str`
 
@@ -3251,11 +3251,11 @@ class ChatPhoto(JsonDeserializable):
         self.big_file_unique_id: str = big_file_unique_id
 
 
-class ChatMember(JsonDeserializable):
+class ChatMember(JsonDeserializable, ABC):
     """
     This object contains information about one member of a chat.
     Currently, the following 6 types of chat members are supported:
-    
+
     * :class:`telebot.types.ChatMemberOwner`
     * :class:`telebot.types.ChatMemberAdministrator`
     * :class:`telebot.types.ChatMemberMember`
@@ -3266,78 +3266,31 @@ class ChatMember(JsonDeserializable):
     Telegram Documentation: https://core.telegram.org/bots/api#chatmember
     """
 
+    def __init__(self, user, status, **kwargs):
+        self.user: User = user
+        self.status: str = status
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         obj['user'] = User.de_json(obj['user'])
-        member_type = obj['status']
+        status = obj['status']
         # Ordered according to estimated appearance frequency.
-        if member_type == "member":
+        if status == "member":
             return ChatMemberMember(**obj)
-        elif member_type == "left":
+        elif status == "left":
             return ChatMemberLeft(**obj)
-        elif member_type == "kicked":
+        elif status == "kicked":
             return ChatMemberBanned(**obj)
-        elif member_type == "restricted":
+        elif status == "restricted":
             return ChatMemberRestricted(**obj)
-        elif member_type == "administrator":
+        elif status == "administrator":
             return ChatMemberAdministrator(**obj)
-        elif member_type == "creator":
+        elif status == "creator":
             return ChatMemberOwner(**obj)
         else:
-            # Should not be here. For "if something happen" compatibility
-            return cls(**obj)
-
-    def __init__(self, user, status, custom_title=None, is_anonymous=None, can_be_edited=None,
-                 can_post_messages=None, can_edit_messages=None, can_delete_messages=None,
-                 can_restrict_members=None, can_promote_members=None, can_change_info=None,
-                 can_invite_users=None,  can_pin_messages=None, is_member=None,
-                 can_send_messages=None, can_send_audios=None, can_send_documents=None,
-                 can_send_photos=None, can_send_videos=None, can_send_video_notes=None,
-                 can_send_voice_notes=None,
-                 can_send_polls=None,
-                 can_send_other_messages=None, can_add_web_page_previews=None,  
-                 can_manage_chat=None, can_manage_video_chats=None, 
-                 until_date=None, can_manage_topics=None, 
-                 can_post_stories=None, can_edit_stories=None, can_delete_stories=None,
-                 **kwargs):
-        self.user: User = user
-        self.status: str = status
-        self.custom_title: str = custom_title
-        self.is_anonymous: bool = is_anonymous 
-        self.can_be_edited: bool = can_be_edited
-        self.can_post_messages: bool = can_post_messages
-        self.can_edit_messages: bool = can_edit_messages
-        self.can_delete_messages: bool = can_delete_messages
-        self.can_restrict_members: bool = can_restrict_members
-        self.can_promote_members: bool = can_promote_members
-        self.can_change_info: bool = can_change_info
-        self.can_invite_users: bool = can_invite_users
-        self.can_pin_messages: bool = can_pin_messages
-        self.is_member: bool = is_member
-        self.can_send_messages: bool = can_send_messages
-        self.can_send_polls: bool = can_send_polls
-        self.can_send_other_messages: bool = can_send_other_messages
-        self.can_add_web_page_previews: bool = can_add_web_page_previews
-        self.can_manage_chat: bool = can_manage_chat
-        self.can_manage_video_chats: bool = can_manage_video_chats
-        self.until_date: int = until_date
-        self.can_manage_topics: bool = can_manage_topics
-        self.can_send_audios: bool = can_send_audios
-        self.can_send_documents: bool = can_send_documents
-        self.can_send_photos: bool = can_send_photos
-        self.can_send_videos: bool = can_send_videos
-        self.can_send_video_notes: bool = can_send_video_notes
-        self.can_send_voice_notes: bool = can_send_voice_notes
-        self.can_post_stories: bool = can_post_stories
-        self.can_edit_stories: bool = can_edit_stories
-        self.can_delete_stories: bool = can_delete_stories
-
-    @property
-    def can_manage_voice_chats(self):
-        log_deprecation_warning('The parameter "can_manage_voice_chats" is deprecated. Use "can_manage_video_chats" instead.')
-        return self.can_manage_video_chats
+            raise ValueError(f"Unknown chat member type: {status}.")
 
 
 # noinspection PyUnresolvedReferences
@@ -3362,7 +3315,10 @@ class ChatMemberOwner(ChatMember):
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatMemberOwner`
     """
-    pass
+    def __init__(self, user, status, is_anonymous, custom_title=None, **kwargs):
+        super().__init__(user, status, **kwargs)
+        self.is_anonymous: bool = is_anonymous
+        self.custom_title: Optional[str] = custom_title
 
 
 # noinspection PyUnresolvedReferences
@@ -3384,8 +3340,8 @@ class ChatMemberAdministrator(ChatMember):
     :param is_anonymous: True, if the user's presence in the chat is hidden
     :type is_anonymous: :obj:`bool`
 
-    :param can_manage_chat: True, if the administrator can access the chat event log, chat statistics, message 
-        statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. 
+    :param can_manage_chat: True, if the administrator can access the chat event log, chat statistics, message
+        statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode.
         Implied by any other administrator privilege
     :type can_manage_chat: :obj:`bool`
 
@@ -3398,8 +3354,8 @@ class ChatMemberAdministrator(ChatMember):
     :param can_restrict_members: True, if the administrator can restrict, ban or unban chat members
     :type can_restrict_members: :obj:`bool`
 
-    :param can_promote_members: True, if the administrator can add new administrators with a subset of their own 
-        privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that 
+    :param can_promote_members: True, if the administrator can add new administrators with a subset of their own
+        privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that
         were appointed by the user)
     :type can_promote_members: :obj:`bool`
 
@@ -3409,36 +3365,60 @@ class ChatMemberAdministrator(ChatMember):
     :param can_invite_users: True, if the user is allowed to invite new users to the chat
     :type can_invite_users: :obj:`bool`
 
+    :param can_post_stories: True, if the administrator can post channel stories
+    :type can_post_stories: :obj:`bool`
+
+    :param can_edit_stories: True, if the administrator can edit stories
+    :type can_edit_stories: :obj:`bool`
+
+    :param can_delete_stories: True, if the administrator can delete stories of other users
+    :type can_delete_stories: :obj:`bool`
+
     :param can_post_messages: Optional. True, if the administrator can post in the channel; channels only
     :type can_post_messages: :obj:`bool`
 
-    :param can_edit_messages: Optional. True, if the administrator can edit messages of other users and can pin 
-        messages; channels only
+    :param can_edit_messages: Optional. True, if the administrator can edit messages of other users and can pin messages; channels only
     :type can_edit_messages: :obj:`bool`
 
     :param can_pin_messages: Optional. True, if the user is allowed to pin messages; groups and supergroups only
     :type can_pin_messages: :obj:`bool`
 
-    :param can_manage_topics: Optional. True, if the user is allowed to create, rename, close, and reopen forum topics;
-        supergroups only
+    :param can_manage_topics: Optional. True, if the user is allowed to create, rename, close, and reopen forum topics; supergroups only
     :type can_manage_topics: :obj:`bool`
 
     :param custom_title: Optional. Custom title for this user
     :type custom_title: :obj:`str`
 
-    :param can_post_stories: Optional. True, if the administrator can post channel stories
-    :type can_post_stories: :obj:`bool`
-
-    :param can_edit_stories: Optional. True, if the administrator can edit stories
-    :type can_edit_stories: :obj:`bool`
-
-    :param can_delete_stories: Optional. True, if the administrator can delete stories of other users
-    :type can_delete_stories: :obj:`bool`
-
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatMemberAdministrator`
     """
-    pass
+    def __init__(self, user, status, can_be_edited, is_anonymous, can_manage_chat, can_delete_messages,
+                 can_manage_video_chats, can_restrict_members, can_promote_members, can_change_info, can_invite_users,
+                 can_post_stories, can_edit_stories, can_delete_stories, can_post_messages=None, can_edit_messages=None,
+                 can_pin_messages=None, can_manage_topics=None, custom_title=None, **kwargs):
+        super().__init__(user, status, **kwargs)
+        self.can_be_edited: bool = can_be_edited
+        self.is_anonymous: bool = is_anonymous
+        self.can_manage_chat: bool = can_manage_chat
+        self.can_delete_messages: bool = can_delete_messages
+        self.can_manage_video_chats: bool = can_manage_video_chats
+        self.can_restrict_members: bool = can_restrict_members
+        self.can_promote_members: bool = can_promote_members
+        self.can_change_info: bool = can_change_info
+        self.can_invite_users: bool = can_invite_users
+        self.can_post_stories: bool = can_post_stories
+        self.can_edit_stories: bool = can_edit_stories
+        self.can_delete_stories: bool = can_delete_stories
+        self.can_post_messages: Optional[bool] = can_post_messages
+        self.can_edit_messages: Optional[bool] = can_edit_messages
+        self.can_pin_messages: Optional[bool] = can_pin_messages
+        self.can_manage_topics: Optional[bool] = can_manage_topics
+        self.custom_title: Optional[str] = custom_title
+
+    @property
+    def can_manage_voice_chats(self):
+        log_deprecation_warning('The parameter "can_manage_voice_chats" is deprecated. Use "can_manage_video_chats" instead.')
+        return self.can_manage_video_chats
 
 
 # noinspection PyUnresolvedReferences
@@ -3454,10 +3434,15 @@ class ChatMemberMember(ChatMember):
     :param user: Information about the user
     :type user: :class:`telebot.types.User`
 
+    :param until_date: Optional. Date when the user's subscription will expire; Unix time. If 0, then the user is a member forever
+    :type until_date: :obj:`int`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatMemberMember`
     """
-    pass
+    def __init__(self, user, status, until_date=None, **kwargs):
+        super().__init__(user, status, **kwargs)
+        self.until_date: Optional[int] = until_date
 
 
 # noinspection PyUnresolvedReferences
@@ -3475,18 +3460,6 @@ class ChatMemberRestricted(ChatMember):
 
     :param is_member: True, if the user is a member of the chat at the moment of the request
     :type is_member: :obj:`bool`
-
-    :param can_change_info: True, if the user is allowed to change the chat title, photo and other settings
-    :type can_change_info: :obj:`bool`
-
-    :param can_invite_users: True, if the user is allowed to invite new users to the chat
-    :type can_invite_users: :obj:`bool`
-
-    :param can_pin_messages: True, if the user is allowed to pin messages
-    :type can_pin_messages: :obj:`bool`
-
-    :param can_manage_topics: True, if the user is allowed to create forum topics
-    :type can_manage_topics: :obj:`bool`
 
     :param can_send_messages: True, if the user is allowed to send text messages, contacts, locations and venues
     :type can_send_messages: :obj:`bool`
@@ -3512,21 +3485,52 @@ class ChatMemberRestricted(ChatMember):
     :param can_send_polls: True, if the user is allowed to send polls
     :type can_send_polls: :obj:`bool`
 
-    :param can_send_other_messages: True, if the user is allowed to send animations, games, stickers and use inline 
-        bots
+    :param can_send_other_messages: True, if the user is allowed to send animations, games, stickers and use inline bots
     :type can_send_other_messages: :obj:`bool`
 
     :param can_add_web_page_previews: True, if the user is allowed to add web page previews to their messages
     :type can_add_web_page_previews: :obj:`bool`
 
-    :param until_date: Date when restrictions will be lifted for this user; unix time. If 0, then the user is restricted 
-        forever
+    :param can_change_info: True, if the user is allowed to change the chat title, photo and other settings
+    :type can_change_info: :obj:`bool`
+
+    :param can_invite_users: True, if the user is allowed to invite new users to the chat
+    :type can_invite_users: :obj:`bool`
+
+    :param can_pin_messages: True, if the user is allowed to pin messages
+    :type can_pin_messages: :obj:`bool`
+
+    :param can_manage_topics: True, if the user is allowed to create forum topics
+    :type can_manage_topics: :obj:`bool`
+
+    :param until_date: Date when restrictions will be lifted for this user; unix time. If 0, then the user is restricted forever
     :type until_date: :obj:`int`
 
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatMemberRestricted`
     """
-    pass
+    def __init__(self, user, status, is_member, can_send_messages, can_send_audios, can_send_documents,
+                 can_send_photos, can_send_videos, can_send_video_notes, can_send_voice_notes, can_send_polls,
+                 can_send_other_messages, can_add_web_page_previews,
+                 can_change_info, can_invite_users, can_pin_messages, can_manage_topics,
+                 until_date=None, **kwargs):
+        super().__init__(user, status, **kwargs)
+        self.is_member: bool = is_member
+        self.can_send_messages: bool = can_send_messages
+        self.can_send_audios: bool = can_send_audios
+        self.can_send_documents: bool = can_send_documents
+        self.can_send_photos: bool = can_send_photos
+        self.can_send_videos: bool = can_send_videos
+        self.can_send_video_notes: bool = can_send_video_notes
+        self.can_send_voice_notes: bool = can_send_voice_notes
+        self.can_send_polls: bool = can_send_polls
+        self.can_send_other_messages: bool = can_send_other_messages
+        self.can_add_web_page_previews: bool = can_add_web_page_previews
+        self.can_change_info: bool = can_change_info
+        self.can_invite_users: bool = can_invite_users
+        self.can_pin_messages: bool = can_pin_messages
+        self.can_manage_topics: bool = can_manage_topics
+        self.until_date: Optional[int] = until_date
 
 
 # noinspection PyUnresolvedReferences
@@ -3561,14 +3565,15 @@ class ChatMemberBanned(ChatMember):
     :param user: Information about the user
     :type user: :class:`telebot.types.User`
 
-    :param until_date: Date when restrictions will be lifted for this user; unix time. If 0, then the user is banned 
-        forever
+    :param until_date: Date when restrictions will be lifted for this user; unix time. If 0, then the user is banned forever
     :type until_date: :obj:`int`
 
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatMemberBanned`
     """
-    pass
+    def __init__(self, user, status, until_date=None, **kwargs):
+        super().__init__(user, status, **kwargs)
+        self.until_date: Optional[int] = until_date
 
 
 class ChatPermissions(JsonDeserializable, JsonSerializable, Dictionaryable):
@@ -3577,8 +3582,7 @@ class ChatPermissions(JsonDeserializable, JsonSerializable, Dictionaryable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#chatpermissions
 
-    :param can_send_messages: Optional. True, if the user is allowed to send text messages, contacts, locations and 
-        venues
+    :param can_send_messages: Optional. True, if the user is allowed to send text messages, contacts, locations and venues
     :type can_send_messages: :obj:`bool`
 
     :param can_send_audios: Optional. True, if the user is allowed to send audios
@@ -3602,15 +3606,15 @@ class ChatPermissions(JsonDeserializable, JsonSerializable, Dictionaryable):
     :param can_send_polls: Optional. True, if the user is allowed to send polls, implies can_send_messages
     :type can_send_polls: :obj:`bool`
 
-    :param can_send_other_messages: Optional. True, if the user is allowed to send animations, games, stickers and use 
+    :param can_send_other_messages: Optional. True, if the user is allowed to send animations, games, stickers and use
         inline bots
     :type can_send_other_messages: :obj:`bool`
 
-    :param can_add_web_page_previews: Optional. True, if the user is allowed to add web page previews to their 
+    :param can_add_web_page_previews: Optional. True, if the user is allowed to add web page previews to their
         messages
     :type can_add_web_page_previews: :obj:`bool`
 
-    :param can_change_info: Optional. True, if the user is allowed to change the chat title, photo and other settings. 
+    :param can_change_info: Optional. True, if the user is allowed to change the chat title, photo and other settings.
         Ignored in public supergroups
     :type can_change_info: :obj:`bool`
 
@@ -3622,7 +3626,7 @@ class ChatPermissions(JsonDeserializable, JsonSerializable, Dictionaryable):
 
     :param can_manage_topics: Optional. True, if the user is allowed to create forum topics. If omitted defaults to the
         value of can_pin_messages
-    :type can_manage_topics: :obj:`bool`    
+    :type can_manage_topics: :obj:`bool`
 
     :param can_send_media_messages: deprecated.
     :type can_send_media_messages: :obj:`bool`
@@ -3641,7 +3645,7 @@ class ChatPermissions(JsonDeserializable, JsonSerializable, Dictionaryable):
                     can_send_videos=None, can_send_video_notes=None,
                     can_send_voice_notes=None, can_send_polls=None, can_send_other_messages=None,
                     can_add_web_page_previews=None, can_change_info=None,
-                    can_invite_users=None, can_pin_messages=None, 
+                    can_invite_users=None, can_pin_messages=None,
                     can_manage_topics=None, **kwargs):
         self.can_send_messages: Optional[bool] = can_send_messages
         self.can_send_polls: Optional[bool] = can_send_polls
@@ -3704,7 +3708,7 @@ class ChatPermissions(JsonDeserializable, JsonSerializable, Dictionaryable):
             json_dict['can_pin_messages'] = self.can_pin_messages
         if self.can_manage_topics is not None:
             json_dict['can_manage_topics'] = self.can_manage_topics
-        
+
         return json_dict
 
 
@@ -3714,7 +3718,7 @@ class BotCommand(JsonSerializable, JsonDeserializable, Dictionaryable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#botcommand
 
-    :param command: Text of the command; 1-32 characters. Can contain only lowercase English letters, digits and 
+    :param command: Text of the command; 1-32 characters. Can contain only lowercase English letters, digits and
         underscores.
     :type command: :obj:`str`
 
@@ -3891,7 +3895,7 @@ class BotCommandScopeChat(BotCommandScope):
     :param type: Scope type, must be chat
     :type type: :obj:`str`
 
-    :param chat_id: Unique identifier for the target chat or username of the target supergroup (in the format 
+    :param chat_id: Unique identifier for the target chat or username of the target supergroup (in the format
         @supergroupusername)
     :type chat_id: :obj:`int` or :obj:`str`
 
@@ -3912,7 +3916,7 @@ class BotCommandScopeChatAdministrators(BotCommandScope):
     :param type: Scope type, must be chat_administrators
     :type type: :obj:`str`
 
-    :param chat_id: Unique identifier for the target chat or username of the target supergroup (in the format 
+    :param chat_id: Unique identifier for the target chat or username of the target supergroup (in the format
         @supergroupusername)
     :type chat_id: :obj:`int` or :obj:`str`
 
@@ -3933,7 +3937,7 @@ class BotCommandScopeChatMember(BotCommandScope):
     :param type: Scope type, must be chat_member
     :type type: :obj:`str`
 
-    :param chat_id: Unique identifier for the target chat or username of the target supergroup (in the format 
+    :param chat_id: Unique identifier for the target chat or username of the target supergroup (in the format
         @supergroupusername)
     :type chat_id: :obj:`int` or :obj:`str`
 
@@ -3968,9 +3972,9 @@ class InlineQuery(JsonDeserializable):
     :param offset: Offset of the results to be returned, can be controlled by the bot
     :type offset: :obj:`str`
 
-    :param chat_type: Optional. Type of the chat from which the inline query was sent. Can be either “sender” for a private 
-        chat with the inline query sender, “private”, “group”, “supergroup”, or “channel”. The chat type should be always 
-        known for requests sent from official clients and most third-party clients, unless the request was sent from a secret 
+    :param chat_type: Optional. Type of the chat from which the inline query was sent. Can be either “sender” for a private
+        chat with the inline query sender, “private”, “group”, “supergroup”, or “channel”. The chat type should be always
+        known for requests sent from official clients and most third-party clients, unless the request was sent from a secret
         chat
     :type chat_type: :obj:`str`
 
@@ -4007,11 +4011,11 @@ class InputTextMessageContent(Dictionaryable):
     :param message_text: Text of the message to be sent, 1-4096 characters
     :type message_text: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the message text. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the message text. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param entities: Optional. List of special entities that appear in message text, which can be specified instead of 
+    :param entities: Optional. List of special entities that appear in message text, which can be specified instead of
         parse_mode
     :type entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -4118,7 +4122,7 @@ class InputVenueMessageContent(Dictionaryable):
     :param foursquare_id: Optional. Foursquare identifier of the venue, if known
     :type foursquare_id: :obj:`str`
 
-    :param foursquare_type: Optional. Foursquare type of the venue, if known. (For example, 
+    :param foursquare_type: Optional. Foursquare type of the venue, if known. (For example,
         “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
     :type foursquare_type: :obj:`str`
 
@@ -4131,7 +4135,7 @@ class InputVenueMessageContent(Dictionaryable):
     :return: Instance of the class
     :rtype: :class:`telebot.types.InputVenueMessageContent`
     """
-    def __init__(self, latitude, longitude, title, address, foursquare_id=None, foursquare_type=None, 
+    def __init__(self, latitude, longitude, title, address, foursquare_id=None, foursquare_type=None,
                  google_place_id=None, google_place_type=None):
         self.latitude: float = latitude
         self.longitude: float = longitude
@@ -4208,7 +4212,7 @@ class InputInvoiceMessageContent(Dictionaryable):
     :param description: Product description, 1-255 characters
     :type description: :obj:`str`
 
-    :param payload: Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your 
+    :param payload: Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your
         internal processes.
     :type payload: :obj:`str`
 
@@ -4219,26 +4223,26 @@ class InputInvoiceMessageContent(Dictionaryable):
     :param currency: Three-letter ISO 4217 currency code, see more on currencies
     :type currency: :obj:`str`
 
-    :param prices: Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery 
+    :param prices: Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery
         cost, delivery tax, bonus, etc.)
     :type prices: :obj:`list` of :class:`telebot.types.LabeledPrice`
 
-    :param max_tip_amount: Optional. The maximum accepted amount for tips in the smallest units of the currency 
-        (integer, not float/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp 
-        parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the 
+    :param max_tip_amount: Optional. The maximum accepted amount for tips in the smallest units of the currency
+        (integer, not float/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp
+        parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the
         majority of currencies). Defaults to 0
     :type max_tip_amount: :obj:`int`
 
-    :param suggested_tip_amounts: Optional. A JSON-serialized array of suggested amounts of tip in the smallest units 
-        of the currency (integer, not float/double). At most 4 suggested tip amounts can be specified. The suggested tip 
+    :param suggested_tip_amounts: Optional. A JSON-serialized array of suggested amounts of tip in the smallest units
+        of the currency (integer, not float/double). At most 4 suggested tip amounts can be specified. The suggested tip
         amounts must be positive, passed in a strictly increased order and must not exceed max_tip_amount.
     :type suggested_tip_amounts: :obj:`list` of :obj:`int`
 
-    :param provider_data: Optional. A JSON-serialized object for data about the invoice, which will be shared with the 
+    :param provider_data: Optional. A JSON-serialized object for data about the invoice, which will be shared with the
         payment provider. A detailed description of the required fields should be provided by the payment provider.
     :type provider_data: :obj:`str`
 
-    :param photo_url: Optional. URL of the product photo for the invoice. Can be a photo of the goods or a marketing image 
+    :param photo_url: Optional. URL of the product photo for the invoice. Can be a photo of the goods or a marketing image
         for a service.
     :type photo_url: :obj:`str`
 
@@ -4260,7 +4264,7 @@ class InputInvoiceMessageContent(Dictionaryable):
     :param need_email: Optional. Pass True, if you require the user's email address to complete the order
     :type need_email: :obj:`bool`
 
-    :param need_shipping_address: Optional. Pass True, if you require the user's shipping address to complete the 
+    :param need_shipping_address: Optional. Pass True, if you require the user's shipping address to complete the
         order
     :type need_shipping_address: :obj:`bool`
 
@@ -4276,7 +4280,7 @@ class InputInvoiceMessageContent(Dictionaryable):
     :return: Instance of the class
     :rtype: :class:`telebot.types.InputInvoiceMessageContent`
     """
-    
+
     def __init__(self, title: str, description: str, payload: str, provider_token: Optional[str], currency: str, prices: List[LabeledPrice],
                     max_tip_amount: Optional[int] = None, suggested_tip_amounts: Optional[List[int]] = None, provider_data: Optional[str] = None,
                     photo_url: Optional[str] = None, photo_size: Optional[int] = None, photo_width: Optional[int] = None, photo_height: Optional[int] = None,
@@ -4302,10 +4306,10 @@ class InputInvoiceMessageContent(Dictionaryable):
         self.send_phone_number_to_provider: Optional[bool] = send_phone_number_to_provider
         self.send_email_to_provider: Optional[bool] = send_email_to_provider
         self.is_flexible: Optional[bool] = is_flexible
-    
+
     def to_dict(self):
         json_dict = {
-            'title': self.title, 
+            'title': self.title,
             'description': self.description,
             'payload': self.payload,
             'provider_token': self.provider_token,
@@ -4313,33 +4317,33 @@ class InputInvoiceMessageContent(Dictionaryable):
             'prices': [LabeledPrice.to_dict(lp) for lp in self.prices]
         }
         if self.max_tip_amount:
-            json_dict['max_tip_amount'] = self.max_tip_amount 
+            json_dict['max_tip_amount'] = self.max_tip_amount
         if self.suggested_tip_amounts:
-            json_dict['suggested_tip_amounts'] = self.suggested_tip_amounts 
+            json_dict['suggested_tip_amounts'] = self.suggested_tip_amounts
         if self.provider_data:
-            json_dict['provider_data'] = self.provider_data 
+            json_dict['provider_data'] = self.provider_data
         if self.photo_url:
-            json_dict['photo_url'] = self.photo_url 
+            json_dict['photo_url'] = self.photo_url
         if self.photo_size:
-            json_dict['photo_size'] = self.photo_size 
+            json_dict['photo_size'] = self.photo_size
         if self.photo_width:
-            json_dict['photo_width'] = self.photo_width 
+            json_dict['photo_width'] = self.photo_width
         if self.photo_height:
-            json_dict['photo_height'] = self.photo_height 
+            json_dict['photo_height'] = self.photo_height
         if self.need_name is not None:
-            json_dict['need_name'] = self.need_name 
+            json_dict['need_name'] = self.need_name
         if self.need_phone_number is not None:
-            json_dict['need_phone_number'] = self.need_phone_number 
+            json_dict['need_phone_number'] = self.need_phone_number
         if self.need_email is not None:
-            json_dict['need_email'] = self.need_email 
+            json_dict['need_email'] = self.need_email
         if self.need_shipping_address is not None:
-            json_dict['need_shipping_address'] = self.need_shipping_address 
+            json_dict['need_shipping_address'] = self.need_shipping_address
         if self.send_phone_number_to_provider is not None:
-            json_dict['send_phone_number_to_provider'] = self.send_phone_number_to_provider      
+            json_dict['send_phone_number_to_provider'] = self.send_phone_number_to_provider
         if self.send_email_to_provider is not None:
-            json_dict['send_email_to_provider'] = self.send_email_to_provider 
+            json_dict['send_email_to_provider'] = self.send_email_to_provider
         if self.is_flexible is not None:
-            json_dict['is_flexible'] = self.is_flexible 
+            json_dict['is_flexible'] = self.is_flexible
         return json_dict
 
 InputMessageContent = Union[InputTextMessageContent, InputLocationMessageContent, InputVenueMessageContent, InputContactMessageContent, InputInvoiceMessageContent]
@@ -4359,7 +4363,7 @@ class ChosenInlineResult(JsonDeserializable):
     :param location: Optional. Sender location, only for bots that require user location
     :type location: :class:`telebot.types.Location`
 
-    :param inline_message_id: Optional. Identifier of the sent inline message. Available only if there is an inline 
+    :param inline_message_id: Optional. Identifier of the sent inline message. Available only if there is an inline
         keyboard attached to the message. Will be also received in callback queries and can be used to edit the message.
     :type inline_message_id: :obj:`str`
 
@@ -4414,7 +4418,7 @@ class InlineQueryResultBase(ABC, Dictionaryable, JsonSerializable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#inlinequeryresult
     """
-    
+
     def __init__(self, type: str, id: str, title: Optional[str] = None, caption: Optional[str] = None, input_message_content: Optional[InputMessageContent] = None,
                     reply_markup: Optional[InlineKeyboardMarkup] = None, caption_entities: Optional[List[MessageEntity]] = None, parse_mode: Optional[str] = None):
         self.type: str = type
@@ -4455,7 +4459,7 @@ class SentWebAppMessage(JsonDeserializable, Dictionaryable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#sentwebappmessage
 
-    :param inline_message_id: Optional. Identifier of the sent inline message. Available only if there is an inline 
+    :param inline_message_id: Optional. Identifier of the sent inline message. Available only if there is an inline
         keyboard attached to the message.
     :type inline_message_id: :obj:`str`
 
@@ -4521,11 +4525,11 @@ class InlineQueryResultArticle(InlineQueryResultBase):
     :return: Instance of the class
     :rtype: :class:`telebot.types.InlineQueryResultArticle`
     """
-        
+
     def __init__(self, id: str, title: str, input_message_content: InputMessageContent, reply_markup: Optional[InlineKeyboardMarkup] = None,
                  url: Optional[str] = None, hide_url: Optional[bool] = None, description: Optional[str] = None,
                  thumbnail_url: Optional[str] = None, thumbnail_width: Optional[int] = None, thumbnail_height: Optional[int] = None):
-                 
+
         super().__init__('article', id, title = title, input_message_content = input_message_content, reply_markup = reply_markup)
         self.url: Optional[str] = url
         self.hide_url: Optional[bool] = hide_url
@@ -4605,11 +4609,11 @@ class InlineQueryResultPhoto(InlineQueryResultBase):
     :param caption: Optional. Caption of the photo to be sent, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the photo caption. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the photo caption. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -4688,7 +4692,7 @@ class InlineQueryResultGif(InlineQueryResultBase):
     :param thumbnail_url: URL of the static (JPEG or GIF) or animated (MPEG4) thumbnail for the result
     :type thumbnail_url: :obj:`str`
 
-    :param thumbnail_mime_type: Optional. MIME type of the thumbnail, must be one of “image/jpeg”, “image/gif”, or 
+    :param thumbnail_mime_type: Optional. MIME type of the thumbnail, must be one of “image/jpeg”, “image/gif”, or
         “video/mp4”. Defaults to “image/jpeg”
     :type thumbnail_mime_type: :obj:`str`
 
@@ -4701,7 +4705,7 @@ class InlineQueryResultGif(InlineQueryResultBase):
     :param parse_mode: Optional. Mode for parsing entities in the caption. See formatting options for more details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -4722,7 +4726,7 @@ class InlineQueryResultGif(InlineQueryResultBase):
                     reply_markup: Optional[InlineKeyboardMarkup] = None, input_message_content: Optional[InputMessageContent] = None,
                     gif_duration: Optional[int] = None, parse_mode: Optional[str] = None, thumbnail_mime_type: Optional[str] = None,
                     show_caption_above_media: Optional[bool] = None):
-        
+
         super().__init__('gif', id, title = title, caption = caption,
                          input_message_content = input_message_content, reply_markup = reply_markup,
                          parse_mode = parse_mode, caption_entities = caption_entities)
@@ -4789,7 +4793,7 @@ class InlineQueryResultMpeg4Gif(InlineQueryResultBase):
     :param thumbnail_url: URL of the static (JPEG or GIF) or animated (MPEG4) thumbnail for the result
     :type thumbnail_url: :obj:`str`
 
-    :param thumbnail_mime_type: Optional. MIME type of the thumbnail, must be one of “image/jpeg”, “image/gif”, or 
+    :param thumbnail_mime_type: Optional. MIME type of the thumbnail, must be one of “image/jpeg”, “image/gif”, or
         “video/mp4”. Defaults to “image/jpeg”
     :type thumbnail_mime_type: :obj:`str`
 
@@ -4802,7 +4806,7 @@ class InlineQueryResultMpeg4Gif(InlineQueryResultBase):
     :param parse_mode: Optional. Mode for parsing entities in the caption. See formatting options for more details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -4822,7 +4826,7 @@ class InlineQueryResultMpeg4Gif(InlineQueryResultBase):
                     title: Optional[str] = None, caption: Optional[str] = None, caption_entities: Optional[List[MessageEntity]] = None,
                     parse_mode: Optional[str] = None, reply_markup: Optional[InlineKeyboardMarkup] = None, input_message_content: Optional[InputMessageContent] = None,
                     mpeg4_duration: Optional[int] = None, thumbnail_mime_type: Optional[str] = None, show_caption_above_media: Optional[bool] = None):
-        
+
         super().__init__('mpeg4_gif', id, title = title, caption = caption,
                          input_message_content = input_message_content, reply_markup = reply_markup,
                          parse_mode = parse_mode, caption_entities = caption_entities)
@@ -4889,11 +4893,11 @@ class InlineQueryResultVideo(InlineQueryResultBase):
     :param caption: Optional. Caption of the video to be sent, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the video caption. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the video caption. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -4912,7 +4916,7 @@ class InlineQueryResultVideo(InlineQueryResultBase):
     :param reply_markup: Optional. Inline keyboard attached to the message
     :type reply_markup: :class:`telebot.types.InlineKeyboardMarkup`
 
-    :param input_message_content: Optional. Content of the message to be sent instead of the video. This field is 
+    :param input_message_content: Optional. Content of the message to be sent instead of the video. This field is
         required if InlineQueryResultVideo is used to send an HTML-page as a result (e.g., a YouTube video).
     :type input_message_content: :class:`telebot.types.InputMessageContent`
 
@@ -4927,7 +4931,7 @@ class InlineQueryResultVideo(InlineQueryResultBase):
                  parse_mode: Optional[str] = None, video_width: Optional[int] = None, video_height: Optional[int] = None,
                  video_duration: Optional[int] = None, description: Optional[str] = None, reply_markup: Optional[InlineKeyboardMarkup] = None,
                  input_message_content: Optional[InputMessageContent] = None, show_caption_above_media: Optional[bool] = None):
-        
+
         super().__init__('video', id, title = title, caption = caption,
                          input_message_content = input_message_content, reply_markup = reply_markup,
                          parse_mode = parse_mode, caption_entities = caption_entities)
@@ -4983,11 +4987,11 @@ class InlineQueryResultAudio(InlineQueryResultBase):
     :param caption: Optional. Caption, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the audio caption. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the audio caption. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -5009,7 +5013,7 @@ class InlineQueryResultAudio(InlineQueryResultBase):
     def __init__(self, id: str, audio_url: str, title: str, caption: Optional[str] = None, caption_entities: Optional[List[MessageEntity]] = None,
                  parse_mode: Optional[str] = None, performer: Optional[str] = None, audio_duration: Optional[int] = None,
                  reply_markup: Optional[InlineKeyboardMarkup] = None, input_message_content: Optional[InputMessageContent] = None):
-        
+
         super().__init__('audio', id, title = title, caption = caption,
                          input_message_content = input_message_content, reply_markup = reply_markup,
                          parse_mode = parse_mode, caption_entities = caption_entities)
@@ -5049,11 +5053,11 @@ class InlineQueryResultVoice(InlineQueryResultBase):
     :param caption: Optional. Caption, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the voice message caption. See formatting options for 
+    :param parse_mode: Optional. Mode for parsing entities in the voice message caption. See formatting options for
         more details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -5072,7 +5076,7 @@ class InlineQueryResultVoice(InlineQueryResultBase):
     def __init__(self, id: str, voice_url: str, title: str, caption: Optional[str] = None, caption_entities: Optional[List[MessageEntity]] = None,
                     parse_mode: Optional[str] = None, voice_duration: Optional[int] = None, reply_markup: Optional[InlineKeyboardMarkup] = None,
                     input_message_content: Optional[InputMessageContent] = None):
-        
+
         super().__init__('voice', id, title = title, caption = caption,
                          input_message_content = input_message_content, reply_markup = reply_markup,
                          parse_mode = parse_mode, caption_entities = caption_entities)
@@ -5106,11 +5110,11 @@ class InlineQueryResultDocument(InlineQueryResultBase):
     :param caption: Optional. Caption of the document to be sent, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the document caption. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the document caption. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -5145,7 +5149,7 @@ class InlineQueryResultDocument(InlineQueryResultBase):
                     parse_mode: Optional[str] = None, description: Optional[str] = None, reply_markup: Optional[InlineKeyboardMarkup] = None,
                     input_message_content: Optional[InputMessageContent] = None, thumbnail_url: Optional[str] = None, thumbnail_width: Optional[int] = None,
                     thumbnail_height: Optional[int] = None):
-        
+
         super().__init__('document', id, title = title, caption = caption,
                          input_message_content = input_message_content, reply_markup = reply_markup,
                          parse_mode = parse_mode, caption_entities = caption_entities)
@@ -5243,7 +5247,7 @@ class InlineQueryResultLocation(InlineQueryResultBase):
                     reply_markup: Optional[InlineKeyboardMarkup] = None, input_message_content: Optional[InputMessageContent] = None,
                     thumbnail_url: Optional[str] = None, thumbnail_width: Optional[int] = None, thumbnail_height: Optional[int] = None,
                     heading: Optional[int] = None, proximity_alert_radius: Optional[int] = None):
-        
+
         super().__init__('location', id, title = title,
                          input_message_content = input_message_content, reply_markup = reply_markup)
         self.latitude: float = latitude
@@ -5320,7 +5324,7 @@ class InlineQueryResultVenue(InlineQueryResultBase):
     :param foursquare_id: Optional. Foursquare identifier of the venue if known
     :type foursquare_id: :obj:`str`
 
-    :param foursquare_type: Optional. Foursquare type of the venue, if known. (For example, 
+    :param foursquare_type: Optional. Foursquare type of the venue, if known. (For example,
         “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
     :type foursquare_type: :obj:`str`
 
@@ -5446,7 +5450,7 @@ class InlineQueryResultContact(InlineQueryResultBase):
     :return: Instance of the class
     :rtype: :class:`telebot.types.InlineQueryResultContact`
     """
-        
+
     def __init__(self, id: str, phone_number: str, first_name: str, last_name: Optional[str] = None, vcard: Optional[str] = None,
                     reply_markup: Optional[InlineKeyboardMarkup] = None, input_message_content: Optional[InputMessageContent] = None,
                     thumbnail_url: Optional[str] = None, thumbnail_width: Optional[int] = None, thumbnail_height: Optional[int] = None):
@@ -5591,11 +5595,11 @@ class InlineQueryResultCachedPhoto(InlineQueryResultCachedBase):
     :param caption: Optional. Caption of the photo to be sent, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the photo caption. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the photo caption. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -5657,7 +5661,7 @@ class InlineQueryResultCachedGif(InlineQueryResultCachedBase):
     :param parse_mode: Optional. Mode for parsing entities in the caption. See formatting options for more details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -5677,7 +5681,7 @@ class InlineQueryResultCachedGif(InlineQueryResultCachedBase):
                     caption: Optional[str] = None, caption_entities: Optional[List[MessageEntity]] = None,
                     parse_mode: Optional[str] = None, reply_markup: Optional[InlineKeyboardMarkup] = None,
                     input_message_content: Optional[InputMessageContent] = None, show_caption_above_media: Optional[bool] = None):
-        
+
         InlineQueryResultCachedBase.__init__(self)
         self.type: str = 'gif'
         self.id: str = id
@@ -5718,7 +5722,7 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResultCachedBase):
     :param parse_mode: Optional. Mode for parsing entities in the caption. See formatting options for more details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -5738,7 +5742,7 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResultCachedBase):
                     caption: Optional[str] = None, caption_entities: Optional[List[MessageEntity]] = None,
                     parse_mode: Optional[str] = None, reply_markup: Optional[InlineKeyboardMarkup] = None,
                     input_message_content: Optional[InputMessageContent] = None, show_caption_above_media: Optional[bool] = None):
-        
+
         InlineQueryResultCachedBase.__init__(self)
         self.type: str = 'mpeg4_gif'
         self.id: str = id
@@ -5815,11 +5819,11 @@ class InlineQueryResultCachedDocument(InlineQueryResultCachedBase):
     :param caption: Optional. Caption of the document to be sent, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the document caption. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the document caption. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -5837,7 +5841,7 @@ class InlineQueryResultCachedDocument(InlineQueryResultCachedBase):
                     caption: Optional[str] = None, caption_entities: Optional[List[MessageEntity]] = None,
                     parse_mode: Optional[str] = None, reply_markup: Optional[InlineKeyboardMarkup] = None,
                     input_message_content: Optional[InputMessageContent] = None):
-        
+
         InlineQueryResultCachedBase.__init__(self)
         self.type: str = 'document'
         self.id: str = id
@@ -5877,11 +5881,11 @@ class InlineQueryResultCachedVideo(InlineQueryResultCachedBase):
     :param caption: Optional. Caption of the video to be sent, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the video caption. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the video caption. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -5902,7 +5906,7 @@ class InlineQueryResultCachedVideo(InlineQueryResultCachedBase):
                     caption: Optional[str] = None, caption_entities: Optional[List[MessageEntity]] = None,
                     parse_mode: Optional[str] = None, reply_markup: Optional[InlineKeyboardMarkup] = None,
                     input_message_content: Optional[InputMessageContent] = None, show_caption_above_media: Optional[bool] = None):
-        
+
         InlineQueryResultCachedBase.__init__(self)
         self.type: str = 'video'
         self.id: str = id
@@ -5940,11 +5944,11 @@ class InlineQueryResultCachedVoice(InlineQueryResultCachedBase):
     :param caption: Optional. Caption, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the voice message caption. See formatting options for 
+    :param parse_mode: Optional. Mode for parsing entities in the voice message caption. See formatting options for
         more details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -5957,7 +5961,7 @@ class InlineQueryResultCachedVoice(InlineQueryResultCachedBase):
     :return: Instance of the class
     :rtype: :class:`telebot.types.InlineQueryResultCachedVoice`
     """
-        
+
     def __init__(self, id: str, voice_file_id: str, title: str, caption: Optional[str] = None,
                     caption_entities: Optional[List[MessageEntity]] = None, parse_mode: Optional[str] = None,
                     reply_markup: Optional[InlineKeyboardMarkup] = None, input_message_content: Optional[InputMessageContent] = None):
@@ -5972,7 +5976,7 @@ class InlineQueryResultCachedVoice(InlineQueryResultCachedBase):
         self.input_message_content: Optional[InputMessageContent] = input_message_content
         self.parse_mode: Optional[str] = parse_mode
         self.payload_dic['voice_file_id'] = voice_file_id
-        
+
 
 
 # noinspection PyUnresolvedReferences,PyShadowingBuiltins
@@ -5994,11 +5998,11 @@ class InlineQueryResultCachedAudio(InlineQueryResultCachedBase):
     :param caption: Optional. Caption, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the audio caption. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the audio caption. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -6011,7 +6015,7 @@ class InlineQueryResultCachedAudio(InlineQueryResultCachedBase):
     :return: Instance of the class
     :rtype: :class:`telebot.types.InlineQueryResultCachedAudio`
     """
-        
+
     def __init__(self, id: str, audio_file_id: str, caption: Optional[str] = None, caption_entities: Optional[List[MessageEntity]] = None,
                     parse_mode: Optional[str] = None, reply_markup: Optional[InlineKeyboardMarkup] = None,
                     input_message_content: Optional[InputMessageContent] = None):
@@ -6044,8 +6048,8 @@ class Game(JsonDeserializable):
     :param photo: Photo that will be displayed in the game message in chats.
     :type photo: :obj:`list` of :class:`telebot.types.PhotoSize`
 
-    :param text: Optional. Brief description of the game or high scores included in the game message. Can be 
-        automatically edited to include current high scores for the game when the bot calls setGameScore, or manually edited 
+    :param text: Optional. Brief description of the game or high scores included in the game message. Can be
+        automatically edited to include current high scores for the game when the bot calls setGameScore, or manually edited
         using editMessageText. 0-4096 characters.
     :type text: :obj:`str`
 
@@ -6107,7 +6111,7 @@ class Animation(JsonDeserializable):
     :param file_id: Identifier for this file, which can be used to download or reuse the file
     :type file_id: :obj:`str`
 
-    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different 
+    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different
         bots. Can't be used to download or reuse the file.
     :type file_unique_id: :obj:`str`
 
@@ -6129,8 +6133,8 @@ class Animation(JsonDeserializable):
     :param mime_type: Optional. MIME type of the file as defined by sender
     :type mime_type: :obj:`str`
 
-    :param file_size: Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have 
-        difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or 
+    :param file_size: Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have
+        difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or
         double-precision float type are safe for storing this value.
     :type file_size: :obj:`int`
 
@@ -6147,7 +6151,7 @@ class Animation(JsonDeserializable):
             obj['thumbnail'] = None
         return cls(**obj)
 
-    def __init__(self, file_id, file_unique_id, width=None, height=None, duration=None, 
+    def __init__(self, file_id, file_unique_id, width=None, height=None, duration=None,
                  thumbnail=None, file_name=None, mime_type=None, file_size=None, **kwargs):
         self.file_id: str = file_id
         self.file_unique_id: str = file_unique_id
@@ -6207,8 +6211,8 @@ class LabeledPrice(JsonSerializable, Dictionaryable):
     :param label: Portion label
     :type label: :obj:`str`
 
-    :param amount: Price of the product in the smallest units of the currency (integer, not float/double). For example, 
-        for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past 
+    :param amount: Price of the product in the smallest units of the currency (integer, not float/double). For example,
+        for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past
         the decimal point for each currency (2 for the majority of currencies).
     :type amount: :obj:`int`
 
@@ -6246,8 +6250,8 @@ class Invoice(JsonDeserializable):
     :param currency: Three-letter ISO 4217 currency code
     :type currency: :obj:`str`
 
-    :param total_amount: Total price in the smallest units of the currency (integer, not float/double). For example, 
-        for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past 
+    :param total_amount: Total price in the smallest units of the currency (integer, not float/double). For example,
+        for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past
         the decimal point for each currency (2 for the majority of currencies).
     :type total_amount: :obj:`int`
 
@@ -6372,7 +6376,7 @@ class ShippingOption(JsonSerializable):
     def add_price(self, *args) -> 'ShippingOption':
         """
         Add LabeledPrice to ShippingOption
-        
+
         :param args: LabeledPrices
         :type args: :obj:`LabeledPrice`
 
@@ -6399,8 +6403,8 @@ class SuccessfulPayment(JsonDeserializable):
     :param currency: Three-letter ISO 4217 currency code
     :type currency: :obj:`str`
 
-    :param total_amount: Total price in the smallest units of the currency (integer, not float/double). For example, 
-        for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past 
+    :param total_amount: Total price in the smallest units of the currency (integer, not float/double). For example,
+        for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past
         the decimal point for each currency (2 for the majority of currencies).
     :type total_amount: :obj:`int`
 
@@ -6439,7 +6443,7 @@ class SuccessfulPayment(JsonDeserializable):
         return cls(**obj)
 
     def __init__(self, currency, total_amount, invoice_payload, shipping_option_id=None, order_info=None,
-                 telegram_payment_charge_id=None, provider_payment_charge_id=None, 
+                 telegram_payment_charge_id=None, provider_payment_charge_id=None,
                     subscription_expiration_date=None, is_recurring=None, is_first_recurring=None, **kwargs):
         self.currency: str = currency
         self.total_amount: int = total_amount
@@ -6506,8 +6510,8 @@ class PreCheckoutQuery(JsonDeserializable):
     :param currency: Three-letter ISO 4217 currency code
     :type currency: :obj:`str`
 
-    :param total_amount: Total price in the smallest units of the currency (integer, not float/double). For example, 
-        for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past 
+    :param total_amount: Total price in the smallest units of the currency (integer, not float/double). For example,
+        for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past
         the decimal point for each currency (2 for the majority of currencies).
     :type total_amount: :obj:`int`
 
@@ -6619,7 +6623,7 @@ class Sticker(JsonDeserializable):
     :param file_id: Identifier for this file, which can be used to download or reuse the file
     :type file_id: :obj:`str`
 
-    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different 
+    :param file_unique_id: Unique identifier for this file, which is supposed to be the same over time and for different
         bots. Can't be used to download or reuse the file.
     :type file_unique_id: :obj:`str`
 
@@ -6683,8 +6687,8 @@ class Sticker(JsonDeserializable):
             obj['premium_animation'] = File.de_json(obj['premium_animation'])
         return cls(**obj)
 
-    def __init__(self, file_id, file_unique_id, type, width, height, is_animated, 
-                is_video, thumbnail=None, emoji=None, set_name=None, mask_position=None, file_size=None, 
+    def __init__(self, file_id, file_unique_id, type, width, height, is_animated,
+                is_video, thumbnail=None, emoji=None, set_name=None, mask_position=None, file_size=None,
                 premium_animation=None, custom_emoji_id=None, needs_repainting=None, **kwargs):
         self.file_id: str = file_id
         self.file_unique_id: str = file_unique_id
@@ -6714,15 +6718,15 @@ class MaskPosition(Dictionaryable, JsonDeserializable, JsonSerializable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#maskposition
 
-    :param point: The part of the face relative to which the mask should be placed. One of “forehead”, “eyes”, “mouth”, or 
+    :param point: The part of the face relative to which the mask should be placed. One of “forehead”, “eyes”, “mouth”, or
         “chin”.
     :type point: :obj:`str`
 
-    :param x_shift: Shift by X-axis measured in widths of the mask scaled to the face size, from left to right. For example, 
+    :param x_shift: Shift by X-axis measured in widths of the mask scaled to the face size, from left to right. For example,
         choosing -1.0 will place mask just to the left of the default mask position.
     :type x_shift: :obj:`float` number
 
-    :param y_shift: Shift by Y-axis measured in heights of the mask scaled to the face size, from top to bottom. For 
+    :param y_shift: Shift by Y-axis measured in heights of the mask scaled to the face size, from top to bottom. For
         example, 1.0 will place the mask just below the default mask position.
     :type y_shift: :obj:`float` number
 
@@ -6790,6 +6794,10 @@ class InputMedia(Dictionaryable, JsonSerializable):
             self._media_name = service_utils.generate_random_token()
             self._media_dic = 'attach://{0}'.format(self._media_name)
 
+        if self.__class__ is InputMedia:
+            # Make InputMedia as ABC some time...
+            log_deprecation_warning('The InputMedia class should not be instantiated directly. Use particular InputMediaXXX class instead')
+
     def to_json(self):
         return json.dumps(self.to_dict())
 
@@ -6811,7 +6819,7 @@ class InputMedia(Dictionaryable, JsonSerializable):
         """
         if service_utils.is_string(self.media):
             return self.to_json(), None
-        
+
         media_dict = {self._media_name: self.media}
         if self._thumbnail_name:
             media_dict[self._thumbnail_name] = self.thumbnail
@@ -6825,19 +6833,19 @@ class InputMediaPhoto(InputMedia):
 
     Telegram Documentation: https://core.telegram.org/bots/api#inputmediaphoto
 
-    :param media: File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an 
-        HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using 
+    :param media: File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an
+        HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using
         multipart/form-data under <file_attach_name> name. More information on Sending Files »
     :type media: :obj:`str`
 
     :param caption: Optional. Caption of the photo to be sent, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the photo caption. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the photo caption. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -6855,7 +6863,7 @@ class InputMediaPhoto(InputMedia):
                  has_spoiler: Optional[bool] = None, show_caption_above_media: Optional[bool] = None):
         if service_utils.is_pil_image(media):
             media = service_utils.pil_image_to_file(media)
-    
+
         super(InputMediaPhoto, self).__init__(
             type="photo", media=media, caption=caption, parse_mode=parse_mode, caption_entities=caption_entities)
 
@@ -6877,15 +6885,15 @@ class InputMediaVideo(InputMedia):
 
     Telegram Documentation: https://core.telegram.org/bots/api#inputmediavideo
 
-    :param media: File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an 
-        HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using 
+    :param media: File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an
+        HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using
         multipart/form-data under <file_attach_name> name. More information on Sending Files »
     :type media: :obj:`str`
 
-    :param thumbnail: Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported 
-        server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should 
-        not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be 
-        only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using 
+    :param thumbnail: Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported
+        server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should
+        not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be
+        only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using
         multipart/form-data under <file_attach_name>. More information on Sending Files »
     :type thumbnail: InputFile or :obj:`str`
 
@@ -6900,11 +6908,11 @@ class InputMediaVideo(InputMedia):
     :param caption: Optional. Caption of the video to be sent, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the video caption. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the video caption. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -6979,26 +6987,26 @@ class InputMediaAnimation(InputMedia):
 
     Telegram Documentation: https://core.telegram.org/bots/api#inputmediaanimation
 
-    :param media: File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an 
-        HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using 
+    :param media: File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an
+        HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using
         multipart/form-data under <file_attach_name> name. More information on Sending Files »
     :type media: :obj:`str`
 
     :param thumbnail: Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported
-        server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should 
-        not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be 
-        only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using 
+        server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should
+        not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be
+        only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using
         multipart/form-data under <file_attach_name>. More information on Sending Files »
     :type thumbnail: InputFile or :obj:`str`
 
     :param caption: Optional. Caption of the animation to be sent, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the animation caption. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the animation caption. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -7061,26 +7069,26 @@ class InputMediaAudio(InputMedia):
 
     Telegram Documentation: https://core.telegram.org/bots/api#inputmediaaudio
 
-    :param media: File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an 
-        HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using 
+    :param media: File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an
+        HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using
         multipart/form-data under <file_attach_name> name. More information on Sending Files »
     :type media: :obj:`str`
 
-    :param thumbnail: Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported 
-        server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should 
-        not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be 
-        only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using 
+    :param thumbnail: Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported
+        server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should
+        not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be
+        only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using
         multipart/form-data under <file_attach_name>. More information on Sending Files »
     :type thumbnail: InputFile or :obj:`str`
 
     :param caption: Optional. Caption of the audio to be sent, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the audio caption. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the audio caption. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
@@ -7129,29 +7137,29 @@ class InputMediaDocument(InputMedia):
     Telegram Documentation: https://core.telegram.org/bots/api#inputmediadocument
 
     :param media: File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an
-        HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using 
+        HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using
         multipart/form-data under <file_attach_name> name. More information on Sending Files »
     :type media: :obj:`str`
 
-    :param thumbnail: Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported 
-        server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should 
-        not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be 
-        only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using 
+    :param thumbnail: Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported
+        server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should
+        not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be
+        only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using
         multipart/form-data under <file_attach_name>. More information on Sending Files »
     :type thumbnail: InputFile or :obj:`str`
 
     :param caption: Optional. Caption of the document to be sent, 0-1024 characters after entities parsing
     :type caption: :obj:`str`
 
-    :param parse_mode: Optional. Mode for parsing entities in the document caption. See formatting options for more 
+    :param parse_mode: Optional. Mode for parsing entities in the document caption. See formatting options for more
         details.
     :type parse_mode: :obj:`str`
 
-    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified 
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified
         instead of parse_mode
     :type caption_entities: :obj:`list` of :class:`telebot.types.MessageEntity`
 
-    :param disable_content_type_detection: Optional. Disables automatic server-side content type detection for 
+    :param disable_content_type_detection: Optional. Disables automatic server-side content type detection for
         files uploaded using multipart/form-data. Always True, if the document is sent as part of an album.
     :type disable_content_type_detection: :obj:`bool`
 
@@ -7374,8 +7382,7 @@ class PollAnswer(JsonSerializable, JsonDeserializable, Dictionaryable):
     :param user: Optional. The user, who changed the answer to the poll
     :type user: :class:`telebot.types.User`
 
-    :param option_ids: 0-based identifiers of answer options, chosen by the user. May be empty if the user retracted 
-        their vote.
+    :param option_ids: 0-based identifiers of answer options, chosen by the user. May be empty if the user retracted their vote.
     :type option_ids: :obj:`list` of :obj:`int`
 
     :return: Instance of the class
@@ -7394,7 +7401,7 @@ class PollAnswer(JsonSerializable, JsonDeserializable, Dictionaryable):
     def __init__(self, poll_id: str, option_ids: List[int], user: Optional[User] = None, voter_chat: Optional[Chat] = None, **kwargs):
         self.poll_id: str = poll_id
         self.user: Optional[User] = user
-        self.option_ids: Optional[List[int]] = option_ids
+        self.option_ids: [List[int]] = option_ids
         self.voter_chat: Optional[Chat] = voter_chat
 
 
@@ -7412,7 +7419,7 @@ class PollAnswer(JsonSerializable, JsonDeserializable, Dictionaryable):
         if self.voter_chat:
             json_dict["voter_chat"] = self.voter_chat
         return json_dict
-    
+
 
 
 class ChatLocation(JsonSerializable, JsonDeserializable, Dictionaryable):
@@ -7436,14 +7443,14 @@ class ChatLocation(JsonSerializable, JsonDeserializable, Dictionaryable):
         obj = cls.check_json(json_string)
         obj['location'] = Location.de_json(obj['location'])
         return cls(**obj)
-    
+
     def __init__(self, location: Location, address: str, **kwargs):
         self.location: Location = location
         self.address: str = address
 
     def to_json(self):
         return json.dumps(self.to_dict())
-    
+
     def to_dict(self):
         return {
             "location": self.location.to_dict(),
@@ -7457,7 +7464,7 @@ class ChatInviteLink(JsonSerializable, JsonDeserializable, Dictionaryable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#chatinvitelink
 
-    :param invite_link: The invite link. If the link was created by another chat administrator, then the second part of 
+    :param invite_link: The invite link. If the link was created by another chat administrator, then the second part of
         the link will be replaced with “…”.
     :type invite_link: :obj:`str`
 
@@ -7479,7 +7486,7 @@ class ChatInviteLink(JsonSerializable, JsonDeserializable, Dictionaryable):
     :param expire_date: Optional. Point in time (Unix timestamp) when the link will expire or has been expired
     :type expire_date: :obj:`int`
 
-    :param member_limit: Optional. The maximum number of users that can be members of the chat simultaneously after 
+    :param member_limit: Optional. The maximum number of users that can be members of the chat simultaneously after
         joining the chat via this invite link; 1-99999
     :type member_limit: :obj:`int`
 
@@ -7495,7 +7502,7 @@ class ChatInviteLink(JsonSerializable, JsonDeserializable, Dictionaryable):
         obj = cls.check_json(json_string)
         obj['creator'] = User.de_json(obj['creator'])
         return cls(**obj)
-    
+
     def __init__(self, invite_link: str, creator: User, creates_join_request: bool, is_primary: bool, is_revoked: bool,
                 name: Optional[str] = None, expire_date: Optional[int] = None, member_limit: Optional[int] = None,
                 pending_join_request_count: Optional[int] = None, **kwargs):
@@ -7508,10 +7515,10 @@ class ChatInviteLink(JsonSerializable, JsonDeserializable, Dictionaryable):
         self.expire_date: Optional[int] = expire_date
         self.member_limit: Optional[int] = member_limit
         self.pending_join_request_count: Optional[int] = pending_join_request_count
-    
+
     def to_json(self):
         return json.dumps(self.to_dict())
-    
+
     def to_dict(self):
         json_dict = {
             "invite_link": self.invite_link,
@@ -7554,7 +7561,7 @@ class ProximityAlertTriggered(JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string, dict_copy=False)
         return cls(**obj)
-    
+
     def __init__(self, traveler, watcher, distance, **kwargs):
         self.traveler: User = traveler
         self.watcher: User = watcher
@@ -7568,7 +7575,7 @@ class VideoChatStarted(JsonDeserializable):
     @classmethod
     def de_json(cls, json_string):
         return cls()
-    
+
     def __init__(self):
         pass
 
@@ -7588,7 +7595,7 @@ class VideoChatScheduled(JsonDeserializable):
 
     Telegram Documentation: https://core.telegram.org/bots/api#videochatscheduled
 
-    :param start_date: Point in time (Unix timestamp) when the video chat is supposed to be started by a chat 
+    :param start_date: Point in time (Unix timestamp) when the video chat is supposed to be started by a chat
         administrator
     :type start_date: :obj:`int`
 
@@ -7600,7 +7607,7 @@ class VideoChatScheduled(JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string, dict_copy=False)
         return cls(**obj)
-    
+
     def __init__(self, start_date, **kwargs):
         self.start_date: int = start_date
 
@@ -7631,7 +7638,7 @@ class VideoChatEnded(JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string, dict_copy=False)
         return cls(**obj)
-    
+
     def __init__(self, duration, **kwargs):
         self.duration: int = duration
 
@@ -7664,7 +7671,7 @@ class VideoChatParticipantsInvited(JsonDeserializable):
         obj = cls.check_json(json_string)
         obj['users'] = [User.de_json(u) for u in obj['users']]
         return cls(**obj)
-    
+
     def __init__(self, users=None, **kwargs):
         self.users: List[User] = users
 
@@ -7689,7 +7696,7 @@ class MessageAutoDeleteTimerChanged(JsonDeserializable):
 
     :return: Instance of the class
     :rtype: :class:`telebot.types.MessageAutoDeleteTimerChanged`
-    """   
+    """
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
@@ -7707,7 +7714,7 @@ class MenuButton(JsonDeserializable, JsonSerializable, Dictionaryable):
     * :class:`MenuButtonCommands`
     * :class:`MenuButtonWebApp`
     * :class:`MenuButtonDefault`
-    
+
     If a menu button other than MenuButtonDefault is set for a private chat, then it is applied
     in the chat. Otherwise the default menu button is applied. By default, the menu button opens the list of bot commands.
     """
@@ -7721,7 +7728,7 @@ class MenuButton(JsonDeserializable, JsonSerializable, Dictionaryable):
             'default': MenuButtonDefault
         }
         return types[obj['type']](**obj)
-    
+
     def to_json(self):
         """
         :meta private:
@@ -7754,7 +7761,7 @@ class MenuButtonCommands(MenuButton):
 
     def to_dict(self):
         return {'type': self.type}
-    
+
     def to_json(self):
         return json.dumps(self.to_dict())
 
@@ -7772,7 +7779,7 @@ class MenuButtonWebApp(MenuButton):
     :param text: Text on the button
     :type text: :obj:`str`
 
-    :param web_app: Description of the Web App that will be launched when the user presses the button. The Web App will be 
+    :param web_app: Description of the Web App that will be launched when the user presses the button. The Web App will be
         able to send an arbitrary message on behalf of the user using the method answerWebAppQuery. Alternatively, a t.me link
         to a Web App of the bot can be specified in the object instead of the Web App's URL, in which case the Web App will be
         opened as if the user pressed the link.
@@ -7816,7 +7823,7 @@ class MenuButtonDefault(MenuButton):
     def to_json(self):
         return json.dumps(self.to_dict())
 
-    
+
 class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryable):
     """
     Represents the rights of an administrator in a chat.
@@ -7826,8 +7833,8 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
     :param is_anonymous: True, if the user's presence in the chat is hidden
     :type is_anonymous: :obj:`bool`
 
-    :param can_manage_chat: True, if the administrator can access the chat event log, chat statistics, message 
-        statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. 
+    :param can_manage_chat: True, if the administrator can access the chat event log, chat statistics, message
+        statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode.
         Implied by any other administrator privilege
     :type can_manage_chat: :obj:`bool`
 
@@ -7840,8 +7847,8 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
     :param can_restrict_members: True, if the administrator can restrict, ban or unban chat members
     :type can_restrict_members: :obj:`bool`
 
-    :param can_promote_members: True, if the administrator can add new administrators with a subset of their own 
-        privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that 
+    :param can_promote_members: True, if the administrator can add new administrators with a subset of their own
+        privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that
         were appointed by the user)
     :type can_promote_members: :obj:`bool`
 
@@ -7854,7 +7861,7 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
     :param can_post_messages: Optional. True, if the administrator can post in the channel; channels only
     :type can_post_messages: :obj:`bool`
 
-    :param can_edit_messages: Optional. True, if the administrator can edit messages of other users and can pin 
+    :param can_edit_messages: Optional. True, if the administrator can edit messages of other users and can pin
         messages; channels only
     :type can_edit_messages: :obj:`bool`
 
@@ -7883,7 +7890,7 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
         obj = cls.check_json(json_string)
         return cls(**obj)
 
-    def __init__(self, is_anonymous: bool, can_manage_chat: bool, 
+    def __init__(self, is_anonymous: bool, can_manage_chat: bool,
         can_delete_messages: bool, can_manage_video_chats: bool, can_restrict_members: bool,
         can_promote_members: bool, can_change_info: bool, can_invite_users: bool,
         can_post_messages: Optional[bool]=None, can_edit_messages: Optional[bool]=None,
@@ -7891,7 +7898,7 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
         can_post_stories: Optional[bool]=None, can_edit_stories: Optional[bool]=None,
         can_delete_stories: Optional[bool]=None, **kwargs
         ) -> None:
-        
+
         self.is_anonymous: bool = is_anonymous
         self.can_manage_chat: bool = can_manage_chat
         self.can_delete_messages: bool = can_delete_messages
@@ -7935,17 +7942,17 @@ class ChatAdministratorRights(JsonDeserializable, JsonSerializable, Dictionaryab
             json_dict['can_delete_stories'] = self.can_delete_stories
 
         return json_dict
-    
+
     def to_json(self):
         return json.dumps(self.to_dict())
-    
+
 
 
 class InputFile:
     """
     A class to send files through Telegram Bot API.
 
-    You need to pass a file, which should be an instance of :class:`io.IOBase` or 
+    You need to pass a file, which should be an instance of :class:`io.IOBase` or
     :class:`pathlib.Path`, or :obj:`str`.
 
     If you pass an :obj:`str` as a file, it will be opened and closed by the class.
@@ -7982,7 +7989,7 @@ class InputFile:
         self._file, self._file_name = self._resolve_file(file)
         if file_name:
             self._file_name = file_name
-        
+
 
     @staticmethod
     def _resolve_file(file):
@@ -8003,7 +8010,7 @@ class InputFile:
         File object.
         """
         return self._file
-    
+
     @property
     def file_name(self) -> str:
         """
@@ -8015,7 +8022,7 @@ class InputFile:
 class ForumTopicCreated(JsonDeserializable):
     """
     This object represents a service message about a new forum topic created in the chat.
-    
+
     Telegram documentation: https://core.telegram.org/bots/api#forumtopiccreated
 
     :param name: Name of the topic
@@ -8045,7 +8052,7 @@ class ForumTopicCreated(JsonDeserializable):
 class ForumTopicClosed(JsonDeserializable):
     """
     This object represents a service message about a forum topic closed in the chat. Currently holds no information.
-    
+
     Telegram documentation: https://core.telegram.org/bots/api#forumtopicclosed
     """
     # for future use
@@ -8117,7 +8124,7 @@ class GeneralForumTopicUnhidden(JsonDeserializable):
 
     Telegram documentation: https://core.telegram.org/bots/api#generalforumtopicunhidden
     """
-    
+
     @classmethod
     def de_json(cls, json_string):
         return cls()
@@ -8186,7 +8193,7 @@ class WriteAccessAllowed(JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         return cls(**obj)
-        
+
 
     def __init__(self, from_request: Optional[bool]=None, web_app_name: Optional[str]=None, from_attachment_menu: Optional[bool]=None,
                  **kwargs) -> None:
@@ -8292,7 +8299,7 @@ class InputSticker(Dictionaryable, JsonSerializable):
 
     :param sticker: The added sticker. Pass a file_id as a String to send a file that already exists on the Telegram servers,
         pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data.
-        Animated and video stickers can't be uploaded via HTTP URL. 
+        Animated and video stickers can't be uploaded via HTTP URL.
     :type sticker: :obj:`str` or :obj:`telebot.types.InputFile`
 
     :param emoji_list: One or more(up to 20) emoji(s) corresponding to the sticker
@@ -8300,7 +8307,7 @@ class InputSticker(Dictionaryable, JsonSerializable):
 
     :param mask_position: Optional. Position where the mask should be placed on faces. For “mask” stickers only.
     :type mask_position: :class:`telebot.types.MaskPosition`
-    
+
     :param keywords: Optional. List of 0-20 search keywords for the sticker with total length of up to 64 characters.
         For “regular” and “custom_emoji” stickers only.
     :type keywords: :obj:`list` of :obj:`str`
@@ -8347,18 +8354,18 @@ class InputSticker(Dictionaryable, JsonSerializable):
             json_dict['keywords'] = self.keywords
 
         return json_dict
-    
+
     def to_json(self) -> str:
         return json.dumps(self.to_dict())
-    
+
     def convert_input_sticker(self) -> Tuple[str, Optional[dict]]:
         if service_utils.is_string(self.sticker):
             return self.to_json(), None
 
         return self.to_json(), {self._sticker_name: self.sticker}
-        
-        
-        
+
+
+
 class SwitchInlineQueryChosenChat(JsonDeserializable, Dictionaryable, JsonSerializable):
     """
     Represents an inline button that switches the current user to inline mode in a chosen chat,
@@ -8457,7 +8464,7 @@ class InlineQueryResultsButton(JsonSerializable, Dictionaryable):
     :param web_app: Optional. Description of the Web App that will be launched when the user presses the button.
         The Web App will be able to switch back to the inline mode using the method web_app_switch_inline_query inside the Web App.
     :type web_app: :class:`telebot.types.WebAppInfo`
-    
+
     :param start_parameter: Optional. Deep-linking parameter for the /start message sent to the bot when a user presses the button.
         1-64 characters, only A-Z, a-z, 0-9, _ and - are allowed.
         Example: An inline bot that sends YouTube videos can ask the user to connect the bot to their YouTube account to adapt search
@@ -8487,7 +8494,7 @@ class InlineQueryResultsButton(JsonSerializable, Dictionaryable):
             json_dict['start_parameter'] = self.start_parameter
 
         return json_dict
-    
+
     def to_json(self) -> str:
         return json.dumps(self.to_dict())
 
@@ -8515,7 +8522,7 @@ class Story(JsonDeserializable):
         obj = cls.check_json(json_string)
         obj['chat'] = Chat.de_json(obj['chat'])
         return cls(**obj)
-    
+
     def __init__(self, chat: Chat, id: int, **kwargs) -> None:
         self.chat: Chat = chat
         self.id: int = id
@@ -8540,23 +8547,30 @@ class ReactionType(JsonDeserializable, Dictionaryable, JsonSerializable):
     def de_json(cls, json_string):
         if json_string is None: return None
         obj = cls.check_json(json_string)
-        # remove type 
+        # remove type
         if obj['type'] == 'emoji':
             del obj['type']
             return ReactionTypeEmoji(**obj)
         elif obj['type'] == 'custom_emoji':
             del obj['type']
             return ReactionTypeCustomEmoji(**obj)
+        elif obj['type'] == 'paid':
+            del obj['type']
+            return ReactionTypePaid(**obj)
+        else:
+            raise ValueError(f"Unknown reaction type: {obj['type']}.")
 
     def __init__(self, type: str) -> None:
         self.type: str = type
+        if self.__class__ is ReactionType:
+            log_deprecation_warning('The ReactionType class should not be instantiated directly. Use particular ReactionTypeXXX class instead')
 
     def to_dict(self) -> dict:
         json_dict = {
             'type': self.type
         }
         return json_dict
-    
+
     def to_json(self) -> str:
         return json.dumps(self.to_dict())
 
@@ -8633,7 +8647,7 @@ class ReactionTypePaid(ReactionType):
 
     def to_dict(self) -> dict:
         return super().to_dict()
-    
+
 
 
 class MessageReactionUpdated(JsonDeserializable):
@@ -8753,7 +8767,7 @@ class ReactionCount(JsonDeserializable):
         obj = cls.check_json(json_string)
         obj['type'] = ReactionType.de_json(obj['type'])
         return cls(**obj)
-    
+
     def __init__(self, type: ReactionType, total_count: int, **kwargs) -> None:
         self.type: ReactionType = type
         self.total_count: int = total_count
@@ -8935,7 +8949,7 @@ class ExternalReplyInfo(JsonDeserializable):
 
 
 # noinspection PyUnresolvedReferences,PyShadowingBuiltins
-class MessageOrigin(JsonDeserializable):
+class MessageOrigin(JsonDeserializable, ABC):
     """
     This object describes the origin of a message.
 
@@ -8979,6 +8993,8 @@ class MessageOrigin(JsonDeserializable):
         elif message_type == 'channel':
             chat = Chat.de_json(obj['chat'])
             return MessageOriginChannel(date=obj['date'], chat=chat, message_id=obj['message_id'], author_signature=obj.get('author_signature'))
+        else:
+            raise ValueError(f"Unknown message origin type: {message_type}.")
 
     def __init__(self, type: str, date: int) -> None:
         self.type: str = type
@@ -9165,7 +9181,7 @@ class Giveaway(JsonDeserializable):
         self.country_codes: Optional[List[str]] = country_codes
         self.premium_subscription_month_count: Optional[int] = premium_subscription_month_count
         self.prize_star_count: Optional[int] = prize_star_count
-                     
+
 
 class GiveawayWinners(JsonDeserializable):
     """
@@ -9220,7 +9236,7 @@ class GiveawayWinners(JsonDeserializable):
         obj['chat'] = Chat.de_json(obj['chat'])
         obj['winners'] = [User.de_json(user) for user in obj['winners']]
         return cls(**obj)
-    
+
     def __init__(self, chat: Chat, giveaway_message_id: int, winners_selection_date: int, winner_count: int,
                  winners: List[User], additional_chat_count: Optional[int] = None,
                  premium_subscription_month_count: Optional[int] = None, unclaimed_prize_count: Optional[int] = None,
@@ -9238,8 +9254,8 @@ class GiveawayWinners(JsonDeserializable):
         self.was_refunded: Optional[bool] = was_refunded
         self.prize_description: Optional[str] = prize_description
         self.prize_star_count: Optional[int] = prize_star_count
-                     
-        
+
+
 class GiveawayCompleted(JsonDeserializable):
     """
     This object represents a service message about the completion of a giveaway without public winners.
@@ -9269,14 +9285,14 @@ class GiveawayCompleted(JsonDeserializable):
         if 'giveaway_message' in obj:
             obj['giveaway_message'] = Message.de_json(obj['giveaway_message'])
         return cls(**obj)
-    
+
     def __init__(self, winner_count: int, unclaimed_prize_count: Optional[int] = None,
                     giveaway_message: Optional[Message] = None, is_star_giveaway: Optional[bool] = None, **kwargs) -> None:
         self.winner_count: int = winner_count
         self.unclaimed_prize_count: Optional[int] = unclaimed_prize_count
         self.giveaway_message: Optional[Message] = giveaway_message
         self.is_star_giveaway: Optional[bool] = is_star_giveaway
-                        
+
 
 class GiveawayCreated(JsonDeserializable):
     """
@@ -9383,7 +9399,7 @@ class ReplyParameters(JsonDeserializable, Dictionaryable, JsonSerializable):
         obj = cls.check_json(json_string)
         if 'quote_entities' in obj:
             obj['quote_entities'] = [MessageEntity.de_json(entity) for entity in obj['quote_entities']]
-        return cls(**obj)    
+        return cls(**obj)
 
     def __init__(self, message_id: int, chat_id: Optional[Union[int, str]] = None,
                  allow_sending_without_reply: Optional[bool] = None, quote: Optional[str] = None,
@@ -9414,11 +9430,11 @@ class ReplyParameters(JsonDeserializable, Dictionaryable, JsonSerializable):
         if self.quote_position is not None:
             json_dict['quote_position'] = self.quote_position
         return json_dict
-    
+
     def to_json(self) -> str:
         return json.dumps(self.to_dict())
-        
-    
+
+
 class UsersShared(JsonDeserializable):
     """
     This object contains information about the users whose identifiers were shared with the bot
@@ -9476,7 +9492,7 @@ class ChatBoostUpdated(JsonDeserializable):
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
-        obj = cls.check_json(json_string)        
+        obj = cls.check_json(json_string)
         obj['chat'] = Chat.de_json(obj['chat'])
         obj['boost'] = ChatBoost.de_json(obj['boost'])
         return cls(**obj)
@@ -9484,8 +9500,8 @@ class ChatBoostUpdated(JsonDeserializable):
     def __init__(self, chat, boost, **kwargs):
         self.chat: Chat = chat
         self.boost: ChatBoost = boost
-        
-    
+
+
 class ChatBoostRemoved(JsonDeserializable):
     """
     This object represents a boost removed from a chat.
@@ -9513,7 +9529,7 @@ class ChatBoostRemoved(JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         obj['chat'] = Chat.de_json(obj['chat'])
-        obj['source'] = ChatBoostSource.de_json(obj['source'])        
+        obj['source'] = ChatBoostSource.de_json(obj['source'])
         return cls(**obj)
 
     def __init__(self, chat, boost_id, remove_date, source, **kwargs):
@@ -9521,8 +9537,8 @@ class ChatBoostRemoved(JsonDeserializable):
         self.boost_id: str = boost_id
         self.remove_date: int = remove_date
         self.source: ChatBoostSource = source
-        
-    
+
+
 class ChatBoostSource(ABC, JsonDeserializable):
     """
     This object describes the source of a chat boost. It can be one of
@@ -9695,7 +9711,7 @@ class ChatBoost(JsonDeserializable):
         self.add_date: int = add_date
         self.expiration_date: int = expiration_date
         self.source: ChatBoostSource = source
-        
+
 
 class UserChatBoosts(JsonDeserializable):
     """
@@ -9719,7 +9735,7 @@ class UserChatBoosts(JsonDeserializable):
 
     def __init__(self, boosts, **kwargs):
         self.boosts: List[ChatBoost] = boosts
-    
+
 
 class InaccessibleMessage(JsonDeserializable):
     """
@@ -9796,7 +9812,7 @@ class ChatBoostAdded(JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         return cls(**obj)
-    
+
     def __init__(self, boost_count, **kwargs):
         self.boost_count: int = boost_count
 
@@ -9840,7 +9856,7 @@ class BusinessConnection(JsonDeserializable):
         obj['user'] = User.de_json(obj['user'])
         obj['rights'] = BusinessBotRights.de_json(obj.get('rights'))
         return cls(**obj)
-    
+
     def __init__(self, id, user, user_chat_id, date, can_reply, is_enabled,
                     rights=None, **kwargs):
         self.id: str = id
@@ -9885,13 +9901,13 @@ class BusinessMessagesDeleted(JsonDeserializable):
         obj = cls.check_json(json_string)
         obj['chat'] = Chat.de_json(obj['chat'])
         return cls(**obj)
-    
+
 
     def __init__(self, business_connection_id, chat, message_ids, **kwargs):
         self.business_connection_id: str = business_connection_id
         self.chat: Chat = chat
         self.message_ids: List[int] = message_ids
-        
+
 
 class BusinessIntro(JsonDeserializable):
     """
@@ -9919,7 +9935,7 @@ class BusinessIntro(JsonDeserializable):
         if 'sticker' in obj:
             obj['sticker'] = Sticker.de_json(obj['sticker'])
         return cls(**obj)
-    
+
     def __init__(self, title=None, message=None, sticker=None, **kwargs):
         self.title: Optional[str] = title
         self.message: Optional[str] = message
@@ -9949,7 +9965,7 @@ class BusinessLocation(JsonDeserializable):
         if 'location' in obj:
             obj['location'] = Location.de_json(obj['location'])
         return cls(**obj)
-    
+
     def __init__(self, address, location=None, **kwargs):
         self.address: str = address
         self.location: Optional[Location] = location
@@ -9976,7 +9992,7 @@ class BusinessOpeningHoursInterval(JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         return cls(**obj)
-    
+
     def __init__(self, opening_minute, closing_minute, **kwargs):
         self.opening_minute: int = opening_minute
         self.closing_minute: int = closing_minute
@@ -10006,7 +10022,7 @@ class BusinessOpeningHours(JsonDeserializable):
         obj = cls.check_json(json_string)
         obj['opening_hours'] = [BusinessOpeningHoursInterval.de_json(interval) for interval in obj['opening_hours']]
         return cls(**obj)
-    
+
     def __init__(self, time_zone_name, opening_hours, **kwargs):
         self.time_zone_name: str = time_zone_name
         self.opening_hours: List[BusinessOpeningHoursInterval] = opening_hours
@@ -10044,7 +10060,7 @@ class SharedUser(JsonDeserializable):
         if 'photo' in obj:
             obj['photo'] = [PhotoSize.de_json(photo) for photo in obj['photo']]
         return cls(**obj)
-    
+
     def __init__(self, user_id, first_name=None, last_name=None, username=None, photo=None, **kwargs):
         self.user_id: int = user_id
         self.first_name: Optional[str] = first_name
@@ -10077,7 +10093,7 @@ class Birthdate(JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         return cls(**obj)
-    
+
     def __init__(self, day, month, year=None, **kwargs):
         self.day: int = day
         self.month: int = month
@@ -10513,13 +10529,17 @@ class RevenueWithdrawalStateFailed(RevenueWithdrawalState):
         return cls(**obj)
 
 
-class TransactionPartner(JsonDeserializable):
+class TransactionPartner(JsonDeserializable, ABC):
     # noinspection PyUnresolvedReferences
     """
     This object describes the source of a transaction, or its recipient for outgoing transactions. Currently, it can be one of
         TransactionPartnerFragment
         TransactionPartnerUser
         TransactionPartnerOther
+        TransactionPartnerTelegramAds
+        TransactionPartnerTelegramApi
+        TransactionPartnerAffiliateProgram
+        TransactionPartnerChat
 
     Telegram documentation: https://core.telegram.org/bots/api#transactionpartner
 
@@ -10548,6 +10568,8 @@ class TransactionPartner(JsonDeserializable):
             return TransactionPartnerOther.de_json(obj)
         elif obj["type"] == "chat":
             return TransactionPartnerChat.de_json(obj)
+        else:
+            raise ValueError(f"Unknown transaction partner type: {obj['type']}")
 
 
 # noinspection PyShadowingBuiltins
@@ -10581,6 +10603,7 @@ class TransactionPartnerFragment(TransactionPartner):
         return cls(**obj)
 
 
+# noinspection PyShadowingBuiltins
 class TransactionPartnerTelegramApi(TransactionPartner):
     """
     Describes a transaction with payment for paid broadcasting.
@@ -10648,8 +10671,8 @@ class TransactionPartnerUser(TransactionPartner):
     :rtype: :class:`TransactionPartnerUser`
     """
 
-    def __init__(self, type, user, affiliate=None, invoice_payload=None, paid_media: Optional[List[PaidMedia]] = None, 
-                    subscription_period=None, gift: Optional[Gift] = None, premium_subscription_duration: Optional[int] = None, 
+    def __init__(self, type, user, affiliate=None, invoice_payload=None, paid_media: Optional[List[PaidMedia]] = None,
+                    subscription_period=None, gift: Optional[Gift] = None, premium_subscription_duration: Optional[int] = None,
                     transaction_type: Optional[str] = None, **kwargs):
         self.type: str = type
         self.user: User = user
@@ -10681,7 +10704,7 @@ class TransactionPartnerTelegramAds(TransactionPartner):
     Describes a transaction with Telegram Ads.
 
     Telegram documentation: https://core.telegram.org/bots/api#transactionpartnertelegramads
-    
+
     :param type: Type of the transaction partner, always “telegram_ads”
     :type type: :obj:`str`
 
@@ -10761,7 +10784,7 @@ class StarTransaction(JsonDeserializable):
         if 'receiver' in obj:
             obj['receiver'] = TransactionPartner.de_json(obj['receiver'])
         return cls(**obj)
-    
+
     def __init__(self, id, amount, date, source=None, receiver=None, nanostar_amount=None, **kwargs):
         self.id: str = id
         self.amount: int = amount
@@ -10791,12 +10814,12 @@ class StarTransactions(JsonDeserializable):
         obj = cls.check_json(json_string)
         obj['transactions'] = [StarTransaction.de_json(transaction) for transaction in obj['transactions']]
         return cls(**obj)
-    
+
     def __init__(self, transactions, **kwargs):
         self.transactions: List[StarTransaction] = transactions
 
 
-class PaidMedia(JsonDeserializable):
+class PaidMedia(JsonDeserializable, ABC):
     """
     This object describes paid media. Currently, it can be one of
 
@@ -10820,6 +10843,8 @@ class PaidMedia(JsonDeserializable):
             return PaidMediaPhoto.de_json(obj)
         elif obj["type"] == "video":
             return PaidMediaVideo.de_json(obj)
+        else:
+            raise ValueError("Unknown type of PaidMedia: {0}".format(obj["type"]))
 
 
 # noinspection PyShadowingBuiltins
@@ -10940,14 +10965,14 @@ class PaidMediaInfo(JsonDeserializable):
         obj = cls.check_json(json_string)
         obj['paid_media'] = [PaidMedia.de_json(media) for media in obj['paid_media']]
         return cls(**obj)
-    
+
     def __init__(self, star_count, paid_media, **kwargs):
         self.star_count: int = star_count
         self.paid_media: List[PaidMedia] = paid_media
 
 
 # noinspection PyShadowingBuiltins
-class InputPaidMedia(JsonSerializable):
+class InputPaidMedia(Dictionaryable, JsonSerializable):
     """
     This object describes the paid media to be sent. Currently, it can be one of
         InputPaidMediaPhoto
@@ -10970,16 +10995,21 @@ class InputPaidMedia(JsonSerializable):
             self._media_name = service_utils.generate_random_token()
             self._media_dic = 'attach://{0}'.format(self._media_name)
 
+        if self.__class__ is InputPaidMedia:
+            # Make InputPaidMedia as ABC some time...
+            log_deprecation_warning('The InputPaidMedia class should not be instantiated directly. Use particular InputPaidMediaXXX class instead')
+
     def to_json(self):
         return json.dumps(self.to_dict())
-    
+
     def to_dict(self):
         data = {
             'type': self.type,
             'media': self._media_dic
         }
         return data
-    
+
+
 class InputPaidMediaPhoto(InputPaidMedia):
     """
     The paid media to send is a photo.
@@ -11000,7 +11030,8 @@ class InputPaidMediaPhoto(InputPaidMedia):
 
     def __init__(self, media: Union[str, InputFile], **kwargs):
         super().__init__(type='photo', media=media)
-    
+
+
 class InputPaidMediaVideo(InputPaidMedia):
     """
     The paid media to send is a video.
@@ -11058,8 +11089,6 @@ class InputPaidMediaVideo(InputPaidMedia):
         self.cover: Optional[Union[str,InputFile]] = cover
         self.start_timestamp: Optional[int] = start_timestamp
 
-
-
     def to_dict(self):
         data = super().to_dict()
         if self.thumbnail:
@@ -11077,6 +11106,7 @@ class InputPaidMediaVideo(InputPaidMedia):
         if self.start_timestamp:
             data['start_timestamp'] = self.start_timestamp
         return data
+
 
 class RefundedPayment(JsonDeserializable):
     """
@@ -11115,8 +11145,8 @@ class RefundedPayment(JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         return cls(**obj)
-    
-    
+
+
 class PaidMediaPurchased(JsonDeserializable):
     """
     This object contains information about a paid media purchase.
@@ -11143,7 +11173,7 @@ class PaidMediaPurchased(JsonDeserializable):
         obj = cls.check_json(json_string)
         obj['from_user'] = User.de_json(obj['from_user'])
         return cls(**obj)
-    
+
 
 class CopyTextButton(JsonSerializable, JsonDeserializable):
     """
@@ -11162,13 +11192,13 @@ class CopyTextButton(JsonSerializable, JsonDeserializable):
 
     def to_json(self):
         return json.dumps(self.to_dict())
-    
+
     def to_dict(self):
         data = {
             'text': self.text
         }
         return data
-    
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
@@ -11176,6 +11206,7 @@ class CopyTextButton(JsonSerializable, JsonDeserializable):
         return cls(**obj)
 
 
+# noinspection PyShadowingBuiltins
 class PreparedInlineMessage(JsonDeserializable):
     """
     Describes an inline message to be sent by a user of a Mini App.
@@ -11201,8 +11232,9 @@ class PreparedInlineMessage(JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         return cls(**obj)
-    
 
+
+# noinspection PyShadowingBuiltins
 class Gift(JsonDeserializable):
     """
     This object represents a gift that can be sent by the bot.
@@ -11245,7 +11277,8 @@ class Gift(JsonDeserializable):
         obj = cls.check_json(json_string)
         obj['sticker'] = Sticker.de_json(obj['sticker'])
         return cls(**obj)
-    
+
+
 class Gifts(JsonDeserializable):
     """
     This object represent a list of gifts.
@@ -11268,8 +11301,9 @@ class Gifts(JsonDeserializable):
         obj = cls.check_json(json_string)
         obj['gifts'] = [Gift.de_json(gift) for gift in obj['gifts']]
         return cls(**obj)
-    
-    
+
+
+# noinspection PyShadowingBuiltins
 class TransactionPartnerAffiliateProgram(TransactionPartner):
     """
     Describes the affiliate program that issued the affiliate commission received via this transaction.
@@ -11302,7 +11336,7 @@ class TransactionPartnerAffiliateProgram(TransactionPartner):
             obj['sponsor_user'] = User.de_json(obj['sponsor_user'])
 
         return cls(**obj)
-    
+
 
 class AffiliateInfo(JsonDeserializable):
     """
@@ -11345,8 +11379,9 @@ class AffiliateInfo(JsonDeserializable):
         if 'affiliate_chat' in obj:
             obj['affiliate_chat'] = Chat.de_json(obj['affiliate_chat'])
         return cls(**obj)
-    
 
+
+# noinspection PyShadowingBuiltins
 class TransactionPartnerChat(TransactionPartner):
     """
     Describes a transaction with a chat.
@@ -11379,7 +11414,7 @@ class TransactionPartnerChat(TransactionPartner):
         if 'gift' in obj:
             obj['gift'] = Gift.de_json(obj['gift'])
         return cls(**obj)
-    
+
 
 class BusinessBotRights(JsonDeserializable):
     """
@@ -11430,10 +11465,10 @@ class BusinessBotRights(JsonDeserializable):
     :type can_manage_stories: :obj:`bool`
 
     :return: Instance of the class
-    :rtype: :class:`BusinessBotRights` 
+    :rtype: :class:`BusinessBotRights`
     """
     def __init__(self, can_reply=None, can_read_messages=None, can_delete_outgoing_messages=None, can_delete_all_messages=None,
-                    can_edit_name=None, can_edit_bio=None, can_edit_profile_photo=None, can_edit_username=None, 
+                    can_edit_name=None, can_edit_bio=None, can_edit_profile_photo=None, can_edit_username=None,
                     can_change_gift_settings=None, can_view_gifts_and_stars=None, can_convert_gifts_to_stars=None,
                     can_transfer_and_upgrade_gifts=None, can_transfer_stars=None, can_manage_stories=None, **kwargs):
         self.can_reply: Optional[bool] = can_reply
@@ -11450,7 +11485,7 @@ class BusinessBotRights(JsonDeserializable):
         self.can_transfer_and_upgrade_gifts: Optional[bool] = can_transfer_and_upgrade_gifts
         self.can_transfer_stars: Optional[bool] = can_transfer_stars
         self.can_manage_stories: Optional[bool] = can_manage_stories
-    
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
@@ -11472,7 +11507,7 @@ class AcceptedGiftTypes(JsonDeserializable, JsonSerializable):
 
     :param unique_gifts: True, if unique gifts or gifts that can be upgraded to unique for free are accepted
     :type unique_gifts: :obj:`bool`
-    
+
     :param premium_subscription: True, if a Telegram Premium subscription is accepted
     :type premium_subscription: :obj:`bool`
 
@@ -11485,10 +11520,10 @@ class AcceptedGiftTypes(JsonDeserializable, JsonSerializable):
         self.limited_gifts: bool = limited_gifts
         self.unique_gifts: bool = unique_gifts
         self.premium_subscription: bool = premium_subscription
-        
+
     def to_json(self):
         return json.dumps(self.to_dict())
-    
+
     def to_dict(self):
         data = {
             'unlimited_gifts': self.unlimited_gifts,
@@ -11497,6 +11532,7 @@ class AcceptedGiftTypes(JsonDeserializable, JsonSerializable):
             'premium_subscription': self.premium_subscription
         }
         return data
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
@@ -11522,13 +11558,15 @@ class StarAmount(JsonDeserializable):
     def __init__(self, amount, nanostar_amount=None, **kwargs):
         self.amount: int = amount
         self.nanostar_amount: Optional[int] = nanostar_amount
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         return cls(**obj)
-    
 
+
+# noinspection PyShadowingBuiltins
 class OwnedGift(JsonDeserializable, ABC):
     """
     This object describes a gift received and owned by a user or a chat. Currently, it can be one of
@@ -11540,9 +11578,8 @@ class OwnedGift(JsonDeserializable, ABC):
 
     def __init__(self, type, **kwargs):
         self.type: str = type
-        self.gift: Union[Gift, UniqueGift] = None
-    
-    
+        self.gift: Optional[Union[Gift, UniqueGift]] = None
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
@@ -11551,7 +11588,11 @@ class OwnedGift(JsonDeserializable, ABC):
             return OwnedGiftRegular.de_json(obj)
         elif obj["type"] == "unique":
             return OwnedGiftUnique.de_json(obj)
-        
+        else:
+            raise ValueError(f"Unknown gift type: {obj['type']}.")
+
+
+# noinspection PyShadowingBuiltins
 class OwnedGiftRegular(OwnedGift):
     """
     This object describes a regular gift owned by a user or a chat.
@@ -11572,7 +11613,7 @@ class OwnedGiftRegular(OwnedGift):
 
     :param send_date: Date the gift was sent in Unix time
     :type send_date: :obj:`int`
-    
+
     :param text: Optional. Text of the message that was added to the gift
     :type text: :obj:`str`
 
@@ -11616,6 +11657,7 @@ class OwnedGiftRegular(OwnedGift):
         self.was_refunded: Optional[bool] = was_refunded
         self.convert_star_count: Optional[int] = convert_star_count
         self.prepaid_upgrade_star_count: Optional[int] = prepaid_upgrade_star_count
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
@@ -11626,7 +11668,9 @@ class OwnedGiftRegular(OwnedGift):
         if 'entities' in obj:
             obj['entities'] = [MessageEntity.de_json(entity) for entity in obj['entities']]
         return cls(**obj)
-    
+
+
+# noinspection PyShadowingBuiltins
 class OwnedGiftUnique(OwnedGift):
     """
     This object describes a unique gift owned by a user or a chat.
@@ -11674,6 +11718,7 @@ class OwnedGiftUnique(OwnedGift):
         self.can_be_transferred: Optional[bool] = can_be_transferred
         self.transfer_star_count: Optional[int] = transfer_star_count
         self.next_transfer_date: Optional[int] = next_transfer_date
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
@@ -11682,7 +11727,7 @@ class OwnedGiftUnique(OwnedGift):
         if 'sender_user' in obj:
             obj['sender_user'] = User.de_json(obj['sender_user'])
         return cls(**obj)
-    
+
 
 class OwnedGifts(JsonDeserializable):
     """
@@ -11707,13 +11752,13 @@ class OwnedGifts(JsonDeserializable):
         self.total_count: int = total_count
         self.gifts: List[OwnedGift] = gifts
         self.next_offset: Optional[str] = next_offset
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         obj['gifts'] = [OwnedGift.de_json(gift) for gift in obj['gifts']]
         return cls(**obj)
-
 
 
 class UniqueGift(JsonDeserializable):
@@ -11750,6 +11795,7 @@ class UniqueGift(JsonDeserializable):
         self.model: UniqueGiftModel = model
         self.symbol: UniqueGiftSymbol = symbol
         self.backdrop: UniqueGiftBackdrop = backdrop
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
@@ -11758,8 +11804,8 @@ class UniqueGift(JsonDeserializable):
         obj['symbol'] = UniqueGiftSymbol.de_json(obj['symbol'])
         obj['backdrop'] = UniqueGiftBackdrop.de_json(obj['backdrop'])
         return cls(**obj)
-    
-    
+
+
 class UniqueGiftModel(JsonDeserializable):
     """
     This object describes the model of a unique gift.
@@ -11783,13 +11829,15 @@ class UniqueGiftModel(JsonDeserializable):
         self.name: str = name
         self.sticker: Sticker = sticker
         self.rarity_per_mille: int = rarity_per_mille
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         obj['sticker'] = Sticker.de_json(obj['sticker'])
         return cls(**obj)
-    
+
+
 class UniqueGiftSymbol(JsonDeserializable):
     """
     This object describes the symbol shown on the pattern of a unique gift.
@@ -11813,13 +11861,15 @@ class UniqueGiftSymbol(JsonDeserializable):
         self.name: str = name
         self.sticker: Sticker = sticker
         self.rarity_per_mille: int = rarity_per_mille
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         obj['sticker'] = Sticker.de_json(obj['sticker'])
         return cls(**obj)
-    
+
+
 class UniqueGiftBackdropColors(JsonDeserializable):
     """
     This object describes the colors of the backdrop of a unique gift.
@@ -11846,12 +11896,14 @@ class UniqueGiftBackdropColors(JsonDeserializable):
         self.edge_color: int = edge_color
         self.symbol_color: int = symbol_color
         self.text_color: int = text_color
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         return cls(**obj)
-    
+
+
 class UniqueGiftBackdrop(JsonDeserializable):
     """
     This object describes the backdrop of a unique gift.
@@ -11874,6 +11926,7 @@ class UniqueGiftBackdrop(JsonDeserializable):
         self.name: str = name
         self.colors: UniqueGiftBackdropColors = colors
         self.rarity_per_mille: int = rarity_per_mille
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
@@ -11881,6 +11934,8 @@ class UniqueGiftBackdrop(JsonDeserializable):
         obj['colors'] = UniqueGiftBackdropColors.de_json(obj['colors'])
         return cls(**obj)
 
+
+# noinspection PyShadowingBuiltins
 class InputStoryContent(JsonSerializable, ABC):
     """
     This object describes the content of a story to post. Currently, it can be one of
@@ -11888,7 +11943,6 @@ class InputStoryContent(JsonSerializable, ABC):
     InputStoryContentVideo
 
     Telegram documentation: https://core.telegram.org/bots/api#inputstorycontent
-
     """
     def __init__(self, type: str, **kwargs):
         self.type: str = type
@@ -11911,20 +11965,20 @@ class InputStoryContentPhoto(InputStoryContent):
         self.photo: InputFile = photo
         self._photo_name = service_utils.generate_random_token()
         self._photo_dic = "attach://{}".format(self._photo_name)
-        
+
     def to_json(self):
         return json.dumps(self.to_dict())
-    
+
     def to_dict(self):
         data = {
             'type': self.type,
             'photo': self._photo_dic
         }
         return data
-    
+
     def convert_input_story(self):
         return self.to_json(), {self._photo_name: self.photo}
-    
+
 
 class InputStoryContentVideo(InputStoryContent):
     """
@@ -11956,9 +12010,10 @@ class InputStoryContentVideo(InputStoryContent):
         self.duration: Optional[float] = duration
         self.cover_frame_timestamp: Optional[float] = cover_frame_timestamp
         self.is_animation: Optional[bool] = is_animation
+
     def to_json(self):
         return json.dumps(self.to_dict())
-    
+
     def to_dict(self):
         data = {
             'type': self.type,
@@ -11971,9 +12026,10 @@ class InputStoryContentVideo(InputStoryContent):
         if self.is_animation is not None:
             data['is_animation'] = self.is_animation
         return data
+
     def convert_input_story(self):
         return self.to_json(), {self._video_name: self.video}
-    
+
 
 class StoryAreaPosition(JsonSerializable):
     """
@@ -12010,8 +12066,10 @@ class StoryAreaPosition(JsonSerializable):
         self.height_percentage: float = height_percentage
         self.rotation_angle: float = rotation_angle
         self.corner_radius_percentage: float = corner_radius_percentage
+
     def to_json(self):
         return json.dumps(self.to_dict())
+
     def to_dict(self):
         data = {
             'x_percentage': self.x_percentage,
@@ -12022,7 +12080,7 @@ class StoryAreaPosition(JsonSerializable):
             'corner_radius_percentage': self.corner_radius_percentage
         }
         return data
-    
+
 
 class LocationAddress(JsonSerializable):
     """
@@ -12051,8 +12109,10 @@ class LocationAddress(JsonSerializable):
         self.state: Optional[str] = state
         self.city: Optional[str] = city
         self.street: Optional[str] = street
+
     def to_json(self):
         return json.dumps(self.to_dict())
+
     def to_dict(self):
         data = {
             'country_code': self.country_code
@@ -12064,7 +12124,9 @@ class LocationAddress(JsonSerializable):
         if self.street is not None:
             data['street'] = self.street
         return data
-    
+
+
+# noinspection PyShadowingBuiltins
 class StoryAreaType(JsonSerializable, ABC):
     """
     Describes the type of a clickable area on a story. Currently, it can be one of
@@ -12109,8 +12171,10 @@ class StoryAreaTypeLocation(StoryAreaType):
         self.latitude: float = latitude
         self.longitude: float = longitude
         self.address: Optional[LocationAddress] = address
+
     def to_json(self):
         return json.dumps(self.to_dict())
+
     def to_dict(self):
         data = {
             'type': self.type,
@@ -12120,7 +12184,7 @@ class StoryAreaTypeLocation(StoryAreaType):
         if self.address is not None:
             data['address'] = self.address.to_dict()
         return data
-    
+
 
 class StoryAreaTypeSuggestedReaction(StoryAreaType):
     """
@@ -12148,8 +12212,10 @@ class StoryAreaTypeSuggestedReaction(StoryAreaType):
         self.reaction_type: ReactionType = reaction_type
         self.is_dark: Optional[bool] = is_dark
         self.is_flipped: Optional[bool] = is_flipped
+
     def to_json(self):
         return json.dumps(self.to_dict())
+
     def to_dict(self):
         data = {
             'type': self.type,
@@ -12160,7 +12226,8 @@ class StoryAreaTypeSuggestedReaction(StoryAreaType):
         if self.is_flipped is not None:
             data['is_flipped'] = self.is_flipped
         return data
-    
+
+
 class StoryAreaTypeLink(StoryAreaType):
     """
     Describes a story area pointing to an HTTP or tg:// link. Currently, a story can have up to 3 link areas.
@@ -12179,15 +12246,18 @@ class StoryAreaTypeLink(StoryAreaType):
     def __init__(self, url: str, **kwargs):
         super().__init__(type="link")
         self.url: str = url
+
     def to_json(self):
         return json.dumps(self.to_dict())
+
     def to_dict(self):
         data = {
             'type': self.type,
             'url': self.url
         }
         return data
-    
+
+
 class StoryAreaTypeWeather(StoryAreaType):
     """
     Describes a story area containing weather information. Currently, a story can have up to 3 weather areas.
@@ -12214,8 +12284,10 @@ class StoryAreaTypeWeather(StoryAreaType):
         self.temperature: float = temperature
         self.emoji: str = emoji
         self.background_color: int = background_color
+
     def to_json(self):
         return json.dumps(self.to_dict())
+
     def to_dict(self):
         data = {
             'type': self.type,
@@ -12224,7 +12296,8 @@ class StoryAreaTypeWeather(StoryAreaType):
             'background_color': self.background_color
         }
         return data
-    
+
+
 class StoryAreaTypeUniqueGift(StoryAreaType):
     """
     Describes a story area pointing to a unique gift. Currently, a story can have at most 1 unique gift area.
@@ -12243,8 +12316,10 @@ class StoryAreaTypeUniqueGift(StoryAreaType):
     def __init__(self, name: str, **kwargs):
         super().__init__(type="unique_gift")
         self.name: str = name
+
     def to_json(self):
         return json.dumps(self.to_dict())
+
     def to_dict(self):
         data = {
             'type': self.type,
@@ -12252,8 +12327,9 @@ class StoryAreaTypeUniqueGift(StoryAreaType):
         }
 
         return data
-    
 
+
+# noinspection PyShadowingBuiltins
 class StoryArea(JsonSerializable):
     """
     Describes a clickable area on a story media.
@@ -12272,15 +12348,17 @@ class StoryArea(JsonSerializable):
     def __init__(self, position: StoryAreaPosition, type: StoryAreaType, **kwargs):
         self.position: StoryAreaPosition = position
         self.type: StoryAreaType = type
+
     def to_json(self):
         return json.dumps(self.to_dict())
+
     def to_dict(self):
         data = {
             'position': self.position.to_dict(),
             'type': self.type.to_dict()
         }
         return data
-    
+
 
 class GiftInfo(JsonDeserializable):
     """
@@ -12327,6 +12405,7 @@ class GiftInfo(JsonDeserializable):
         self.text: Optional[str] = text
         self.entities: Optional[List[MessageEntity]] = entities
         self.is_private: Optional[bool] = is_private
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
@@ -12335,7 +12414,8 @@ class GiftInfo(JsonDeserializable):
         if 'entities' in obj:
             obj['entities'] = [MessageEntity.de_json(entity) for entity in obj['entities']]
         return cls(**obj)
-    
+
+
 class UniqueGiftInfo(JsonDeserializable):
     """
     This object describes a service message about a unique gift that was sent or received.
@@ -12380,7 +12460,7 @@ class UniqueGiftInfo(JsonDeserializable):
         obj = cls.check_json(json_string)
         obj['gift'] = UniqueGift.de_json(obj['gift'])
         return cls(**obj)
-    
+
 
 class PaidMessagePriceChanged(JsonDeserializable):
     """
@@ -12396,14 +12476,15 @@ class PaidMessagePriceChanged(JsonDeserializable):
     """
     def __init__(self, paid_message_star_count: int, **kwargs):
         self.paid_message_star_count: int = paid_message_star_count
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         return cls(**obj)
-    
 
-class InputProfilePhoto(JsonSerializable):
+
+class InputProfilePhoto(JsonSerializable, ABC):
     """
     This object describes a profile photo to set. Currently, it can be one of
     InputProfilePhotoStatic
@@ -12415,10 +12496,11 @@ class InputProfilePhoto(JsonSerializable):
     :rtype: :class:`InputProfilePhoto`
     """
 
+
 class InputProfilePhotoStatic(InputProfilePhoto):
     """
     This object describes a static profile photo to set.
-    
+
     Telegram documentation: https://core.telegram.org/bots/api#inputprofilephotostatic
 
     :param type: Type of the profile photo, must be static
@@ -12434,18 +12516,19 @@ class InputProfilePhotoStatic(InputProfilePhoto):
     def __init__(self, photo: InputFile, **kwargs):
         self.type: str = "static"
         self.photo: InputFile = photo
-
         self._photo_name = service_utils.generate_random_token()
         self._photo_dic = "attach://{}".format(self._photo_name)
+
     def to_json(self):
         return json.dumps(self.to_dict())
-    
+
     def to_dict(self):
         data = {
             'type': self.type,
             'photo': self._photo_dic
         }
         return data
+
     def convert_input_profile_photo(self):
         return self.to_json(), {self._photo_name: self.photo}
 
@@ -12475,8 +12558,10 @@ class InputProfilePhotoAnimated(InputProfilePhoto):
         self._animation_name = service_utils.generate_random_token()
         self._animation_dic = "attach://{}".format(self._animation_name)
         self.main_frame_timestamp: Optional[float] = main_frame_timestamp
+
     def to_json(self):
         return json.dumps(self.to_dict())
+
     def to_dict(self):
         data = {
             'type': self.type,
@@ -12485,10 +12570,12 @@ class InputProfilePhotoAnimated(InputProfilePhoto):
         if self.main_frame_timestamp is not None:
             data['main_frame_timestamp'] = self.main_frame_timestamp
         return data
+
     def convert_input_profile_photo(self):
         return self.to_json(), {self._animation_name: self.animation}
 
 
+# noinspection PyShadowingBuiltins
 class ChecklistTask(JsonDeserializable):
     """
     Describes a task in a checklist.
@@ -12531,7 +12618,8 @@ class ChecklistTask(JsonDeserializable):
         if 'completed_by_user' in obj:
             obj['completed_by_user'] = User.de_json(obj['completed_by_user'])
         return cls(**obj)
-    
+
+
 class Checklist(JsonDeserializable):
     """
     Describes a checklist.
@@ -12557,7 +12645,7 @@ class Checklist(JsonDeserializable):
     :rtype: :class:`Checklist`
     """
     def __init__(self, title: str, tasks: List[ChecklistTask],
-                    title_entities: Optional[List[MessageEntity]] = None,    
+                    title_entities: Optional[List[MessageEntity]] = None,
                     others_can_add_tasks: Optional[bool] = None,
                     others_can_mark_tasks_as_done: Optional[bool] = None, **kwargs):
         self.title: str = title
@@ -12575,6 +12663,8 @@ class Checklist(JsonDeserializable):
         obj['tasks'] = [ChecklistTask.de_json(task) for task in obj['tasks']]
         return cls(**obj)
 
+
+# noinspection PyShadowingBuiltins
 class InputChecklistTask(JsonSerializable):
     """
     Describes a task to add to a checklist.
@@ -12602,10 +12692,10 @@ class InputChecklistTask(JsonSerializable):
         self.text: str = text
         self.parse_mode: Optional[str] = parse_mode
         self.text_entities: Optional[List[MessageEntity]] = text_entities
-        
+
     def to_json(self):
         return json.dumps(self.to_dict())
-    
+
     def to_dict(self):
         data = {
             'id': self.id,
@@ -12616,7 +12706,8 @@ class InputChecklistTask(JsonSerializable):
         if self.text_entities:
             data['text_entities'] = [entity.to_dict() for entity in self.text_entities]
         return data
-    
+
+
 class InputChecklist(JsonSerializable):
     """
     Describes a checklist to create.
@@ -12644,7 +12735,7 @@ class InputChecklist(JsonSerializable):
     :return: Instance of the class
     :rtype: :class:`InputChecklist`
     """
-    def __init__(self, title: str, tasks: List[InputChecklistTask], 
+    def __init__(self, title: str, tasks: List[InputChecklistTask],
                     parse_mode: Optional[str] = None,
                     title_entities: Optional[List[MessageEntity]] = None,
                     others_can_add_tasks: Optional[bool] = None,
@@ -12658,7 +12749,7 @@ class InputChecklist(JsonSerializable):
 
     def to_json(self):
         return json.dumps(self.to_dict())
-    
+
     def to_dict(self):
         data = {
             'title': self.title,
@@ -12706,8 +12797,8 @@ class ChecklistTasksDone(JsonDeserializable):
         if 'checklist_message' in obj:
             obj['checklist_message'] = Message.de_json(obj['checklist_message'])
         return cls(**obj)
-    
-    
+
+
 class ChecklistTasksAdded(JsonDeserializable):
     """
     Describes a service message about tasks added to a checklist.
@@ -12726,6 +12817,7 @@ class ChecklistTasksAdded(JsonDeserializable):
     def __init__(self, tasks: List[ChecklistTask], checklist_message: Optional[Message] = None, **kwargs):
         self.checklist_message: Optional[Message] = checklist_message
         self.tasks: List[ChecklistTask] = tasks
+
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
@@ -12734,6 +12826,7 @@ class ChecklistTasksAdded(JsonDeserializable):
             obj['checklist_message'] = Message.de_json(obj['checklist_message'])
         obj['tasks'] = [ChecklistTask.de_json(task) for task in obj['tasks']]
         return cls(**obj)
+
 
 class DirectMessagePriceChanged(JsonDeserializable):
     """


### PR DESCRIPTION
## Description
Set func=None as default for the inline handler. and clean up whitespace.

## Describe your tests
This should not break anything, it falls in line with the way the other handlers are written to default func to None when no filter is required.

Python version:
3.13

OS:
Ubuntu 24.04

## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [x] I made changes both for sync and async
