### PR TITLE
Fix: correct type hint for message to allow None

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -3277,7 +3277,7 @@ class CallbackQuery(JsonDeserializable):
             game_short_name=None, **kwargs):
         self.id: int = id
         self.from_user: User = from_user
-        self.message: Union[Message, InaccessibleMessage] = message
+        self.message: Optional[Union[Message, InaccessibleMessage]] = message
         self.inline_message_id: Optional[str] = inline_message_id
         self.chat_instance: Optional[str] = chat_instance
         self.data: Optional[str] = data


### PR DESCRIPTION
## Description
The attribute `message` can be `None` in practice, but the type hint only allowed `Message | InaccessibleMessage`.

This PR updates it to:

    Optional[Union[Message, InaccessibleMessage]]

This prevents false positives in type checkers (Pyright, MyPy, Pylance) and reflects the real behavior.

## Describe your tests
Although the change doesn't require its own test, I ran the tests and detected no errors.

Python version: 3.13

OS: Windows 11

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [ ] I made changes both for sync and async
