### PR TITLE
Retain strong refs to update-processing tasks in AsyncTeleBot

### DIFF
--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -196,7 +196,7 @@ class AsyncTeleBot:
         # Strong references to background tasks created via asyncio.create_task().
         # asyncio only keeps weak references, so unreferenced tasks can be GC'd
         # mid-execution; see https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
-        self._pending_tasks: set = set()
+        self._pending_tasks: set[asyncio.Task[Any]] = set()
         self.webhook_listener = None
 
         if validate_token:

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -193,6 +193,10 @@ class AsyncTeleBot:
 
         self._user = None # set during polling
         self._polling = None
+        # Strong references to background tasks created via asyncio.create_task().
+        # asyncio only keeps weak references, so unreferenced tasks can be GC'd
+        # mid-execution; see https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+        self._pending_tasks: set = set()
         self.webhook_listener = None
 
         if validate_token:
@@ -456,8 +460,10 @@ class AsyncTeleBot:
                     updates = await self.get_updates(offset=self.offset, allowed_updates=allowed_updates, timeout=timeout, request_timeout=request_timeout)
                     if updates:
                         self.offset = updates[-1].update_id + 1
-                        # noinspection PyAsyncCall
-                        asyncio.create_task(self.process_new_updates(updates)) # Seperate task for processing updates
+                        # Retain a strong reference so the task isn't GC'd mid-execution.
+                        task = asyncio.create_task(self.process_new_updates(updates))
+                        self._pending_tasks.add(task)
+                        task.add_done_callback(self._pending_tasks.discard)
                     if interval: await asyncio.sleep(interval)
                     error_interval = 0.25 # drop error_interval if no errors
 

--- a/tests/test_async_telebot.py
+++ b/tests/test_async_telebot.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for `telebot.async_telebot.AsyncTeleBot`.
+
+These tests are self-contained (no TOKEN/CHAT_ID required) and stub out all
+network I/O.
+"""
+import asyncio
+
+from telebot import types
+from telebot.async_telebot import AsyncTeleBot
+
+
+def _make_fake_me() -> types.User:
+    return types.User.de_json({
+        "id": 1,
+        "is_bot": True,
+        "first_name": "Test",
+        "username": "test_bot",
+    })
+
+
+def test_process_polling_retains_update_processing_tasks():
+    """Regression test for issue #2572.
+
+    Tasks fired by `_process_polling` for `process_new_updates` must be held
+    in `self._pending_tasks` while running and discarded on completion, so
+    they cannot be garbage-collected mid-execution.
+    """
+    bot = AsyncTeleBot("1:fake", validate_token=False)
+
+    task_was_tracked_during_run: list[bool] = []
+    process_completed = asyncio.Event()
+
+    async def fake_process_new_updates(updates):
+        current = asyncio.current_task()
+        task_was_tracked_during_run.append(current in bot._pending_tasks)
+        process_completed.set()
+
+    async def fake_get_me():
+        return _make_fake_me()
+
+    # Deliver a single update batch, then stop polling on the next tick.
+    fake_update = types.Update.de_json({"update_id": 1})
+    call_count = {"n": 0}
+
+    async def fake_get_updates(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return [fake_update]
+        bot._polling = False
+        return []
+
+    async def noop():
+        return None
+
+    bot.get_me = fake_get_me
+    bot.get_updates = fake_get_updates
+    bot.process_new_updates = fake_process_new_updates
+    bot.close_session = noop  # stub: no real aiohttp session in tests
+
+    async def driver():
+        await bot._process_polling(non_stop=True, interval=0, timeout=0)
+        # Allow the fire-and-forget task to finish plus one yield for the
+        # add_done_callback discard to run.
+        await process_completed.wait()
+        await asyncio.sleep(0)
+
+    asyncio.run(driver())
+
+    assert task_was_tracked_during_run == [True], (
+        "In-flight processing task must be held by _pending_tasks"
+    )
+    assert bot._pending_tasks == set(), (
+        "Completed processing tasks must be discarded from _pending_tasks"
+    )

--- a/tests/test_async_telebot.py
+++ b/tests/test_async_telebot.py
@@ -61,8 +61,9 @@ def test_process_polling_retains_update_processing_tasks():
     async def driver():
         await bot._process_polling(non_stop=True, interval=0, timeout=0)
         # Allow the fire-and-forget task to finish plus one yield for the
-        # add_done_callback discard to run.
-        await process_completed.wait()
+        # add_done_callback discard to run. A timeout guards against the
+        # stub ever being rewired such that the processing task never runs.
+        await asyncio.wait_for(process_completed.wait(), timeout=1)
         await asyncio.sleep(0)
 
     asyncio.run(driver())


### PR DESCRIPTION
Closes #2572.

### What

`AsyncTeleBot._process_polling` dispatches incoming update batches via `asyncio.create_task(...)` without retaining a reference to the resulting `Task`. Per the [Python asyncio docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task), the event loop only keeps **weak** references to tasks, so an unreferenced task may be garbage-collected mid-execution and updates silently dropped.

### Change

- Added `self._pending_tasks: set` to `AsyncTeleBot.__init__` to hold strong references to in-flight background tasks.
- In `_process_polling`, captured the `Task` returned by `asyncio.create_task(...)`, added it to `_pending_tasks`, and attached `task.add_done_callback(self._pending_tasks.discard)` so the set self-cleans on completion.

This is the exact pattern suggested by the asyncio docs and matches the minimal fix proposed by the reporter (@fshp971).

### Why this approach vs the alternatives

@All-The-Foxes suggested two alternatives in the thread:

1. **Process updates via an internal queue** — larger architectural change; unclear benefit if `process_new_updates` is fast.
2. **Just `await` `process_new_updates` directly** — simplest, but changes concurrency semantics (polling would block on handler execution). That's a behavior change for existing bots.

This PR takes the minimal-risk route: preserves existing fire-and-forget semantics while fixing the GC hazard. Happy to rework toward either alternative if that's the preferred direction.

### Tests

Added `tests/test_async_telebot.py` with a regression test that:

- Drives `_process_polling` with stubbed `get_updates` / `process_new_updates` / `get_me` / `close_session`
- Verifies the in-flight processing task is present in `_pending_tasks` during execution
- Verifies `_pending_tasks` is emptied after the task completes (discard callback fires)

Full test run: `49 passed, 72 skipped` (skipped tests require `TOKEN`/`CHAT_ID` env vars, unchanged from before this PR).