### PR TITLE
[fix] use thread-local aiohttp.ClientSession, as it is not thread-safe

### DIFF
--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1,5 +1,6 @@
 import asyncio # for future uses
 import ssl
+import threading
 import aiohttp
 import certifi
 from telebot import types
@@ -30,9 +31,16 @@ REQUEST_LIMIT = 50
 
 class SessionManager:
     def __init__(self) -> None:
-        self.session = None
+        self._local = threading.local()
         self.ssl_context = ssl.create_default_context(cafile=certifi.where())
 
+    @property
+    def session(self):
+        return getattr(self._local, 'session', None)
+
+    @session.setter
+    def session(self, value):
+        self._local.session = value
 
     async def create_session(self):
         self.session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(
@@ -45,7 +53,7 @@ class SessionManager:
         if self.session is None:
             self.session = await self.create_session()
             return self.session
-            
+
         if self.session.closed:
             self.session = await self.create_session()
 


### PR DESCRIPTION
## Description

Fix thread-safety issue in async SessionManager.
 
`SessionManager` in `telebot/asyncio_helper.py` is currently a module-level singleton. Its `session` attribute (which is an `aiohttp.ClientSession`) was stored as a plain instance variable, meaning it was __shared across all threads__ => when multiple threads each run their own event loop with separate AsyncTeleBot instances, they all use the same `aiohttp.ClientSession` — which is not thread-safe.

I encountered this issue myself – were getting unpredictable `2026-02-26 23:26:15,914 (asyncio_helper.py:103 workflow-exec_1) ERROR - TeleBot: "Unknown error: RuntimeError"` errors in separate threads, each with its own eventloop and `AsyncTeleBot` instance local to this loop.

This PR wraps the session attribute in `threading.local()`, so each thread gets its own `aiohttp.ClientSession`, matching how the sync side already handles this via `util.per_thread`.

## Describe your tests

Confirmed that multiple `AsyncTeleBot` instances running on separate threads with separate event loops no longer share aiohttp session state across threads.

Python version: 3.12

OS: macOS

## Checklist:

- [x] ~~I added/edited example on new feature/change (if exists)~~ n/a, see below
- [x] My changes won't break backward compatibility
- [x] ~~I made changes both for sync and async~~ n/a, see below

No examples needed — this is an internal bugfix with no external API changes.

The sync side (`apihelper.py`) already uses util.per_thread for thread-local sessions, so no sync changes were needed.