### PR TITLE
Prepare for Bot Api 9.4

### DIFF
--- a/telebot/types.py
+++ b/telebot/types.py
@@ -3148,8 +3148,7 @@ class InlineKeyboardButton(Dictionaryable, JsonSerializable, JsonDeserializable)
     :param copy_text: Optional. Description of the button that copies the specified text to the clipboard.
     :type copy_text: :class:`telebot.types.CopyTextButton`
     
-    :param icon_custom_emoji_id: Optional. Custom emoji identifier to be shown on the button. 
-    Can only be used if the bot has a Telegram Premium subscription.
+    :param icon_custom_emoji_id: Optional. Custom emoji identifier to be shown on the button. Can only be used if the bot owner has a Telegram Premium subscription.
     :type icon_custom_emoji_id: :obj:`str`
     
     :param style: Optional. Style of the button. Can be used to change the color of the button.


### PR DESCRIPTION
## Summary
This PR implements Bot API 9.4 features for keyboard buttons, adding support for custom emoji icons and button styling.

## Changes
- Added `icon_custom_emoji_id` parameter to `InlineKeyboardButton` class
- Added `style` parameter to `InlineKeyboardButton` class  
- Added `icon_custom_emoji_id` parameter to `KeyboardButton` class
- Added `style` parameter to `KeyboardButton` class
- Updated `to_dict()` methods to serialize the new fields
- Updated docstrings with parameter documentation

These changes allow bots with Telegram Premium subscription to display custom emojis on buttons and change button colors using style parameters.

## References
- [Bot API 9.4 Changelog](https://core.telegram.org/bots/api-changelog#february-9-2026)
- [InlineKeyboardButton Documentation](https://core.telegram.org/bots/api#inlinekeyboardbutton)
- [KeyboardButton Documentation](https://core.telegram.org/bots/api#keyboardbutton)

## Testing
```python
@bot.message_handler(commands=['start'])
def start(message):
    markup = InlineKeyboardMarkup()
    
    # Button with style (color) - Bot API 9.4
    btn1 = InlineKeyboardButton(
        text="🔥 Destructive Action",
        callback_data="delete",
        style="danger"  # NEW: Red button
    )
    
    btn2 = InlineKeyboardButton(
        text="✅ Confirm",
        callback_data="confirm",
        style="success"  # NEW: Green button
    )
    
    btn3 = InlineKeyboardButton(
        text="ℹ️ Info",
        callback_data="info",
        style="primary"  # NEW: Blue button
    )
    
    # Button with custom emoji icon - Bot API 9.4
    btn4 = InlineKeyboardButton(
        text="Premium Button",
        callback_data="premium",
        icon_custom_emoji_id="5368324170671202286"  # NEW: Shows custom emoji on button
    )
    
    markup.add(btn1, btn2)
    markup.add(btn3)
    markup.add(btn4)
    
    bot.send_message(message.chat.id, "Choose an action:", reply_markup=markup)