### PR TITLE
Update format_header_param to format_multipart_header_param

### DIFF
--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -15,7 +15,7 @@ from requests.adapters import HTTPAdapter
 try:
     # noinspection PyUnresolvedReferences
     from requests.packages.urllib3 import fields
-    format_header_param = fields.format_header_param
+    format_header_param = fields.format_multipart_header_param
 except ImportError:
     format_header_param = None
 import telebot
@@ -100,7 +100,7 @@ def _make_request(token, method_name, method='get', params=None, files=None):
 
     
     if files and format_header_param:
-        fields.format_header_param = _no_encode(format_header_param)
+        fields.format_multipart_header_param = _no_encode(format_header_param)
     if params:
         if 'timeout' in params:
             read_timeout = params.pop('timeout')


### PR DESCRIPTION
## Description
Update format_header_param to format_multipart_header_param since it is deprecated in URLLIB3.

## Error solved
Traceback (most recent call last):
  File "/home/kali/Downloads/search_Telegram_phone/search_phone.py", line 3, in <module>
    import telebot
  File "/home/kali/Downloads/venv_covert/lib/python3.13/site-packages/telebot/__init__.py", line 40, in <module>
    from telebot import apihelper, util, types
  File "/home/kali/Downloads/venv_covert/lib/python3.13/site-packages/telebot/apihelper.py", line 18, in <module>
    format_header_param = fields.format_header_param
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'urllib3.fields' has no attribute 'format_header_param'. Did you mean: 'format_header_param_rfc2231'?

Python version: Python 3.13.11

OS: Linux kali 6.12.25-amd64 #1 SMP PREEMPT_DYNAMIC Kali 6.12.25-1kali1 (2025-04-30) x86_64 GNU/Linux

## Checklist:
- [ ] I added/edited example on new feature/change (if exists)
- [ ] My changes won't break backward compatibility
- [ ] I made changes both for sync and async
