### PR TITLE
Added RichBlock (half) and RichText stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">A simple, but extensible Python implementation for the <a href="https://core.telegram.org/bots/api">Telegram Bot API</a>.</p>
 <p align="center">Both synchronous and asynchronous.</p>
 
-## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#may-8-2026"><img src="https://img.shields.io/badge/Bot%20API-10.0-blue?logo=telegram" alt="Supported Bot API version"></a>
+## <p align="center">Supported Bot API version: <a href="https://core.telegram.org/bots/api#june-11-2026"><img src="https://img.shields.io/badge/Bot%20API-10.1-blue?logo=telegram" alt="Supported Bot API version"></a>
 
 <h2><a href='https://pytba.readthedocs.io/en/latest/index.html'>Official documentation</a></h2>
 <h2><a href='https://pytba.readthedocs.io/ru/latest/index.html'>Official ru documentation</a></h2>

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -4453,7 +4453,105 @@ class TeleBot:
         """
         return apihelper.send_message_draft(
             self.token, chat_id, draft_id, text, parse_mode=parse_mode, entities=entities, message_thread_id=message_thread_id)
+    
+    def send_rich_message(
+            self, chat_id: Union[int, str],
+            rich_message: types.InputRichMessage,
+            business_connection_id: Optional[str]=None,
+            message_thread_id: Optional[int]=None,
+            direct_messages_topic_id: Optional[int]=None,
+            disable_notification: Optional[bool]=None,
+            protect_content: Optional[bool]=None,
+            allow_paid_broadcast: Optional[bool]=None,
+            message_effect_id: Optional[str]=None,
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None) -> types.Message:
+        """
+        Use this method to send rich messages. If the message contains a block with a media element,
+        then the bot must have the right to send the media to the chat. On success, the sent Message is returned.
 
+        Telegram documentation: https://core.telegram.org/bots/api#sendrichmessage
+
+        :param chat_id: Unique identifier for the target chat or username of the target bot, supergroup or channel in the format @username
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param rich_message: The message to be sent
+        :type rich_message: :class:`telebot.types.InputRichMessage`
+
+        :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
+        :type disable_notification: :obj:`bool`
+
+        :param protect_content: Protects the contents of the sent message from forwarding and saving
+        :type protect_content: :obj:`bool`
+
+        :param allow_paid_broadcast: Pass True to allow up to 1000 messages per second, ignoring broadcasting limits for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance.
+        :type allow_paid_broadcast: :obj:`bool`
+
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
+        :param suggested_post_parameters: A JSON-serialized object containing the parameters of the suggested post to send;
+            for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+        :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
+
+        :param reply_parameters: Description of the message to reply to
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
+        :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user.
+        :type reply_markup: :class:`telebot.types.InlineKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardRemove` or :class:`telebot.types.ForceReply`
+
+        :param business_connection_id: Identifier of a business connection
+        :type business_connection_id: :obj:`str`
+
+        :param message_thread_id: The thread identifier of a message from which the reply will be sent
+        :type message_thread_id: :obj:`int`
+
+        :param direct_messages_topic_id: Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
+        :type direct_messages_topic_id: :obj:`int`
+
+        :return: On success, the sent Message is returned.
+        :rtype: :class:`telebot.types.Message`
+        """
+        disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
+        protect_content = self.protect_content if (protect_content is None) else protect_content
+
+        return types.Message.de_json(
+            apihelper.send_rich_message(
+                self.token, chat_id, rich_message, disable_notification=disable_notification, protect_content=protect_content,
+                allow_paid_broadcast=allow_paid_broadcast, message_effect_id=message_effect_id, suggested_post_parameters=suggested_post_parameters, reply_parameters=reply_parameters,
+                reply_markup=reply_markup, business_connection_id=business_connection_id, message_thread_id=message_thread_id, direct_messages_topic_id=direct_messages_topic_id)
+            )
+
+    def send_rich_message_draft(
+            self, chat_id: int,
+            draft_id: int,
+            rich_message: types.InputRichMessage,
+            message_thread_id: Optional[int]=None) -> bool:
+        """
+        Use this method to stream a partial rich message to a user while the message is being generated
+        Note that the streamed draft is ephemeral and acts as a temporary 30-second preview - once the output
+        is finalized, you must call sendRichMessage with the complete message to persist it in the user's chat. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#sendrichmessagedraft
+
+        :param chat_id: Unique identifier for the target private chat
+        :type chat_id: :obj:`int`
+
+        :param draft_id: Unique identifier of the message draft; must be non-zero. Changes to drafts with the same identifier are animated.
+        :type draft_id: :obj:`int`
+
+        :param rich_message: The partial message to be streamed
+        :type rich_message: :class:`telebot.types.InputRichMessage`
+
+        :param message_thread_id: Unique identifier for the target message thread
+        :type message_thread_id: :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.send_rich_message_draft(
+            self.token, chat_id, draft_id, rich_message, message_thread_id=message_thread_id)
 
 
     def send_chat_action(
@@ -5114,6 +5212,42 @@ class TeleBot:
         """
         return apihelper.decline_chat_join_request(self.token, chat_id, user_id)
 
+    def answer_chat_join_request_query(self, chat_join_request_query_id: str, result: str) -> bool:
+        """
+        Use this method to process a received chat join request query. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#answerchatjoinrequestquery
+
+        :param chat_join_request_query_id: Unique identifier of the join request query
+        :type chat_join_request_query_id: :obj:`str`
+
+        :param result: Result of the query. Must be either “approve” to allow the user to join the chat,
+            “decline” to disallow the user to join the chat, or “queue” to leave the decision to other administrators.
+        :type result: :obj:`str`
+
+        :return: True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.answer_chat_join_request_query(self.token, chat_join_request_query_id, result)
+
+    def send_chat_join_request_web_app(self, chat_join_request_query_id: str, web_app_url: str) -> bool:
+        """
+        Use this method to process a received chat join request query by showing a Mini App to the
+        user before deciding the outcome. Call answerChatJoinRequestQuery to resolve the join request query based on the user interaction with the Mini App.
+        Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#sendchatjoinrequestwebapp
+
+        :param chat_join_request_query_id: Unique identifier of the join request query
+        :type chat_join_request_query_id: :obj:`str`
+
+        :param web_app_url: The URL of the Mini App to be opened
+        :type web_app_url: :obj:`str`
+
+        :return: True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.send_chat_join_request_web_app(self.token, chat_join_request_query_id, web_app_url)
 
     def set_chat_photo(self, chat_id: Union[int, str], photo: Any) -> bool:
         """
@@ -5659,7 +5793,8 @@ class TeleBot:
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             link_preview_options : Optional[types.LinkPreviewOptions]=None,
             business_connection_id: Optional[str]=None,
-            timeout: Optional[int]=None) -> Union[types.Message, bool]:
+            timeout: Optional[int]=None,
+            rich_message: Optional[types.InputRichMessage]=None) -> Union[types.Message, bool]:
         """
         Use this method to edit text and game messages.
 
@@ -5698,6 +5833,9 @@ class TeleBot:
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
 
+        :param rich_message: New rich content of the message; required if text isn't specified
+        :type rich_message: :obj:`types.InputRichMessage`
+
         :return: On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
         :rtype: :obj:`types.Message` or :obj:`bool`
         """
@@ -5725,7 +5863,7 @@ class TeleBot:
         result = apihelper.edit_message_text(
             self.token, text, chat_id=chat_id, message_id=message_id, inline_message_id=inline_message_id,
             parse_mode=parse_mode, entities=entities, reply_markup=reply_markup, link_preview_options=link_preview_options,
-            business_connection_id=business_connection_id, timeout=timeout)
+            business_connection_id=business_connection_id, timeout=timeout, rich_message=rich_message)
 
         if isinstance(result, bool):  # if edit inline message return is bool not Message.
             return result

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5867,7 +5867,7 @@ class TeleBot:
             link_preview_options = types.LinkPreviewOptions(is_disabled=self.disable_web_page_preview)
 
         result = apihelper.edit_message_text(
-            self.token, text, chat_id=chat_id, message_id=message_id, inline_message_id=inline_message_id,
+            self.token, text=text, chat_id=chat_id, message_id=message_id, inline_message_id=inline_message_id,
             parse_mode=parse_mode, entities=entities, reply_markup=reply_markup, link_preview_options=link_preview_options,
             business_connection_id=business_connection_id, timeout=timeout, rich_message=rich_message)
 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5783,7 +5783,7 @@ class TeleBot:
 
 
     def edit_message_text(
-            self, text: str,
+            self, text: Optional[str]=None,
             chat_id: Optional[Union[int, str]]=None,
             message_id: Optional[int]=None,
             inline_message_id: Optional[str]=None,
@@ -5840,6 +5840,12 @@ class TeleBot:
         :rtype: :obj:`types.Message` or :obj:`bool`
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
+        disable_web_page_preview = self.disable_web_page_preview if (disable_web_page_preview is None) else disable_web_page_preview
+
+        if (rich_message is not None) and (text is not None):
+            raise ValueError("Both 'rich_message' and 'text' parameters are provided. Only one of them should be provided.")
+        if (rich_message is None) and (text is None):
+            raise ValueError("Both 'rich_message' and 'text' parameters are None. One of them should be provided.")
 
         if disable_web_page_preview is not None:
             # show a deprecation warning

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -5800,7 +5800,7 @@ class TeleBot:
 
         Telegram documentation: https://core.telegram.org/bots/api#editmessagetext
 
-        :param text: New text of the message, 1-4096 characters after entities parsing
+        :param text: New text of the message, 1-4096 characters after entity parsing; required if rich_message isn't specified
         :type text: :obj:`str`
 
         :param chat_id: Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -286,7 +286,8 @@ def send_rich_message(
         token, chat_id, rich_message,
         disable_notification=None, protect_content=None, message_effect_id=None,
         reply_parameters=None, reply_markup=None, business_connection_id=None,
-        direct_messages_topic_id=None, suggested_post_parameters=None, allow_paid_broadcast=None):
+        direct_messages_topic_id=None, suggested_post_parameters=None, allow_paid_broadcast=None,
+        message_thread_id=None):
     method_url = r'sendRichMessage'
     payload = {'chat_id': str(chat_id), 'rich_message': rich_message.to_json()}
     if disable_notification is not None:
@@ -307,6 +308,8 @@ def send_rich_message(
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
     if allow_paid_broadcast is not None:
         payload['allow_paid_broadcast'] = allow_paid_broadcast
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
     return _make_request(token, method_url, params=payload, method='post') 
 
 def send_rich_message_draft(token, chat_id, draft_id, rich_message, message_thread_id=None):

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -289,7 +289,7 @@ def send_rich_message(
         direct_messages_topic_id=None, suggested_post_parameters=None, allow_paid_broadcast=None,
         message_thread_id=None):
     method_url = r'sendRichMessage'
-    payload = {'chat_id': str(chat_id), 'rich_message': rich_message.to_json()}
+    payload = {'chat_id': chat_id, 'rich_message': rich_message.to_json()}
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
     if protect_content is not None:

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -1792,10 +1792,12 @@ def unpin_all_chat_messages(token, chat_id):
 # Updating messages
 
 def edit_message_text(
-        token, text, chat_id=None, message_id=None, inline_message_id=None, parse_mode=None, entities = None,
+        token, text=None, chat_id=None, message_id=None, inline_message_id=None, parse_mode=None, entities = None,
         reply_markup=None, link_preview_options=None, business_connection_id=None, timeout=None, rich_message=None):
     method_url = r'editMessageText'
-    payload = {'text': text}
+    payload = {}
+    if text:
+        payload['text'] = text
     if chat_id:
         payload['chat_id'] = chat_id
     if message_id:

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -282,6 +282,41 @@ def send_message(
     return _make_request(token, method_url, params=payload, method='post')
 
 
+def send_rich_message(
+        token, chat_id, rich_message,
+        disable_notification=None, protect_content=None, message_effect_id=None,
+        reply_parameters=None, reply_markup=None, business_connection_id=None,
+        direct_messages_topic_id=None, suggested_post_parameters=None, allow_paid_broadcast=None):
+    method_url = r'sendRichMessage'
+    payload = {'chat_id': str(chat_id), 'rich_message': rich_message.to_json()}
+    if disable_notification is not None:
+        payload['disable_notification'] = disable_notification
+    if protect_content is not None:
+        payload['protect_content'] = protect_content
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
+    if reply_parameters:
+        payload['reply_parameters'] = reply_parameters.to_json()
+    if reply_markup:
+        payload['reply_markup'] = _convert_markup(reply_markup)
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
+    if direct_messages_topic_id is not None:
+        payload['direct_messages_topic_id'] = direct_messages_topic_id
+    if suggested_post_parameters is not None:
+        payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if allow_paid_broadcast is not None:
+        payload['allow_paid_broadcast'] = allow_paid_broadcast
+    return _make_request(token, method_url, params=payload, method='post') 
+
+def send_rich_message_draft(token, chat_id, draft_id, rich_message, message_thread_id=None):
+    method_url = r'sendRichMessageDraft'
+    payload = {'chat_id': str(chat_id), 'draft_id': draft_id, 'rich_message': rich_message.to_json()}
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
+    return _make_request(token, method_url, params=payload, method='post')
+
+
 def set_webhook(token, url=None, certificate=None, max_connections=None, allowed_updates=None, ip_address=None,
                 drop_pending_updates = None, timeout=None, secret_token=None):
     method_url = r'setWebhook'
@@ -1516,6 +1551,24 @@ def decline_chat_join_request(token, chat_id, user_id):
     return _make_request(token, method_url, params=payload, method='post')
 
 
+def answer_chat_join_request_query(token, chat_join_request_query_id, result):
+    method_url = 'answerChatJoinRequestQuery'
+    payload = {
+        'chat_join_request_query_id': chat_join_request_query_id,
+        'result': result
+    }
+    return _make_request(token, method_url, params=payload, method='post')
+
+
+def send_chat_join_request_web_app(token, chat_join_request_query_id, web_app_url):
+    method_url = 'sendChatJoinRequestWebApp'
+    payload = {
+        'chat_join_request_query_id': chat_join_request_query_id,
+        'web_app_url': web_app_url
+    }
+    return _make_request(token, method_url, params=payload, method='post')
+
+
 def set_chat_photo(token, chat_id, photo):
     method_url = 'setChatPhoto'
     payload = {'chat_id': chat_id}
@@ -1737,7 +1790,7 @@ def unpin_all_chat_messages(token, chat_id):
 
 def edit_message_text(
         token, text, chat_id=None, message_id=None, inline_message_id=None, parse_mode=None, entities = None,
-        reply_markup=None, link_preview_options=None, business_connection_id=None, timeout=None):
+        reply_markup=None, link_preview_options=None, business_connection_id=None, timeout=None, rich_message=None):
     method_url = r'editMessageText'
     payload = {'text': text}
     if chat_id:
@@ -1758,6 +1811,8 @@ def edit_message_text(
         payload['business_connection_id'] = business_connection_id
     if timeout:
         payload['timeout'] = timeout
+    if rich_message:
+        payload['rich_message'] = rich_message.to_json()
     return _make_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7410,7 +7410,7 @@ class AsyncTeleBot:
 
         Telegram documentation: https://core.telegram.org/bots/api#editmessagetext
 
-        :param text: New text of the message, 1-4096 characters after entities parsing
+        :param text: New text of the message, 1-4096 characters after entity parsing; required if rich_message isn't specified
         :type text: :obj:`str`
 
         :param chat_id: Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7476,8 +7476,9 @@ class AsyncTeleBot:
             link_preview_options = types.LinkPreviewOptions(is_disabled=self.disable_web_page_preview)
 
         result = await asyncio_helper.edit_message_text(
-            self.token, text, chat_id, message_id, inline_message_id, parse_mode, entities, reply_markup,
-            link_preview_options, business_connection_id, timeout, rich_message)
+            self.token, text=text, chat_id=chat_id, message_id=message_id, inline_message_id=inline_message_id,
+            parse_mode=parse_mode, entities=entities, reply_markup=reply_markup,
+            link_preview_options=link_preview_options, business_connection_id=business_connection_id, timeout=timeout, rich_message=rich_message)
         if isinstance(result, bool):  # if edit inline message return is bool not Message.
             return result
         return types.Message.de_json(result)

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6143,8 +6143,7 @@ class AsyncTeleBot:
             self, chat_id: int,
             draft_id: int,
             rich_message: types.InputRichMessage,
-            message_thread_id: Optional[int]=None,
-            business_connection_id: Optional[str]=None) -> bool:
+            message_thread_id: Optional[int]=None) -> bool:
         """
         Use this method to stream a partial rich message to a user while the message is being generated
         Note that the streamed draft is ephemeral and acts as a temporary 30-second preview - once the output is finalized,
@@ -6164,14 +6163,11 @@ class AsyncTeleBot:
         :param message_thread_id: Unique identifier for the target message thread
         :type message_thread_id: :obj:`int`
 
-        :param business_connection_id: Identifier of a business connection, in which the message will be sent
-        :type business_connection_id: :obj:`str`
-
         :return: Returns True on success.
         :rtype: :obj:`bool`
         """
         return await asyncio_helper.send_rich_message_draft(
-            self.token, chat_id, draft_id, rich_message, message_thread_id=message_thread_id, business_connection_id=business_connection_id)
+            self.token, chat_id, draft_id, rich_message, message_thread_id=message_thread_id)
         
     async def send_message_draft(
             self, chat_id: int,

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -6062,6 +6062,116 @@ class AsyncTeleBot:
                 protect_content, message_thread_id, reply_parameters, business_connection_id,
                 message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast,
                 direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters))
+    
+    async def send_rich_message(
+            self, chat_id: Union[int, str],
+            rich_message: types.InputRichMessage,
+            business_connection_id: Optional[str]=None,
+            message_thread_id: Optional[int]=None,
+            direct_messages_topic_id: Optional[int]=None,
+            disable_notification: Optional[bool]=None,
+            protect_content: Optional[bool]=None,
+            allow_paid_broadcast: Optional[bool]=None,
+            message_effect_id: Optional[str]=None,
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            reply_parameters: Optional[types.ReplyParameters]=None,
+            reply_markup: Optional[REPLY_MARKUP_TYPES]=None) -> types.Message:
+        """
+        Use this method to send rich messages. If the message contains a block with a media element then
+        the bot must have the right to send the media to the chat. On success, the sent Message is returned.
+
+        Telegram documentation: https://core.telegram.org/bots/api#sendrichmessage
+
+        :param chat_id: Unique identifier for the target chat or username of the target bot, supergroup or channel in the format @username
+        :type chat_id: :obj:`int` or :obj:`str`
+
+        :param rich_message: The message to be sent
+        :type rich_message: :class:`telebot.types.InputRichMessage`
+
+        :param business_connection_id: Unique identifier of the business connection on behalf of which the message will be sent.
+            Bot can send rich messages on behalf of a business account only if the corresponding user can send rich messages.
+        :type business_connection_id: :obj:`str`
+
+        :param message_thread_id: Unique identifier for the target message thread (topic) of a forum; for forum supergroups
+            and private chats of bots with forum topic mode enabled only
+        :type message_thread_id: :obj:`int`
+
+        :param direct_messages_topic_id: Identifier of the direct messages topic to which the message will be sent;
+            required if the message is sent to a direct messages chat
+        :type direct_messages_topic_id: :obj:`int`
+
+        :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
+        :type disable_notification: :obj:`bool`
+
+        :param protect_content: Protects the contents of the sent message from forwarding and saving
+        :type protect_content: :obj:`bool`
+
+        :param allow_paid_broadcast: Pass True to allow up to 1000 messages per second, ignoring broadcasting limits for a fee
+            of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance.
+        :type allow_paid_broadcast: :obj:`bool` 
+
+        :param message_effect_id: Unique identifier of the message effect to be added to the message; for private chats only
+        :type message_effect_id: :obj:`str`
+
+        :param suggested_post_parameters: A JSON-serialized object containing the parameters of the suggested post to send;
+            for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post
+            is automatically declined.
+        :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
+
+        :param reply_parameters: Description of the message to reply to
+        :type reply_parameters: :class:`telebot.types.ReplyParameters`
+
+        :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard,
+            instructions to remove a reply keyboard or to force a reply from the user.
+        :type reply_markup: :class:`telebot.types.InlineKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardMarkup` or :class:`telebot.types.ReplyKeyboardRemove`
+            or :class:`telebot.types.ForceReply`
+
+        :return: On success, the sent Message is returned.
+        :rtype: :class:`telebot.types.Message`
+        """
+        disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
+        protect_content = self.protect_content if (protect_content is None) else protect_content
+
+        return types.Message.de_json(
+            await asyncio_helper.send_rich_message(
+                self.token, chat_id, rich_message, business_connection_id=business_connection_id, message_thread_id=message_thread_id, direct_messages_topic_id=direct_messages_topic_id,
+                disable_notification=disable_notification, protect_content=protect_content, allow_paid_broadcast=allow_paid_broadcast, message_effect_id=message_effect_id, suggested_post_parameters=suggested_post_parameters
+                , reply_parameters=reply_parameters, reply_markup=reply_markup)
+        )
+
+    async def send_rich_message_draft(
+            self, chat_id: int,
+            draft_id: int,
+            rich_message: types.InputRichMessage,
+            message_thread_id: Optional[int]=None,
+            business_connection_id: Optional[str]=None) -> bool:
+        """
+        Use this method to stream a partial rich message to a user while the message is being generated
+        Note that the streamed draft is ephemeral and acts as a temporary 30-second preview - once the output is finalized,
+        you must call sendRichMessage with the complete message to persist it in the user's chat. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#sendrichmessagedraft
+
+        :param chat_id: Unique identifier for the target private chat
+        :type chat_id: :obj:`int`
+
+        :param draft_id: Unique identifier of the message draft; must be non-zero. Changes to drafts with the same identifier are animated.
+        :type draft_id: :obj:`int`
+
+        :param rich_message: The partial message to be streamed
+        :type rich_message: :class:`telebot.types.InputRichMessage`
+        
+        :param message_thread_id: Unique identifier for the target message thread
+        :type message_thread_id: :obj:`int`
+
+        :param business_connection_id: Identifier of a business connection, in which the message will be sent
+        :type business_connection_id: :obj:`str`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.send_rich_message_draft(
+            self.token, chat_id, draft_id, rich_message, message_thread_id=message_thread_id, business_connection_id=business_connection_id)
         
     async def send_message_draft(
             self, chat_id: int,
@@ -6739,6 +6849,43 @@ class AsyncTeleBot:
         """
         return await asyncio_helper.decline_chat_join_request(self.token, chat_id, user_id)
 
+    async def answer_chat_join_request_query(self, chat_join_request_query_id: str, result: str) -> bool:
+        """
+        Use this method to process a received chat join request query. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#answerchatjoinrequestquery
+
+        :param chat_join_request_query_id: Unique identifier of the join request query
+        :type chat_join_request_query_id: :obj:`str`
+
+        :param result: Result of the query. Must be either “approve” to allow the user to join the chat, “decline”
+            to disallow the user to join the chat, or “queue” to leave the decision to other administrators.
+        :type result: :obj:`str`
+
+        :return: True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.answer_chat_join_request_query(self.token, chat_join_request_query_id, result)
+
+    async def send_chat_join_request_web_app(self, chat_join_request_query_id: str, web_app_url: str) -> bool:
+        """
+        Use this method to process a received chat join request query by showing a Mini App to the
+        user before deciding the outcome. Call answerChatJoinRequestQuery to resolve the join request query based on the user interaction with the Mini App.
+        Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#sendchatjoinrequestwebapp
+
+        :param chat_join_request_query_id: Unique identifier of the join request query
+        :type chat_join_request_query_id: :obj:`str`
+
+        :param web_app_url: The URL of the Mini App to be opened
+        :type web_app_url: :obj:`str`
+
+        :return: True on success.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.send_chat_join_request_web_app(self.token, chat_join_request_query_id, web_app_url)
+
     async def set_chat_photo(self, chat_id: Union[int, str], photo: Any) -> bool:
         """
         Use this method to set a new profile photo for the chat. Photos can't be changed for private chats.
@@ -7260,7 +7407,8 @@ class AsyncTeleBot:
             reply_markup: Optional[types.InlineKeyboardMarkup]=None,
             link_preview_options: Optional[types.LinkPreviewOptions]=None,
             business_connection_id: Optional[str]=None,
-            timeout: Optional[int]=None) -> Union[types.Message, bool]:
+            timeout: Optional[int]=None,
+            rich_message: Optional[types.InputRichMessage]=None) -> Union[types.Message, bool]:
         """
         Use this method to edit text and game messages.
 
@@ -7299,6 +7447,9 @@ class AsyncTeleBot:
         :param timeout: Timeout in seconds for the request.
         :type timeout: :obj:`int`
 
+        :param rich_message: New rich content of the message; required if text isn't specified
+        :type rich_message: :obj:`types.InputRichMessage`
+
         :return: On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
         :rtype: :obj:`types.Message` or :obj:`bool`
         """
@@ -7325,7 +7476,7 @@ class AsyncTeleBot:
 
         result = await asyncio_helper.edit_message_text(
             self.token, text, chat_id, message_id, inline_message_id, parse_mode, entities, reply_markup,
-            link_preview_options, business_connection_id, timeout)
+            link_preview_options, business_connection_id, timeout, rich_message)
         if isinstance(result, bool):  # if edit inline message return is bool not Message.
             return result
         return types.Message.de_json(result)

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -7393,7 +7393,7 @@ class AsyncTeleBot:
         return await asyncio_helper.unpin_all_chat_messages(self.token, chat_id)
 
     async def edit_message_text(
-            self, text: str,
+            self, text: Optional[str]=None,
             chat_id: Optional[Union[int, str]]=None,
             message_id: Optional[int]=None,
             inline_message_id: Optional[str]=None,
@@ -7451,6 +7451,11 @@ class AsyncTeleBot:
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_web_page_preview = self.disable_web_page_preview if (disable_web_page_preview is None) else disable_web_page_preview
+
+        if (rich_message is not None) and (text is not None):
+            raise ValueError("Both 'rich_message' and 'text' parameters are provided. Only one of them should be provided.")
+        if (rich_message is None) and (text is None):
+            raise ValueError("Both 'rich_message' and 'text' parameters are None. One of them should be provided.")
 
         if disable_web_page_preview is not None:
             if link_preview_options:

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -334,7 +334,7 @@ async def send_rich_message(
         reply_parameters=None, reply_markup=None, business_connection_id=None,  allow_paid_broadcast=None, direct_messages_topic_id=None,
         suggested_post_parameters=None, message_thread_id=None):
     method_url = r'sendRichMessage'
-    payload = {'chat_id': chat_id, 'rich_message': rich_message.to_json()}
+    payload = {'chat_id': str(chat_id), 'rich_message': rich_message.to_json()}
     if disable_notification is not None:
         payload['disable_notification'] = disable_notification
     if protect_content is not None:

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -328,7 +328,43 @@ async def send_message(
     
     return await _process_request(token, method_name, params=params, method='post')
 
-# methods
+async def send_rich_message(
+        token, chat_id, rich_message,
+        disable_notification=None, protect_content=None, message_effect_id=None,
+        reply_parameters=None, reply_markup=None, business_connection_id=None, payload=None, allow_paid_broadcast=None, direct_messages_topic_id=None,
+        suggested_post_parameters=None):
+    method_url = r'sendRichMessage'
+    payload = {'chat_id': chat_id, 'rich_message': rich_message.to_json()}
+    if disable_notification is not None:
+        payload['disable_notification'] = disable_notification
+    if protect_content is not None:
+        payload['protect_content'] = protect_content
+    if message_effect_id:
+        payload['message_effect_id'] = message_effect_id
+    if reply_parameters:
+        payload['reply_parameters'] = reply_parameters.to_json()
+    if reply_markup:
+        payload['reply_markup'] = await _convert_markup(reply_markup)
+    if business_connection_id:
+        payload['business_connection_id'] = business_connection_id
+    if payload:
+        payload['payload'] = payload
+    if allow_paid_broadcast is not None:
+        payload['allow_paid_broadcast'] = allow_paid_broadcast
+    if direct_messages_topic_id is not None:
+        payload['direct_messages_topic_id'] = direct_messages_topic_id
+    if suggested_post_parameters is not None:
+        payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    
+    return await _process_request(token, method_url, params=payload, method='post')
+
+async def send_rich_message_draft(token, chat_id, draft_id, rich_message, message_thread_id=None):
+    method_url = r'sendRichMessageDraft'
+    payload = {'chat_id': chat_id, 'draft_id': draft_id, 'rich_message': rich_message.to_json()}
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
+    return await _process_request(token, method_url, params=payload, method='post')
+
 
 async def get_user_profile_photos(token, user_id, offset=None, limit=None):
     method_url = r'getUserProfilePhotos'
@@ -1529,6 +1565,22 @@ async def decline_chat_join_request(token, chat_id, user_id):
     }
     return await _process_request(token, method_url, params=payload, method='post')
 
+async def answer_chat_join_request_query(token, chat_join_request_query_id, result):
+    method_url = 'answerChatJoinRequestQuery'
+    payload = {
+        'chat_join_request_query_id': chat_join_request_query_id,
+        'result': result
+    }
+    return await _process_request(token, method_url, params=payload, method='post')
+
+async def send_chat_join_request_web_app(token, chat_join_request_query_id, web_app_url):
+    method_url = 'sendChatJoinRequestWebApp'
+    payload = {
+        'chat_join_request_query_id': chat_join_request_query_id,
+        'web_app_url': web_app_url
+    }
+    return await _process_request(token, method_url, params=payload, method='post')
+
 
 async def set_chat_photo(token, chat_id, photo):
     method_url = 'setChatPhoto'
@@ -1753,7 +1805,7 @@ async def unpin_all_chat_messages(token, chat_id):
 
 async def edit_message_text(
         token, text, chat_id=None, message_id=None, inline_message_id=None, parse_mode=None, entities = None,
-        reply_markup=None, link_preview_options=None, business_connection_id=None, timeout=None):
+        reply_markup=None, link_preview_options=None, business_connection_id=None, timeout=None, rich_message=None):
     method_url = r'editMessageText'
     payload = {'text': text}
     if chat_id:
@@ -1774,6 +1826,8 @@ async def edit_message_text(
         payload['business_connection_id'] = business_connection_id
     if timeout:
         payload['timeout'] = timeout
+    if rich_message:
+        payload['rich_message'] = rich_message.to_json()
     return await _process_request(token, method_url, params=payload, method='post')
 
 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -332,7 +332,7 @@ async def send_rich_message(
         token, chat_id, rich_message,
         disable_notification=None, protect_content=None, message_effect_id=None,
         reply_parameters=None, reply_markup=None, business_connection_id=None, payload=None, allow_paid_broadcast=None, direct_messages_topic_id=None,
-        suggested_post_parameters=None):
+        suggested_post_parameters=None, message_thread_id=None):
     method_url = r'sendRichMessage'
     payload = {'chat_id': chat_id, 'rich_message': rich_message.to_json()}
     if disable_notification is not None:
@@ -355,6 +355,8 @@ async def send_rich_message(
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if message_thread_id is not None:
+        payload['message_thread_id'] = message_thread_id
     
     return await _process_request(token, method_url, params=payload, method='post')
 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -331,7 +331,7 @@ async def send_message(
 async def send_rich_message(
         token, chat_id, rich_message,
         disable_notification=None, protect_content=None, message_effect_id=None,
-        reply_parameters=None, reply_markup=None, business_connection_id=None, payload=None, allow_paid_broadcast=None, direct_messages_topic_id=None,
+        reply_parameters=None, reply_markup=None, business_connection_id=None,  allow_paid_broadcast=None, direct_messages_topic_id=None,
         suggested_post_parameters=None, message_thread_id=None):
     method_url = r'sendRichMessage'
     payload = {'chat_id': chat_id, 'rich_message': rich_message.to_json()}
@@ -347,8 +347,6 @@ async def send_rich_message(
         payload['reply_markup'] = await _convert_markup(reply_markup)
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
-    if payload:
-        payload['payload'] = payload
     if allow_paid_broadcast is not None:
         payload['allow_paid_broadcast'] = allow_paid_broadcast
     if direct_messages_topic_id is not None:
@@ -1806,10 +1804,12 @@ async def unpin_all_chat_messages(token, chat_id):
 # Updating messages
 
 async def edit_message_text(
-        token, text, chat_id=None, message_id=None, inline_message_id=None, parse_mode=None, entities = None,
+        token, text=None, chat_id=None, message_id=None, inline_message_id=None, parse_mode=None, entities = None,
         reply_markup=None, link_preview_options=None, business_connection_id=None, timeout=None, rich_message=None):
     method_url = r'editMessageText'
-    payload = {'text': text}
+    payload = {}
+    if text:
+        payload['text'] = text
     if chat_id:
         payload['chat_id'] = chat_id
     if message_id:

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -14543,3 +14543,1401 @@ class BotAccessSettings(JsonDeserializable):
         if 'added_users' in obj:
             obj['added_users'] = [User.de_json(user) for user in obj['added_users']]
         return cls(**obj)
+
+
+class RichText(JsonDeserializable):
+    """
+    This object represents a rich formatted text. Currently, it can be either a String for plain text,
+    an Array of :class:`RichText`, or any of the following types:
+    - :class:`RichTextBold`
+    - :class:`RichTextItalic`
+    - :class:`RichTextUnderline`
+    - :class:`RichTextStrikethrough`
+    - :class:`RichTextSpoiler`
+    - :class:`RichTextDateTime`
+    - :class:`RichTextTextMention`
+    - :class:`RichTextSubscript`
+    - :class:`RichTextSuperscript`
+    - :class:`RichTextMarked`
+    - :class:`RichTextCode`
+    - :class:`RichTextCustomEmoji`
+    - :class:`RichTextMathematicalExpression`
+    - :class:`RichTextUrl`
+    - :class:`RichTextEmailAddress`
+    - :class:`RichTextPhoneNumber`
+    - :class:`RichTextBankCardNumber`
+    - :class:`RichTextMention`
+    - :class:`RichTextHashtag`
+    - :class:`RichTextCashtag`
+    - :class:`RichTextBotCommand`
+    - :class:`RichTextAnchor`
+    - :class:`RichTextAnchorLink`
+    - :class:`RichTextReference`
+    - :class:`RichTextReferenceLink`
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtext
+
+    :return: Instance of the class
+    :rtype: :class:`RichText`
+    """
+    def __init__(self, type: str, **kwargs):
+        self.type: str = type
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        type = obj['type']
+        if type == 'bold':
+            return RichTextBold.de_json(json_string)
+        elif type == 'italic':
+            return RichTextItalic.de_json(json_string)
+        elif type == 'underline':
+            return RichTextUnderline.de_json(json_string)
+        elif type == 'strikethrough':
+            return RichTextStrikethrough.de_json(json_string)
+        elif type == 'spoiler':
+            return RichTextSpoiler.de_json(json_string)
+        elif type == 'date_time':
+            return RichTextDateTime.de_json(json_string)
+        elif type == 'text_mention':
+            return RichTextTextMention.de_json(json_string)
+        elif type == 'subscript':
+            return RichTextSubscript.de_json(json_string)
+        elif type == 'superscript':
+            return RichTextSuperscript.de_json(json_string)
+        elif type == 'marked':
+            return RichTextMarked.de_json(json_string)
+        elif type == 'code':
+            return RichTextCode.de_json(json_string)
+        elif type == 'custom_emoji':
+            return RichTextCustomEmoji.de_json(json_string)
+        elif type == 'mathematical_expression':
+            return RichTextMathematicalExpression.de_json(json_string)
+        elif type == 'url':
+            return RichTextUrl.de_json(json_string)
+        elif type == 'email_address':
+            return RichTextEmailAddress.de_json(json_string)
+        elif type == 'phone_number':
+            return RichTextPhoneNumber.de_json(json_string)
+        elif type == 'bank_card_number':
+            return RichTextBankCardNumber.de_json(json_string)
+        elif type == 'mention':
+            return RichTextMention.de_json(json_string)
+        elif type == 'hashtag':
+            return RichTextHashtag.de_json(json_string)
+        elif type == 'cashtag':
+            return RichTextCashtag.de_json(json_string)
+        elif type == 'bot_command':
+            return RichTextBotCommand.de_json(json_string)
+        elif type == 'anchor':
+            return RichTextAnchor.de_json(json_string)
+        elif type == 'anchor_link':
+            return RichTextAnchorLink.de_json(json_string)
+        elif type == 'reference':
+            return RichTextReference.de_json(json_string)
+        elif type == 'reference_link':
+            return RichTextReferenceLink.de_json(json_string)
+        return None
+    
+class RichTextBold(RichText):
+    """
+    A bold text.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextbold
+
+    :param type: Type of the rich text, always “bold”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextBold`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='bold', **kwargs)
+        self.text: RichText = text
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextItalic(RichText):
+    """
+    An italicized text.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextitalic
+
+    :param type: Type of the rich text, always “italic”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextItalic`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='italic', **kwargs)
+        self.text: RichText = text
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextUnderline(RichText):
+    """
+    An underlined text.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextunderline
+
+    :param type: Type of the rich text, always “underline”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextUnderline`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='underline', **kwargs)
+        self.text: RichText = text
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextStrikethrough(RichText):
+    """
+    A strikethrough text.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextstrikethrough
+
+    :param type: Type of the rich text, always “strikethrough”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextStrikethrough`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='strikethrough', **kwargs)
+        self.text: RichText = text
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextSpoiler(RichText):
+    """
+    A text covered by a spoiler.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextspoiler
+
+    :param type: Type of the rich text, always “spoiler”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextSpoiler`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='spoiler', **kwargs)
+        self.text: RichText = text
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextDateTime(RichText):
+    """
+    Formatted date and time.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextdatetime
+
+    :param type: Type of the rich text, always “date_time”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextDateTime`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='date_time', **kwargs)
+        self.text: RichText = text
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextTextMention(RichText):
+    """
+    A mention of a Telegram user by their identifier.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtexttextmention
+
+    :param type: Type of the rich text, always “text_mention”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :param user: The mentioned user
+    :type user: :class:`User`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextTextMention`
+    """
+    def __init__(self, text: RichText, user: 'User', **kwargs):
+        super().__init__(type='text_mention', **kwargs)
+        self.text: RichText = text
+        self.user: User = user
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        obj['user'] = User.de_json(obj['user'])
+        return cls(**obj)
+
+
+class RichTextSubscript(RichText):
+    """
+    A subscript text.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextsubscript
+
+    :param type: Type of the rich text, always “subscript”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextSubscript`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='subscript', **kwargs)
+        self.text: RichText = text
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextSuperscript(RichText):
+    """
+    A superscript text.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextsuperscript
+
+    :param type: Type of the rich text, always “superscript”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextSuperscript`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='superscript', **kwargs)
+        self.text: RichText = text
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextMarked(RichText):
+    """
+    A marked text.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextmarked
+
+    :param type: Type of the rich text, always “marked”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextMarked`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='marked', **kwargs)
+        self.text: RichText = text
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextCode(RichText):
+    """
+    A monowidth text.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextcode
+
+    :param type: Type of the rich text, always “code”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextCode`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='code', **kwargs)
+        self.text: RichText = text
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextCustomEmoji(RichText):
+    """
+    A custom emoji.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextcustomemoji
+
+    :param type: Type of the rich text, always “custom_emoji”
+    :type type: :obj:`str`
+
+    :param custom_emoji_id: Unique identifier of the custom emoji. Use getCustomEmojiStickers to get full information about the sticker.
+    :type custom_emoji_id: :obj:`str`
+
+    :param alternative_text: Alternative emoji for the custom emoji
+    :type alternative_text: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextCustomEmoji`
+    """
+    def __init__(self, custom_emoji_id: str, alternative_text: str, **kwargs):
+        super().__init__(type='custom_emoji', **kwargs)
+        self.custom_emoji_id: str = custom_emoji_id
+        self.alternative_text: str = alternative_text
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+
+class RichTextMathematicalExpression(RichText):
+    """
+    A mathematical expression.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextmathematicalexpression
+
+    :param type: Type of the rich text, always “mathematical_expression”
+    :type type: :obj:`str`
+
+    :param expression: The expression in LaTeX format
+    :type expression: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextMathematicalExpression`
+    """
+    def __init__(self, expression: str, **kwargs):
+        super().__init__(type='mathematical_expression', **kwargs)
+        self.expression: str = expression
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+
+class RichTextUrl(RichText):
+    """
+    A text with a link.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtexturl
+
+    :param type: Type of the rich text, always “url”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :param url: URL of the link
+    :type url: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextUrl`
+    """
+    def __init__(self, text: RichText, url: str, **kwargs):
+        super().__init__(type='url', **kwargs)
+        self.text: RichText = text
+        self.url: str = url
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextEmailAddress(RichText):
+    """
+    A text with an email address.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextemailaddress
+
+    :param type: Type of the rich text, always “email_address”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :param email_address: The email address
+    :type email_address: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextEmailAddress`
+    """
+    def __init__(self, text: RichText, email_address: str, **kwargs):
+        super().__init__(type='email_address', **kwargs)
+        self.text: RichText = text
+        self.email_address: str = email_address
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextPhoneNumber(RichText):
+    """
+    A text with a phone number.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextphonenumber
+
+    :param type: Type of the rich text, always “phone_number”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :param phone_number: The phone number
+    :type phone_number: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextPhoneNumber`
+    """
+    def __init__(self, text: RichText, phone_number: str, **kwargs):
+        super().__init__(type='phone_number', **kwargs)
+        self.text: RichText = text
+        self.phone_number: str = phone_number
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextBankCardNumber(RichText):
+    """
+    A text with a bank card number.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextbankcardnumber
+
+    :param type: Type of the rich text, always “bank_card_number”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :param bank_card_number: The bank card number
+    :type bank_card_number: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextBankCardNumber`
+    """
+    def __init__(self, text: RichText, bank_card_number: str, **kwargs):
+        super().__init__(type='bank_card_number', **kwargs)
+        self.text: RichText = text
+        self.bank_card_number: str = bank_card_number
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+class RichTextMention(RichText):
+    """
+    A mention by a username.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextmention
+
+    :param type: Type of the rich text, always “mention”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :param username: The username
+    :type username: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextMention`
+    """
+
+    def __init__(self, text: RichText, username: str, **kwargs):
+        super().__init__(type='mention', **kwargs)
+        self.text: RichText = text
+        self.username: str = username
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+
+class RichTextHashtag(RichText):
+    """
+    A hashtag.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtexthashtag
+
+    :param type: Type of the rich text, always “hashtag”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :param hashtag: The hashtag
+    :type hashtag: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextHashtag`
+    """
+    def __init__(self, text: RichText, hashtag: str, **kwargs):
+        super().__init__(type='hashtag', **kwargs)
+        self.text: RichText = text
+        self.hashtag: str = hashtag
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+
+class RichTextCashtag(RichText):
+    """
+    A cashtag.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextcashtag
+
+    :param type: Type of the rich text, always “cashtag”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :param cashtag: The cashtag
+    :type cashtag: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextCashtag`
+    """
+    def __init__(self, text: RichText, cashtag: str, **kwargs):
+        super().__init__(type='cashtag', **kwargs)
+        self.text: RichText = text
+        self.cashtag: str = cashtag
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+
+class RichTextBotCommand(RichText):
+    """
+    A bot command.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextbotcommand
+
+    :param type: Type of the rich text, always “bot_command”
+    :type type: :obj:`str`
+
+    :param text: The text
+    :type text: :class:`RichText`
+
+    :param bot_command: The bot command
+    :type bot_command: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextBotCommand`
+    """
+    def __init__(self, text: RichText, bot_command: str, **kwargs):
+        super().__init__(type='bot_command', **kwargs)
+        self.text: RichText = text
+        self.bot_command: str = bot_command
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+
+class RichTextAnchor(RichText):
+    """
+    An anchor.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextanchor
+
+    :param type: Type of the rich text, always “anchor”
+    :type type: :obj:`str`
+
+    :param name: The name of the anchor
+    :type name: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextAnchor`
+    """
+    def __init__(self, name: str, **kwargs):
+        super().__init__(type='anchor', **kwargs)
+        self.name: str = name
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+
+
+class RichTextAnchorLink(RichText):
+    """
+    A link to an anchor.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextanchorlink
+
+    :param type: Type of the rich text, always “anchor_link”
+    :type type: :obj:`str`
+
+    :param text: The link text
+    :type text: :class:`RichText`
+
+    :param anchor_name: The name of the anchor. If the name is empty, then the link brings back to the top of the message.
+    :type anchor_name: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextAnchorLink`
+    """
+    def __init__(self, text: RichText, anchor_name: str, **kwargs):
+        super().__init__(type='anchor_link', **kwargs)
+        self.text: RichText = text
+        self.anchor_name: str = anchor_name
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+    
+    
+class RichTextReference(RichText):
+    """
+    A reference.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextreference
+
+    :param type: Type of the rich text, always “reference”
+    :type type: :obj:`str`
+
+    :param text: Text of the reference
+    :type text: :class:`RichText`
+
+    :param name: The name of the reference
+    :type name: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextReference`
+    """
+
+    def __init__(self, text: RichText, name: str, **kwargs):
+        super().__init__(type='reference', **kwargs)
+        self.text: RichText = text
+        self.name: str = name
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+    
+    
+class RichTextReferenceLink(RichText):
+    """
+    A link to a reference.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richtextreferencelink
+
+    :param type: Type of the rich text, always “reference_link”
+    :type type: :obj:`str`
+
+    :param text: The link text
+    :type text: :class:`RichText`
+
+    :param reference_name: The name of the reference
+    :type reference_name: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichTextReferenceLink`
+
+    """
+
+    def __init__(self, text: RichText, reference_name: str, **kwargs):
+        super().__init__(type='reference_link', **kwargs)
+        self.text: RichText = text
+        self.reference_name: str = reference_name
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+
+class RichBlockCaption(JsonDeserializable):
+    """
+    This object represents the caption of a rich formatted block.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockcaption
+
+    :param text: Block caption
+    :type text: :class:`RichText`
+
+    :param credit: Optional. Block credit which corresponds to the HTML tag <cite>
+    :type credit: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockCaption`
+
+    """
+
+    def __init__(self, text: RichText, credit: Optional[RichText] = None, **kwargs):
+        self.text: RichText = text
+        self.credit: Optional[RichText] = credit
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        if 'credit' in obj:
+            obj['credit'] = RichText.de_json(obj['credit'])
+        return cls(**obj)
+
+
+class RichBlockTableCell(JsonDeserializable):
+    """
+    This object represents a cell of a table.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblocktablecell
+
+    :param text: Optional. Text in the cell. If omitted, then the cell is invisible.
+    :type text: :class:`RichText`
+
+    :param is_header: Optional. True, if the cell is a header cell
+    :type is_header: :obj:`bool`
+
+    :param colspan: Optional. The number of columns the cell spans if it is bigger than 1
+    :type colspan: :obj:`int`
+
+    :param rowspan: Optional. The number of rows the cell spans if it is bigger than 1
+    :type rowspan: :obj:`int`
+
+    :param align: Horizontal cell content alignment. Currently, must be one of “left”, “center”, or “right”.
+    :type align: :obj:`str`
+
+    :param valign: Vertical cell content alignment. Currently, must be one of “top”, “middle”, or “bottom”.
+    :type valign: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockTableCell`
+    """
+    def __init__(self, text: Optional[RichText] = None, is_header: Optional[bool] = None, colspan: Optional[int] = None, rowspan: Optional[int] = None,
+                    align: Optional[str] = None, valign: Optional[str] = None, **kwargs):
+        self.text: Optional[RichText] = text
+        self.is_header: Optional[bool] = is_header
+        self.colspan: Optional[int] = colspan
+        self.rowspan: Optional[int] = rowspan
+        self.align: Optional[str] = align
+        self.valign: Optional[str] = valign
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        if 'text' in obj:
+            obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+    
+    
+class RichBlockListItem(JsonDeserializable):
+    """
+    This object represents an item of a list.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblocklistitem
+
+    :param label: Label of the item
+    :type label: :obj:`str`
+
+    :param blocks: The content of the item
+    :type blocks: :obj:`list` of :class:`RichBlock`
+
+    :param has_checkbox: Optional. True, if the item has a checkbox
+    :type has_checkbox: :obj:`bool`
+
+    :param is_checked: Optional. True, if the item has a checked checkbox
+    :type is_checked: :obj:`bool`
+
+    :param value: Optional. For ordered lists, the numeric value of the item label
+    :type value: :obj:`int`
+
+    :param type: Optional. For ordered lists, the type of the item label; must be one of “a” for lowercase letters, “A” for uppercase letters, “i” for lowercase Roman numerals, “I” for uppercase Roman numerals, or “1” for decimal numbers
+    :type type: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockListItem`
+    """
+    def __init__(self, label: str, blocks: List['RichBlock'], has_checkbox: Optional[bool] = None, is_checked: Optional[bool] = None, value: Optional[int] = None, type: Optional[str] = None, **kwargs):
+        self.label: str = label
+        self.blocks: List[RichBlock] = blocks
+        self.has_checkbox: Optional[bool] = has_checkbox
+        self.is_checked: Optional[bool] = is_checked
+        self.value: Optional[int] = value
+        self.type: Optional[str] = type
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['blocks'] = [RichBlock.de_json(block) for block in obj['blocks']]
+        return cls(**obj)
+
+
+class RichBlock(JsonDeserializable):
+    """
+    This object represents a block in a rich formatted message. Currently, it can be any of the following types:
+
+    - :class:`RichBlockParagraph`
+    - :class:`RichBlockSectionHeading`
+    - :class:`RichBlockPreformatted`
+    - :class:`RichBlockFooter`
+    - :class:`RichBlockDivider`
+    - :class:`RichBlockMathematicalExpression`
+    - :class:`RichBlockAnchor`
+    - :class:`RichBlockList`
+    - :class:`RichBlockBlockQuotation`
+    - :class:`RichBlockPullQuotation`
+    - :class:`RichBlockCollage`
+    - :class:`RichBlockSlideshow`
+    - :class:`RichBlockTable`
+    - :class:`RichBlockDetails`
+    - :class:`RichBlockMap`
+    - :class:`RichBlockAnimation`
+    - :class:`RichBlockAudio`
+    - :class:`RichBlockPhoto`
+    - :class:`RichBlockVideo`
+    - :class:`RichBlockVoiceNote`
+    - :class:`RichBlockThinking`
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblock
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlock`
+    """
+    def __init__(self, type: str, **kwargs):
+        self.type: str = type
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        type = obj['type']
+        if type == 'paragraph':
+            return RichBlockParagraph.de_json(json_string)
+        elif type == 'heading':
+            return RichBlockSectionHeading.de_json(json_string)
+        elif type == 'pre':
+            return RichBlockPreformatted.de_json(json_string)
+        elif type == 'footer':
+            return RichBlockFooter.de_json(json_string)
+        elif type == 'divider':
+            return RichBlockDivider.de_json(json_string)
+        elif type == 'mathematical_expression':
+            return RichBlockMathematicalExpression.de_json(json_string)
+        elif type == 'anchor':
+            return RichBlockAnchor.de_json(json_string)
+        elif type == 'list':
+            return RichBlockList.de_json(json_string)
+        elif type == 'blockquote':
+            return RichBlockBlockQuotation.de_json(json_string)
+        elif type == 'pullquote':
+            return RichBlockPullQuotation.de_json(json_string)
+        elif type == 'collage':
+            return RichBlockCollage.de_json(json_string)
+        elif type == 'slideshow':
+            return RichBlockSlideshow.de_json(json_string)
+        elif type == 'table':
+            return RichBlockTable.de_json(json_string)
+        elif type == 'details':
+            return RichBlockDetails.de_json(json_string)
+        elif type == 'map':
+            return RichBlockMap.de_json(json_string)
+        elif type == 'animation':
+            return RichBlockAnimation.de_json(json_string)
+        elif type == 'audio':
+            return RichBlockAudio.de_json(json_string)
+        elif type == 'photo':
+            return RichBlockPhoto.de_json(json_string)
+        elif type == 'video':
+            return RichBlockVideo.de_json(json_string)
+        elif type == 'voice_note':
+            return RichBlockVoiceNote.de_json(json_string)
+        elif type == 'thinking':
+            return RichBlockThinking.de_json(json_string)
+        return None
+    
+    
+class RichBlockParagraph(RichBlock):
+    """
+    A text paragraph, corresponding to the HTML tag <p>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockparagraph
+
+    :param type: Type of the block, always “paragraph”
+    :type type: :obj:`str`
+
+    :param text: Text of the block
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockParagraph`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='paragraph', **kwargs)
+        self.text: RichText = text
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+        
+
+class RichBlockSectionHeading(RichBlock):
+    """
+    A section heading, corresponding to the HTML tags <h1>, <h2>, <h3>, <h4>, <h5>, or <h6>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblocksectionheading
+
+    :param type: Type of the block, always “heading”
+    :type type: :obj:`str`
+
+    :param text: Text of the block
+    :type text: :class:`RichText`
+
+    :param size: Relative size of the text font; 1-6, 1 is the largest, 6 is the smallest
+    :type size: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockSectionHeading`
+    """
+    def __init__(self, text: RichText, size: int, **kwargs):
+        super().__init__(type='heading', **kwargs)
+        self.text: RichText = text
+        self.size: int = size
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+        
+
+class RichBlockPreformatted(RichBlock):
+    """
+    A preformatted text block, corresponding to the nested HTML tags <pre> and <code>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockpreformatted
+
+    :param type: Type of the block, always “pre”
+    :type type: :obj:`str`
+
+    :param text: Text of the block
+    :type text: :class:`RichText`
+
+    :param language: Optional. The programming language of the text
+    :type language: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockPreformatted`
+    """
+    def __init__(self, text: RichText, language: Optional[str] = None, **kwargs):
+        super().__init__(type='pre', **kwargs)
+        self.text: RichText = text
+        self.language: Optional[str] = language
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+
+class RichBlockFooter(RichBlock):
+    """
+    A footer, corresponding to the HTML tag <footer>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockfooter
+
+    :param type: Type of the block, always “footer”
+
+    :param text: Text of the block
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockFooter`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='footer', **kwargs)
+        self.text: RichText = text
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        return cls(**obj)
+
+
+class RichBlockDivider(RichBlock):
+    """
+    A divider, corresponding to the HTML tag <hr/>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockdivider
+
+    :param type: Type of the block, always “divider”
+    :type type: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockDivider`
+    """
+    def __init__(self, **kwargs):
+        super().__init__(type='divider', **kwargs)
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+
+
+class RichBlockMathematicalExpression(RichBlock):
+    """
+    A block with a mathematical expression in LaTeX format, corresponding to the custom HTML tag <tg-math-block>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockmathematicalexpression
+
+    :param type: Type of the block, always “mathematical_expression”
+    :type type: :obj:`str`
+
+    :param expression: The mathematical expression in LaTeX format
+    :type expression: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockMathematicalExpression`
+    """
+    def __init__(self, expression: str, **kwargs):
+        super().__init__(type='mathematical_expression', **kwargs)
+        self.expression: str = expression
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+
+
+class RichBlockAnchor(RichBlock):
+    """
+    A block with an anchor, corresponding to the HTML tag <a> with the attribute name.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockanchor
+
+    :param type: Type of the block, always “anchor”
+    :type type: :obj:`str`
+
+    :param name: The name of the anchor
+    :type name: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockAnchor`
+    """
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__(type='anchor', **kwargs)
+        self.name: str = name
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+
+
+class RichBlockList(RichBlock):
+    """
+    A list of blocks, corresponding to the HTML tag <ul> or <ol> with multiple nested tags <li>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblocklist
+
+    :param type: Type of the block, always “list”
+    :type type: :obj:`str`
+
+    :param items: Items of the list
+    :type items: :obj:`list` of :class:`RichBlockListItem`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockList`
+    """
+
+    def __init__(self, items: List['RichBlockListItem'], **kwargs):
+        super().__init__(type='list', **kwargs)
+        self.items: List[RichBlockListItem] = items
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['items'] = [RichBlockListItem.de_json(item) for item in obj['items']]
+        return cls(**obj)
+
+
+class RichBlockBlockQuotation(RichBlock):
+    """
+    A block quotation, corresponding to the HTML tag <blockquote>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockblockquote
+
+    :param type: Type of the block, always “blockquote”
+    :type type: :obj:`str`
+
+    :param blocks: Content of the block
+    :type blocks: :obj:`list` of :class:`RichBlock`
+
+    :param credit: Optional. Credit of the block
+    :type credit: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockBlockQuotation`
+    """
+    def __init__(self, blocks: List['RichBlock'], credit: Optional[RichText] = None, **kwargs):
+        super().__init__(type='blockquote', **kwargs)
+        self.blocks: List[RichBlock] = blocks
+        self.credit: Optional[RichText] = credit
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['blocks'] = [RichBlock.de_json(block) for block in obj['blocks']]
+        obj['credit'] = RichText.de_json(obj['credit']) if obj.get('credit') else None
+        return cls(**obj)
+
+
+class RichBlockPullQuotation(RichBlock):
+    """
+    A quotation with centered text, loosely corresponding to the HTML tag <aside>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockpullquotation
+
+    :param type: Type of the block, always “pullquote”
+    :type type: :obj:`str`
+
+    :param text: Text of the block
+    :type text: :class:`RichText`
+
+    :param credit: Optional. Credit of the block
+    :type credit: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockPullQuotation`
+
+    """
+    def __init__(self, text: RichText, credit: Optional[RichText] = None, **kwargs):
+        super().__init__(type='pullquote', **kwargs)
+        self.text: RichText = text
+        self.credit: Optional[RichText] = credit
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
+        obj['credit'] = RichText.de_json(obj['credit']) if obj.get('credit') else None
+        return cls(**obj)
+    
+class RichBlockCollage(RichBlock):
+    """
+    A collage, corresponding to the custom HTML tag <tg-collage>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockcollage
+
+    :param type: Type of the block, always “collage”
+    :type type: :obj:`str`
+
+    :param blocks: Elements of the collage
+    :type blocks: :obj:`list` of :class:`RichBlock`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockCollage`
+    """
+    def __init__(self, blocks: List['RichBlock'], caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='collage', **kwargs)
+        self.blocks: List[RichBlock] = blocks
+        self.caption: Optional[RichBlockCaption] = caption
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['blocks'] = [RichBlock.de_json(block) for block in obj['blocks']]
+        obj['caption'] = RichBlockCaption.de_json(obj['caption']) if obj.get('caption') else None
+        return cls(**obj)
+    
+
+class RichBlockSlideshow(RichBlock):
+    """
+    A slideshow, corresponding to the custom HTML tag <tg-slideshow>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockslideshow
+
+    :param type: Type of the block, always “slideshow”
+    :type type: :obj:`str`
+
+    :param blocks: Elements of the slideshow
+    :type blocks: :obj:`list` of :class:`RichBlock`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockSlideshow`
+    """
+    def __init__(self, blocks: List['RichBlock'], caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='slideshow', **kwargs)
+        self.blocks: List[RichBlock] = blocks
+        self.caption: Optional[RichBlockCaption] = caption
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['blocks'] = [RichBlock.de_json(block) for block in obj['blocks']]
+        obj['caption'] = RichBlockCaption.de_json(obj['caption']) if obj.get('caption') else None
+        return cls(**obj)
+    
+
+class RichBlockTable(RichBlock):
+    """
+    A table, corresponding to the HTML tag <table>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblocktable
+
+    :param type: Type of the block, always “table”
+    :type type: :obj:`str`
+
+    :param cells: Cells of the table
+    :type cells: :obj:`list` of :obj:`list` of :class:`RichBlockTableCell`
+
+    :param is_bordered: Optional. True, if the table has borders
+    :type is_bordered: :obj:`bool`
+
+    :param is_striped: Optional. True, if the table is striped
+    :type is_striped: :obj:`bool`
+
+    :param caption: Optional. Caption of the table
+    :type caption: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockTable`
+    """
+    def __init__(self, cells: List[List[RichBlockTableCell]], is_bordered: Optional[bool] = None, is_striped: Optional[bool] = None, caption: Optional[RichText] = None, **kwargs):
+        super().__init__(type='table', **kwargs)
+        self.cells: List[List[RichBlockTableCell]] = cells
+        self.is_bordered: Optional[bool] = is_bordered
+        self.is_striped: Optional[bool] = is_striped
+        self.caption: Optional[RichText] = caption
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['cells'] = [[RichBlockTableCell.de_json(cell) for cell in row] for row in obj['cells']]
+        obj['caption'] = RichText.de_json(obj['caption']) if obj.get('caption') else None
+        return cls(**obj)
+

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1694,6 +1694,7 @@ class Message(JsonDeserializable):
             opts['guest_query_id'] = obj['guest_query_id']
         if 'rich_message' in obj:
             opts['rich_message'] = RichMessage.de_json(obj['rich_message'])
+            content_type = 'rich_message'
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
     @classmethod

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -7164,7 +7164,7 @@ class InputMedia(Dictionaryable, JsonSerializable):
         :meta private:
         """
         if self.media is None:
-            raise ValueError('Invalid method call: media is None')
+            return None, None
         
         if service_utils.is_string(self.media):
             return self.to_json(), None
@@ -16308,7 +16308,7 @@ class RichBlockThinking(RichBlock):
     :return: Instance of the class
     :rtype: :class:`RichBlockThinking`
     """
-    def __init__(self, text: RichText = None, **kwargs):
+    def __init__(self, text: RichText, **kwargs):
         super().__init__(type='thinking', **kwargs)
         self.text: RichText = text
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -391,6 +391,10 @@ class ChatJoinRequest(JsonDeserializable):
     :param invite_link: Optional. Chat invite link that was used by the user to send the join request
     :type invite_link: :class:`telebot.types.ChatInviteLink`
 
+    :param query_id: Optional. Identifier of the join request query; for bots assigned to process join request only.
+        If present, then the bot must call sendChatJoinRequestWebApp or directly call answerChatJoinRequestQuery within 10 seconds.
+    :type query_id: :obj:`int`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatJoinRequest`
     """
@@ -403,13 +407,14 @@ class ChatJoinRequest(JsonDeserializable):
         obj['invite_link'] = ChatInviteLink.de_json(obj.get('invite_link'))
         return cls(**obj)
 
-    def __init__(self, chat, from_user, user_chat_id, date, bio=None, invite_link=None, **kwargs):
+    def __init__(self, chat, from_user, user_chat_id, date, bio=None, invite_link=None, query_id=None, **kwargs):
         self.chat: Chat = chat
         self.from_user: User = from_user
         self.date: str = date
         self.bio: Optional[str] = bio
         self.invite_link: Optional[ChatInviteLink] = invite_link
         self.user_chat_id: int = user_chat_id
+        self.query_id: Optional[int] = query_id
 
 
 class WebhookInfo(JsonDeserializable):
@@ -533,6 +538,9 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
     :param can_manage_bots: Optional. True, if other bots can be created to be controlled by the bot. Returned only in getMe.
     :type can_manage_bots: :obj:`bool`
 
+    :param supports_join_request_queries: Optional. True, if the bot supports join request queries and can be assigned to process them. Returned only in getMe.
+    :type supports_join_request_queries: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.User`
     """
@@ -547,7 +555,7 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
                  can_join_groups=None, can_read_all_group_messages=None, supports_inline_queries=None, 
                  is_premium=None, added_to_attachment_menu=None, can_connect_to_business=None, 
                  has_main_web_app=None, has_topics_enabled=None, allows_users_to_create_topics=None, can_manage_bots=None,
-                 supports_guest_queries=None, **kwargs):
+                 supports_guest_queries=None, supports_join_request_queries=None, **kwargs):
         self.id: int = id
         self.is_bot: bool = is_bot
         self.first_name: str = first_name
@@ -565,6 +573,7 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
         self.allows_users_to_create_topics: Optional[bool] = allows_users_to_create_topics
         self.can_manage_bots: Optional[bool] = can_manage_bots
         self.supports_guest_queries: Optional[bool] = supports_guest_queries
+        self.supports_join_request_queries: Optional[bool] = supports_join_request_queries
 
     @property
     def full_name(self) -> str:
@@ -596,7 +605,8 @@ class User(JsonDeserializable, Dictionaryable, JsonSerializable):
                 'has_topics_enabled': self.has_topics_enabled,
                 'allows_users_to_create_topics': self.allows_users_to_create_topics,
                 'can_manage_bots': self.can_manage_bots,
-                'supports_guest_queries': self.supports_guest_queries
+                'supports_guest_queries': self.supports_guest_queries,
+                'supports_join_request_queries': self.supports_join_request_queries
                 }
 
 
@@ -787,6 +797,9 @@ class ChatFullInfo(JsonDeserializable):
     :param unique_gift_colors: Optional. The color scheme based on a unique gift that must be used for the chat's name, message replies and link previews
     :type unique_gift_colors: :class:`telebot.types.UniqueGiftColors`
 
+    :param guard_bot: Optional. The bot that processes join request queries in the chat. The field is only available to chat administrators.
+    :type guard_bot: :class:`telebot.types.User`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatFullInfo`
     """
@@ -824,6 +837,8 @@ class ChatFullInfo(JsonDeserializable):
             obj['unique_gift_colors'] = UniqueGiftColors.de_json(obj['unique_gift_colors'])
         if 'first_profile_audio' in obj:
             obj['first_profile_audio'] = Audio.de_json(obj['first_profile_audio'])
+        if 'guard_bot' in obj:
+            obj['guard_bot'] = User.de_json(obj['guard_bot'])
         return cls(**obj)
 
     def __init__(self, id, type, title=None, username=None, first_name=None,
@@ -841,7 +856,7 @@ class ChatFullInfo(JsonDeserializable):
                 business_opening_hours=None, personal_chat=None, birthdate=None,
                 can_send_paid_media=None,
                 accepted_gift_types=None, is_direct_messages=None, parent_chat=None, rating=None, paid_message_star_count=None,
-                unique_gift_colors=None, first_profile_audio=None, **kwargs):
+                unique_gift_colors=None, first_profile_audio=None, guard_bot=None, **kwargs):
         self.id: int = id
         self.type: str = type
         self.title: Optional[str] = title
@@ -893,6 +908,7 @@ class ChatFullInfo(JsonDeserializable):
         self.paid_message_star_count: Optional[int] = paid_message_star_count
         self.unique_gift_colors: Optional[UniqueGiftColors] = unique_gift_colors
         self.first_profile_audio: Optional[Audio] = first_profile_audio
+        self.guard_bot: Optional[User] = guard_bot
 
 
     @property
@@ -14426,6 +14442,9 @@ class PollMedia(JsonDeserializable):
     :param document: Optional. Media is a general file, information about the file; currently, can't be received in a poll option
     :type document: :class:`Document`
 
+    :param link: Optional. The HTTP link attached to the poll option
+    :type link: :class:`Link`
+
     :param live_photo: Optional. Media is a live photo, information about the live photo
     :type live_photo: :class:`LivePhoto`
 
@@ -14450,7 +14469,7 @@ class PollMedia(JsonDeserializable):
     """
     def __init__(self, animation: Optional[Animation] = None, audio: Optional[Audio] = None, document: Optional[Document] = None,
                     live_photo: Optional[LivePhoto] = None, location: Optional[Location] = None, photo: Optional[List[PhotoSize]] = None,
-                    sticker: Optional[Sticker] = None, venue: Optional[Venue] = None, video: Optional[Video] = None, **kwargs):
+                    sticker: Optional[Sticker] = None, venue: Optional[Venue] = None, video: Optional[Video] = None, link: Optional[Link] = None):
         self.animation: Optional[Animation] = animation
         self.audio: Optional[Audio] = audio
         self.document: Optional[Document] = document
@@ -14460,6 +14479,7 @@ class PollMedia(JsonDeserializable):
         self.sticker: Optional[Sticker] = sticker
         self.venue: Optional[Venue] = venue
         self.video: Optional[Video] = video
+        self.link: Optional[Link] = link
 
     @classmethod
     def de_json(cls, json_string):
@@ -14483,12 +14503,40 @@ class PollMedia(JsonDeserializable):
             obj['venue'] = Venue.de_json(obj['venue'])
         if 'video' in obj:
             obj['video'] = Video.de_json(obj['video'])
+        if 'link' in obj:
+            obj['link'] = Link.de_json(obj['link'])
         return cls(**obj)
+
+
+class InputMediaLink(JsonDeserializable):
+    """
+    This object represents an HTTP link to be sent.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputmedialink
+
+    :param url: HTTP URL of the link
+    :type url: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`InputMediaLink`
+    """
+    def __init__(self, url: str, **kwargs):
+        self.url: str = url
+
+    def to_json(self):
+        return json.dumps(self.to_dict())
+    
+    def to_dict(self):
+        return {
+            'type': 'link',
+            'url': self.url
+        }
+    
 
 # why not..
 InputPollMedia = Union[InputMediaAnimation, InputMediaAudio, InputMediaDocument, InputMediaLivePhoto, InputMediaLocation, InputMediaPhoto, InputMediaVenue, InputMediaVideo]
 
-InputPollOptionMedia = Union[InputMediaAnimation, InputMediaLivePhoto, InputMediaLocation, InputMediaPhoto, InputMediaSticker, InputMediaVenue, InputMediaVideo]
+InputPollOptionMedia = Union[InputMediaAnimation, InputMediaLivePhoto, InputMediaLocation, InputMediaPhoto, InputMediaSticker, InputMediaVenue, InputMediaVideo, InputMediaLink]
 
     
 class LivePhoto(JsonDeserializable):
@@ -16319,4 +16367,24 @@ class InputRichMessage(Dictionaryable):
         return json.dumps(self.to_dict())
     
 
+class Link(JsonDeserializable):
+    """
+    This object represents an HTTP link.
 
+    Telegram documentation: https://core.telegram.org/bots/api#link
+
+    :param url: URL of the link
+    :type url: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`Link`
+    """
+    def __init__(self, url: str, **kwargs):
+        self.url: str = url
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+    

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -14661,58 +14661,60 @@ class RichText(JsonDeserializable):
     @classmethod
     def de_json(cls, json_string):
         if json_string is None: return None
+        if isinstance(json_string, str):
+            return json_string
         obj = cls.check_json(json_string)
-        type = obj['type']
+        type = obj.pop('type')
         if type == 'bold':
-            return RichTextBold.de_json(json_string)
+            return RichTextBold.de_json(obj)
         elif type == 'italic':
-            return RichTextItalic.de_json(json_string)
+            return RichTextItalic.de_json(obj)
         elif type == 'underline':
-            return RichTextUnderline.de_json(json_string)
+            return RichTextUnderline.de_json(obj)
         elif type == 'strikethrough':
-            return RichTextStrikethrough.de_json(json_string)
+            return RichTextStrikethrough.de_json(obj)
         elif type == 'spoiler':
-            return RichTextSpoiler.de_json(json_string)
+            return RichTextSpoiler.de_json(obj)
         elif type == 'date_time':
-            return RichTextDateTime.de_json(json_string)
+            return RichTextDateTime.de_json(obj)
         elif type == 'text_mention':
-            return RichTextTextMention.de_json(json_string)
+            return RichTextTextMention.de_json(obj)
         elif type == 'subscript':
-            return RichTextSubscript.de_json(json_string)
+            return RichTextSubscript.de_json(obj)
         elif type == 'superscript':
-            return RichTextSuperscript.de_json(json_string)
+            return RichTextSuperscript.de_json(obj)
         elif type == 'marked':
-            return RichTextMarked.de_json(json_string)
+            return RichTextMarked.de_json(obj)
         elif type == 'code':
-            return RichTextCode.de_json(json_string)
+            return RichTextCode.de_json(obj)
         elif type == 'custom_emoji':
-            return RichTextCustomEmoji.de_json(json_string)
+            return RichTextCustomEmoji.de_json(obj)
         elif type == 'mathematical_expression':
-            return RichTextMathematicalExpression.de_json(json_string)
+            return RichTextMathematicalExpression.de_json(obj)
         elif type == 'url':
-            return RichTextUrl.de_json(json_string)
+            return RichTextUrl.de_json(obj)
         elif type == 'email_address':
-            return RichTextEmailAddress.de_json(json_string)
+            return RichTextEmailAddress.de_json(obj)
         elif type == 'phone_number':
-            return RichTextPhoneNumber.de_json(json_string)
+            return RichTextPhoneNumber.de_json(obj)
         elif type == 'bank_card_number':
-            return RichTextBankCardNumber.de_json(json_string)
+            return RichTextBankCardNumber.de_json(obj)
         elif type == 'mention':
-            return RichTextMention.de_json(json_string)
+            return RichTextMention.de_json(obj)
         elif type == 'hashtag':
-            return RichTextHashtag.de_json(json_string)
+            return RichTextHashtag.de_json(obj)
         elif type == 'cashtag':
-            return RichTextCashtag.de_json(json_string)
+            return RichTextCashtag.de_json(obj)
         elif type == 'bot_command':
-            return RichTextBotCommand.de_json(json_string)
+            return RichTextBotCommand.de_json(obj)
         elif type == 'anchor':
-            return RichTextAnchor.de_json(json_string)
+            return RichTextAnchor.de_json(obj)
         elif type == 'anchor_link':
-            return RichTextAnchorLink.de_json(json_string)
+            return RichTextAnchorLink.de_json(obj)
         elif type == 'reference':
-            return RichTextReference.de_json(json_string)
+            return RichTextReference.de_json(obj)
         elif type == 'reference_link':
-            return RichTextReferenceLink.de_json(json_string)
+            return RichTextReferenceLink.de_json(obj)
         return None
     
 class RichTextBold(RichText):
@@ -15585,49 +15587,49 @@ class RichBlock(JsonDeserializable):
     def de_json(cls, json_string):
         if json_string is None: return None
         obj = cls.check_json(json_string)
-        type = obj['type']
+        type = obj.pop('type', None)
         if type == 'paragraph':
-            return RichBlockParagraph.de_json(json_string)
+            return RichBlockParagraph.de_json(obj)
         elif type == 'heading':
-            return RichBlockSectionHeading.de_json(json_string)
+            return RichBlockSectionHeading.de_json(obj)
         elif type == 'pre':
-            return RichBlockPreformatted.de_json(json_string)
+            return RichBlockPreformatted.de_json(obj)
         elif type == 'footer':
-            return RichBlockFooter.de_json(json_string)
+            return RichBlockFooter.de_json(obj)
         elif type == 'divider':
-            return RichBlockDivider.de_json(json_string)
+            return RichBlockDivider.de_json(obj)
         elif type == 'mathematical_expression':
-            return RichBlockMathematicalExpression.de_json(json_string)
+            return RichBlockMathematicalExpression.de_json(obj)
         elif type == 'anchor':
-            return RichBlockAnchor.de_json(json_string)
+            return RichBlockAnchor.de_json(obj)
         elif type == 'list':
-            return RichBlockList.de_json(json_string)
+            return RichBlockList.de_json(obj)
         elif type == 'blockquote':
-            return RichBlockBlockQuotation.de_json(json_string)
+            return RichBlockBlockQuotation.de_json(obj)
         elif type == 'pullquote':
-            return RichBlockPullQuotation.de_json(json_string)
+            return RichBlockPullQuotation.de_json(obj)
         elif type == 'collage':
-            return RichBlockCollage.de_json(json_string)
+            return RichBlockCollage.de_json(obj)
         elif type == 'slideshow':
-            return RichBlockSlideshow.de_json(json_string)
+            return RichBlockSlideshow.de_json(obj)
         elif type == 'table':
-            return RichBlockTable.de_json(json_string)
+            return RichBlockTable.de_json(obj)
         elif type == 'details':
-            return RichBlockDetails.de_json(json_string)
+            return RichBlockDetails.de_json(obj)
         elif type == 'map':
-            return RichBlockMap.de_json(json_string)
+            return RichBlockMap.de_json(obj)
         elif type == 'animation':
-            return RichBlockAnimation.de_json(json_string)
+            return RichBlockAnimation.de_json(obj)
         elif type == 'audio':
-            return RichBlockAudio.de_json(json_string)
+            return RichBlockAudio.de_json(obj)
         elif type == 'photo':
-            return RichBlockPhoto.de_json(json_string)
+            return RichBlockPhoto.de_json(obj)
         elif type == 'video':
-            return RichBlockVideo.de_json(json_string)
+            return RichBlockVideo.de_json(obj)
         elif type == 'voice_note':
-            return RichBlockVoiceNote.de_json(json_string)
+            return RichBlockVoiceNote.de_json(obj)
         elif type == 'thinking':
-            return RichBlockThinking.de_json(json_string)
+            return RichBlockThinking.de_json(obj)
         return None
     
     

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -14674,7 +14674,7 @@ class RichText(JsonDeserializable):
         if isinstance(json_string, list):
             return [RichText.de_json(item) for item in json_string]
         obj = cls.check_json(json_string)
-        type = obj.pop('type')
+        type = obj.pop('type', None)
         if type == 'bold':
             return RichTextBold.de_json(obj)
         elif type == 'italic':

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -393,7 +393,7 @@ class ChatJoinRequest(JsonDeserializable):
 
     :param query_id: Optional. Identifier of the join request query; for bots assigned to process join request only.
         If present, then the bot must call sendChatJoinRequestWebApp or directly call answerChatJoinRequestQuery within 10 seconds.
-    :type query_id: :obj:`int`
+    :type query_id: :obj:`str`
 
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatJoinRequest`
@@ -414,7 +414,7 @@ class ChatJoinRequest(JsonDeserializable):
         self.bio: Optional[str] = bio
         self.invite_link: Optional[ChatInviteLink] = invite_link
         self.user_chat_id: int = user_chat_id
-        self.query_id: Optional[int] = query_id
+        self.query_id: Optional[str] = query_id
 
 
 class WebhookInfo(JsonDeserializable):
@@ -7113,9 +7113,9 @@ class InputMedia(Dictionaryable, JsonSerializable):
     * :class:`InputMediaPhoto`
     * :class:`InputMediaVideo`
     """
-    def __init__(self, type, media, caption=None, parse_mode=None, caption_entities=None, thumbnail=None):
+    def __init__(self, type, media=None, caption=None, parse_mode=None, caption_entities=None, thumbnail=None):
         self.type: str = type
-        self.media: str = media
+        self.media: Optional[str] = media
         self.caption: Optional[str] = caption
         self.parse_mode: Optional[str] = parse_mode
         self.caption_entities: Optional[List[MessageEntity]] = caption_entities
@@ -7146,7 +7146,9 @@ class InputMedia(Dictionaryable, JsonSerializable):
         return json.dumps(self.to_dict())
 
     def to_dict(self):
-        json_dict = {'type': self.type, 'media': self._media_dic}
+        json_dict = {'type': self.type}
+        if self.media:
+            json_dict['media'] = self._media_dic
         if self._thumbnail_dic:
             json_dict['thumbnail'] = self._thumbnail_dic
         if self.caption:
@@ -14509,7 +14511,7 @@ class PollMedia(JsonDeserializable):
         return cls(**obj)
 
 
-class InputMediaLink(JsonDeserializable):
+class InputMediaLink(InputMedia):
     """
     This object represents an HTTP link to be sent.
 
@@ -14521,18 +14523,19 @@ class InputMediaLink(JsonDeserializable):
     :return: Instance of the class
     :rtype: :class:`InputMediaLink`
     """
+
     def __init__(self, url: str, **kwargs):
+        super().__init__(type='link', **kwargs)
         self.url: str = url
 
     def to_json(self):
         return json.dumps(self.to_dict())
     
     def to_dict(self):
-        return {
-            'type': 'link',
-            'url': self.url
-        }
-    
+        data = super().to_dict()
+        data['url'] = self.url
+        return data
+
 
 # why not..
 InputPollMedia = Union[InputMediaAnimation, InputMediaAudio, InputMediaDocument, InputMediaLivePhoto, InputMediaLocation, InputMediaPhoto, InputMediaVenue, InputMediaVideo]
@@ -14862,12 +14865,20 @@ class RichTextDateTime(RichText):
     :param text: The text
     :type text: :class:`RichText`
 
+    :param unix_time: The Unix time associated with the entity
+    :type unix_time: :obj:`int`
+
+    :param date_time_format: The string that defines the formatting of the date and time. See date-time entity formatting for more details.
+    :type date_time_format: :obj:`str`
+
     :return: Instance of the class
     :rtype: :class:`RichTextDateTime`
     """
-    def __init__(self, text: RichText, **kwargs):
+    def __init__(self, text: RichText, unix_time: int, date_time_format: str, **kwargs):
         super().__init__(type='date_time', **kwargs)
         self.text: RichText = text
+        self.unix_time: int = unix_time
+        self.date_time_format: str = date_time_format
 
     @classmethod
     def de_json(cls, json_string):
@@ -15491,14 +15502,14 @@ class RichBlockTableCell(JsonDeserializable):
     :return: Instance of the class
     :rtype: :class:`RichBlockTableCell`
     """
-    def __init__(self, text: Optional[RichText] = None, is_header: Optional[bool] = None, colspan: Optional[int] = None, rowspan: Optional[int] = None,
-                    align: Optional[str] = None, valign: Optional[str] = None, **kwargs):
+    def __init__(self, align: str, valign: str, text: Optional[RichText] = None, is_header: Optional[bool] = None,
+                 colspan: Optional[int] = None, rowspan: Optional[int] = None, **kwargs):
         self.text: Optional[RichText] = text
         self.is_header: Optional[bool] = is_header
         self.colspan: Optional[int] = colspan
         self.rowspan: Optional[int] = rowspan
-        self.align: Optional[str] = align
-        self.valign: Optional[str] = valign
+        self.align: str = align
+        self.valign: str = valign
 
     @classmethod
     def de_json(cls, json_string):
@@ -16255,9 +16266,6 @@ class RichBlockVoiceNote(RichBlock):
     :param voice_note: The voice note
     :type voice_note: :class:`Voice`
 
-    :param has_spoiler: Optional. True, if the media preview is covered by a spoiler animation
-    :type has_spoiler: :obj:`bool`
-
     :param caption: Optional. Caption of the block
     :type caption: :class:`RichBlockCaption`
 
@@ -16265,10 +16273,9 @@ class RichBlockVoiceNote(RichBlock):
     :rtype: :class:`RichBlockVoiceNote`
 
     """
-    def __init__(self, voice_note: Voice, has_spoiler: Optional[bool] = None, caption: Optional[RichBlockCaption] = None, **kwargs):
+    def __init__(self, voice_note: Voice, caption: Optional[RichBlockCaption] = None, **kwargs):
         super().__init__(type='voice_note', **kwargs)
         self.voice_note: Voice = voice_note
-        self.has_spoiler: Optional[bool] = has_spoiler
         self.caption: Optional[RichBlockCaption] = caption
 
     @classmethod
@@ -16285,14 +16292,21 @@ class RichBlockThinking(RichBlock):
     A block with a “Thinking…” placeholder, corresponding to the custom HTML tag <tg-thinking>.
     The block may be used only in sendRichMessageDraft, therefore it can't be received in messages
 
+    Telegram documentation: https://core.telegram.org/bots/api#richblockthinking
+
     :param type: Type of the block, always “thinking”
     :type type: :obj:`str`
+
+    :param text: Text of the block. See https://t.me/addemoji/AIActions for examples of custom emoji,
+        which are recommended for usage in the block.
+    :type text: :class:`RichText`
 
     :return: Instance of the class
     :rtype: :class:`RichBlockThinking`
     """
-    def __init__(self, **kwargs):
+    def __init__(self, text: RichText = None, **kwargs):
         super().__init__(type='thinking', **kwargs)
+        self.text: RichText = text
 
     @classmethod
     def de_json(cls, json_string):

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -7147,7 +7147,7 @@ class InputMedia(Dictionaryable, JsonSerializable):
 
     def to_dict(self):
         json_dict = {'type': self.type}
-        if self.media:
+        if self.media is not None:
             json_dict['media'] = self._media_dic
         if self._thumbnail_dic:
             json_dict['thumbnail'] = self._thumbnail_dic
@@ -7163,6 +7163,9 @@ class InputMedia(Dictionaryable, JsonSerializable):
         """
         :meta private:
         """
+        if self.media is None:
+            raise ValueError('Invalid method call: media is None')
+        
         if service_utils.is_string(self.media):
             return self.to_json(), None
 
@@ -14472,7 +14475,8 @@ class PollMedia(JsonDeserializable):
     """
     def __init__(self, animation: Optional[Animation] = None, audio: Optional[Audio] = None, document: Optional[Document] = None,
                     live_photo: Optional[LivePhoto] = None, location: Optional[Location] = None, photo: Optional[List[PhotoSize]] = None,
-                    sticker: Optional[Sticker] = None, venue: Optional[Venue] = None, video: Optional[Video] = None, link: Optional[Link] = None):
+                    sticker: Optional[Sticker] = None, venue: Optional[Venue] = None, video: Optional[Video] = None, link: Optional[Link] = None,
+                    **kwargs):
         self.animation: Optional[Animation] = animation
         self.audio: Optional[Audio] = audio
         self.document: Optional[Document] = document
@@ -16312,6 +16316,7 @@ class RichBlockThinking(RichBlock):
     def de_json(cls, json_string):
         if json_string is None: return None
         obj = cls.check_json(json_string)
+        obj['text'] = RichText.de_json(obj['text'])
         return cls(**obj)
 
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1102,6 +1102,9 @@ class Message(JsonDeserializable):
     :param effect_id: Optional. Unique identifier of the message effect added to the message
     :type effect_id: :obj:`str`
 
+    :param rich_message: Optional. Message is a rich formatted message
+    :type rich_message: :class:`telebot.types.RichMessage`
+
     :param animation: Optional. Message is an animation, information about the animation. For backward
         compatibility, when this field is set, the document field will also be set
     :type animation: :class:`telebot.types.Animation`
@@ -1673,6 +1676,8 @@ class Message(JsonDeserializable):
             opts['guest_bot_caller_chat'] = Chat.de_json(obj['guest_bot_caller_chat'])
         if 'guest_query_id' in obj:
             opts['guest_query_id'] = obj['guest_query_id']
+        if 'rich_message' in obj:
+            opts['rich_message'] = RichMessage.de_json(obj['rich_message'])
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
     @classmethod
@@ -1819,6 +1824,7 @@ class Message(JsonDeserializable):
         self.guest_bot_caller_chat: Optional[Chat] = None
         self.guest_query_id: Optional[str] = None
         self.live_photo: Optional[LivePhoto] = None
+        self.rich_message: Optional[RichMessage] = None
 
         for key in options:
             setattr(self, key, options[key])
@@ -4646,8 +4652,29 @@ class InputInvoiceMessageContent(Dictionaryable):
         if self.is_flexible is not None:
             json_dict['is_flexible'] = self.is_flexible
         return json_dict
+    
+class InputRichMessageContent(Dictionaryable):
+    """
+    This object represents the content of a rich message to be sent as the result of an inline query.
 
-InputMessageContent = Union[InputTextMessageContent, InputLocationMessageContent, InputVenueMessageContent, InputContactMessageContent, InputInvoiceMessageContent]
+    :param rich_message: The message to be sent
+    :type rich_message: :class:`InputRichMessage`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichMessageContent`
+
+    """
+    def __init__(self, rich_message: InputRichMessage, **kwargs):
+        self.rich_message: InputRichMessage = rich_message
+
+    def to_dict(self) -> dict:
+        return {'rich_message': self.rich_message.to_dict()}
+    
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+
+InputMessageContent = Union[InputTextMessageContent, InputLocationMessageContent, InputVenueMessageContent, InputContactMessageContent, InputInvoiceMessageContent, InputRichMessageContent]
 
 class ChosenInlineResult(JsonDeserializable):
     """
@@ -15940,4 +15967,356 @@ class RichBlockTable(RichBlock):
         obj['cells'] = [[RichBlockTableCell.de_json(cell) for cell in row] for row in obj['cells']]
         obj['caption'] = RichText.de_json(obj['caption']) if obj.get('caption') else None
         return cls(**obj)
+
+
+class RichBlockDetails(RichBlock):
+    """
+    An expandable block for details disclosure, corresponding to the HTML tag <details>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockdetails
+
+    :param type: Type of the block, always “details”
+    :type type: :obj:`str`
+
+    :param summary: Always shown summary of the block
+    :type summary: :class:`RichText`
+
+    :param blocks: Content of the block
+    :type blocks: :obj:`list` of :class:`RichBlock`
+
+    :param is_open: Optional. True, if the content of the block is visible by default
+    :type is_open: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockDetails`
+    """
+    def __init__(self, summary: RichText, blocks: List[RichBlock], is_open: Optional[bool] = None, **kwargs):
+        super().__init__(type='details', **kwargs)
+        self.summary: RichText = summary
+        self.blocks: List[RichBlock] = blocks
+        self.is_open: Optional[bool] = is_open
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['summary'] = RichText.de_json(obj['summary'])
+        obj['blocks'] = [RichBlock.de_json(block) for block in obj['blocks']]
+        return cls(**obj)
+    
+    
+class RichBlockMap(RichBlock):
+    """
+    A block with a map, corresponding to the custom HTML tag <tg-map>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockmap
+
+    :param type: Type of the block, always “map”
+    :type type: :obj:`str`
+
+    :param location: Location of the center of the map
+    :type location: :class:`Location`
+
+    :param zoom: Map zoom level; 13-20
+    :type zoom: :obj:`int`
+
+    :param width: Expected width of the map
+    :type width: :obj:`int`
+
+    :param height: Expected height of the map
+    :type height: :obj:`int`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockMap`
+    """
+    def __init__(self, location: Location, zoom: int, width: int, height: int, caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='map', **kwargs)
+        self.location: Location = location
+        self.zoom: int = zoom
+        self.width: int = width
+        self.height: int = height
+        self.caption: Optional[RichBlockCaption] = caption
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['location'] = Location.de_json(obj['location'])
+        obj['caption'] = RichBlockCaption.de_json(obj['caption']) if obj.get('caption') else None
+        return cls(**obj)
+    
+
+class RichBlockAnimation(RichBlock):
+    """
+    A block with an animation, corresponding to the HTML tag <video>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockanimation
+
+    :param type: Type of the block, always “animation”
+    :type type: :obj:`str`
+
+    :param animation: The animation
+    :type animation: :class:`Animation`
+
+    :param has_spoiler: Optional. True, if the media preview is covered by a spoiler animation
+    :type has_spoiler: :obj:`bool`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockAnimation`
+
+    """
+    def __init__(self, animation: Animation, has_spoiler: Optional[bool] = None, caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='animation', **kwargs)
+        self.animation: Animation = animation
+        self.has_spoiler: Optional[bool] = has_spoiler
+        self.caption: Optional[RichBlockCaption] = caption
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['animation'] = Animation.de_json(obj['animation'])
+        obj['caption'] = RichBlockCaption.de_json(obj['caption']) if obj.get('caption') else None
+        return cls(**obj)
+    
+
+class RichBlockAudio(RichBlock):
+    """
+    A block with a music file, corresponding to the HTML tag <audio>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockaudio
+
+    :param type: Type of the block, always “audio”
+    :type type: :obj:`str`
+
+    :param audio: The audio
+    :type audio: :class:`Audio`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockAudio`
+    """
+    def __init__(self, audio: Audio, caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='audio', **kwargs)
+        self.audio: Audio = audio
+        self.caption: Optional[RichBlockCaption] = caption
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['audio'] = Audio.de_json(obj['audio'])
+        obj['caption'] = RichBlockCaption.de_json(obj['caption']) if obj.get('caption') else None
+        return cls(**obj)
+    
+
+class RichBlockPhoto(RichBlock):
+    """
+    A block with a photo, corresponding to the HTML tag <img>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockphoto
+
+    :param type: Type of the block, always “photo”
+    :type type: :obj:`str`
+
+    :param photo: Available sizes of the photo
+    :type photo: :obj:`list` of :class:`PhotoSize`
+
+    :param has_spoiler: Optional. True, if the media preview is covered by a spoiler animation
+    :type has_spoiler: :obj:`bool`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockPhoto`
+    """
+    def __init__(self, photo: List[PhotoSize], has_spoiler: Optional[bool] = None, caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='photo', **kwargs)
+        self.photo: List[PhotoSize] = photo
+        self.has_spoiler: Optional[bool] = has_spoiler
+        self.caption: Optional[RichBlockCaption] = caption
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['photo'] = [PhotoSize.de_json(photo) for photo in obj['photo']]
+        obj['caption'] = RichBlockCaption.de_json(obj['caption']) if obj.get('caption') else None
+        return cls(**obj)
+    
+
+class RichBlockVideo(RichBlock):
+    """
+    A block with a video, corresponding to the HTML tag <video>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockvideo
+
+    :param type: Type of the block, always “video”
+    :type type: :obj:`str`
+
+    :param video: The video
+    :type video: :class:`Video`
+
+    :param has_spoiler: Optional. True, if the media preview is covered by a spoiler animation
+    :type has_spoiler: :obj:`bool`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockVideo`
+    """
+    def __init__(self, video: Video, has_spoiler: Optional[bool] = None, caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='video', **kwargs)
+        self.video: Video = video
+        self.has_spoiler: Optional[bool] = has_spoiler
+        self.caption: Optional[RichBlockCaption] = caption
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['video'] = Video.de_json(obj['video'])
+        obj['caption'] = RichBlockCaption.de_json(obj['caption']) if obj.get('caption') else None
+        return cls(**obj)
+
+
+class RichBlockVoiceNote(RichBlock):
+    """
+    A block with a voice note, corresponding to the HTML tag <audio>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richblockvoicenote
+
+    :param type: Type of the block, always “voice_note”
+    :type type: :obj:`str`
+
+    :param voice_note: The voice note
+    :type voice_note: :class:`Voice`
+
+    :param has_spoiler: Optional. True, if the media preview is covered by a spoiler animation
+    :type has_spoiler: :obj:`bool`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockVoiceNote`
+
+    """
+    def __init__(self, voice_note: Voice, has_spoiler: Optional[bool] = None, caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='voice_note', **kwargs)
+        self.voice_note: Voice = voice_note
+        self.has_spoiler: Optional[bool] = has_spoiler
+        self.caption: Optional[RichBlockCaption] = caption
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['voice_note'] = Voice.de_json(obj['voice_note'])
+        obj['caption'] = RichBlockCaption.de_json(obj['caption']) if obj.get('caption') else None
+        return cls(**obj)
+
+
+class RichBlockThinking(RichBlock):
+    """
+    A block with a “Thinking…” placeholder, corresponding to the custom HTML tag <tg-thinking>.
+    The block may be used only in sendRichMessageDraft, therefore it can't be received in messages
+
+    :param type: Type of the block, always “thinking”
+    :type type: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`RichBlockThinking`
+    """
+    def __init__(self, **kwargs):
+        super().__init__(type='thinking', **kwargs)
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+
+
+class RichMessage(JsonDeserializable):
+    """
+    This object represents a rich formatted message.
+
+    Telegram documentation: https://core.telegram.org/bots/api#richmessage
+
+    :param blocks: Content of the message
+    :type blocks: :obj:`list` of :class:`RichBlock`
+
+    :param is_rtl: Optional. True, if the rich message must be shown right-to-left
+    :type is_rtl: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`RichMessage`
+    """
+    def __init__(self, blocks: List['RichBlock'], is_rtl: Optional[bool] = None, **kwargs):
+        self.blocks: List[RichBlock] = blocks
+        self.is_rtl: Optional[bool] = is_rtl
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['blocks'] = [RichBlock.de_json(block) for block in obj['blocks']]
+        return cls(**obj)
+
+
+class InputRichMessage(Dictionaryable):
+    """
+    This object represents a rich message to be sent. Exactly one of the fields html or markdown must be used.
+
+    :param html: Optional. Content of the rich message to send described using HTML formatting.
+        See rich message formatting options for more details.
+    :type html: :obj:`str`
+
+    :param markdown: Optional. Content of the rich message to send described using Markdown formatting.
+    See rich message formatting options for more details.
+    :type markdown: :obj:`str`
+
+    :param is_rtl: Optional. Pass True if the rich message must be shown right-to-left
+    :type is_rtl: :obj:`bool`
+
+    :param skip_entity_detection: Optional. Pass True to skip automatic detection of entities
+        (e.g., URLs, email addresses, username mentions, hashtags, cashtags, bot commands, or phone numbers) in the text
+    :type skip_entity_detection: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichMessage`
+    """
+    def __init__(self, html: Optional[str] = None, markdown: Optional[str] = None, is_rtl: Optional[bool] = None, skip_entity_detection: Optional[bool] = None, **kwargs):
+        self.html: Optional[str] = html
+        self.markdown: Optional[str] = markdown
+        self.is_rtl: Optional[bool] = is_rtl
+        self.skip_entity_detection: Optional[bool] = skip_entity_detection
+
+    def to_dict(self) -> dict:
+        data = {}
+        if self.html is not None:
+            data['html'] = self.html
+        if self.markdown is not None:
+            data['markdown'] = self.markdown
+        if self.is_rtl is not None:
+            data['is_rtl'] = self.is_rtl
+        if self.skip_entity_detection is not None:
+            data['skip_entity_detection'] = self.skip_entity_detection
+        return data
+    
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+    
+
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -14663,6 +14663,8 @@ class RichText(JsonDeserializable):
         if json_string is None: return None
         if isinstance(json_string, str):
             return json_string
+        if isinstance(json_string, list):
+            return [RichText.de_json(item) for item in json_string]
         obj = cls.check_json(json_string)
         type = obj.pop('type')
         if type == 'bold':


### PR DESCRIPTION
**Rich Messages**

- [x] Added support for [Rich Messages](https://core.telegram.org/bots/features#rich-messages), allowing bots to send highly structured text and stream AI-generated replies with seamless rich formatting.
- [x] Added the classes [RichTextBold](https://core.telegram.org/bots/api#richtextbold), [RichTextItalic](https://core.telegram.org/bots/api#richtextitalic), [RichTextUnderline](https://core.telegram.org/bots/api#richtextunderline), [RichTextStrikethrough](https://core.telegram.org/bots/api#richtextstrikethrough), [RichTextSpoiler](https://core.telegram.org/bots/api#richtextspoiler), [RichTextDateTime](https://core.telegram.org/bots/api#richtextdatetime), [RichTextTextMention](https://core.telegram.org/bots/api#richtexttextmention), [RichTextSubscript](https://core.telegram.org/bots/api#richtextsubscript), [RichTextSuperscript](https://core.telegram.org/bots/api#richtextsuperscript), [RichTextMarked](https://core.telegram.org/bots/api#richtextmarked), [RichTextCode](https://core.telegram.org/bots/api#richtextcode), [RichTextCustomEmoji](https://core.telegram.org/bots/api#richtextcustomemoji), [RichTextMathematicalExpression](https://core.telegram.org/bots/api#richtextmathematicalexpression), [RichTextUrl](https://core.telegram.org/bots/api#richtexturl), [RichTextEmailAddress](https://core.telegram.org/bots/api#richtextemailaddress), [RichTextPhoneNumber](https://core.telegram.org/bots/api#richtextphonenumber), [RichTextBankCardNumber](https://core.telegram.org/bots/api#richtextbankcardnumber), [RichTextMention](https://core.telegram.org/bots/api#richtextmention), [RichTextHashtag](https://core.telegram.org/bots/api#richtexthashtag), [RichTextCashtag](https://core.telegram.org/bots/api#richtextcashtag), [RichTextBotCommand](https://core.telegram.org/bots/api#richtextbotcommand), [RichTextAnchor](https://core.telegram.org/bots/api#richtextanchor), [RichTextAnchorLink](https://core.telegram.org/bots/api#richtextanchorlink), [RichTextReference](https://core.telegram.org/bots/api#richtextreference) and [RichTextReferenceLink](https://core.telegram.org/bots/api#richtextreferencelink), which represent different types of rich formatted text.
- [x] Added the class [RichText](https://core.telegram.org/bots/api#richtext), which represents rich formatted text.
- [x] Added the class [RichBlockCaption](https://core.telegram.org/bots/api#richblockcaption), which represents the caption of a rich formatted text.
- [x] Added the class [RichBlockTableCell](https://core.telegram.org/bots/api#richblocktablecell), which represents a cell in a table.
- [x] Added the class [RichBlockListItem](https://core.telegram.org/bots/api#richblocklistitem), which represents an item in a list.
- [x] Added the classes [RichBlockParagraph](https://core.telegram.org/bots/api#richblockparagraph), [RichBlockSectionHeading](https://core.telegram.org/bots/api#richblocksectionheading), [RichBlockPreformatted](https://core.telegram.org/bots/api#richblockpreformatted), [RichBlockFooter](https://core.telegram.org/bots/api#richblockfooter), [RichBlockDivider](https://core.telegram.org/bots/api#richblockdivider), [RichBlockMathematicalExpression](https://core.telegram.org/bots/api#richblockmathematicalexpression), [RichBlockAnchor](https://core.telegram.org/bots/api#richblockanchor), [RichBlockList](https://core.telegram.org/bots/api#richblocklist), [RichBlockBlockQuotation](https://core.telegram.org/bots/api#richblockblockquotation), [RichBlockPullQuotation](https://core.telegram.org/bots/api#richblockpullquotation), [RichBlockCollage](https://core.telegram.org/bots/api#richblockcollage), [RichBlockSlideshow](https://core.telegram.org/bots/api#richblockslideshow), [RichBlockTable](https://core.telegram.org/bots/api#richblocktable), [RichBlockDetails](https://core.telegram.org/bots/api#richblockdetails), [RichBlockMap](https://core.telegram.org/bots/api#richblockmap), [RichBlockAnimation](https://core.telegram.org/bots/api#richblockanimation), [RichBlockAudio](https://core.telegram.org/bots/api#richblockaudio), [RichBlockPhoto](https://core.telegram.org/bots/api#richblockphoto), [RichBlockVideo](https://core.telegram.org/bots/api#richblockvideo), [RichBlockVoiceNote](https://core.telegram.org/bots/api#richblockvoicenote) and [RichBlockThinking](https://core.telegram.org/bots/api#richblockthinking), which represent different types of blocks in a rich formatted message.
- [x] Added the class [RichBlock](https://core.telegram.org/bots/api#richblock), which represents a block in a rich formatted message.
- [x] Added the class [RichMessage](https://core.telegram.org/bots/api#richmessage), which represents a rich formatted message.
- [x] Added the field rich_message to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the class [InputRichMessage](https://core.telegram.org/bots/api#inputrichmessage), describing a rich message to send.
- [x] Added the class [InputRichMessageContent](https://core.telegram.org/bots/api#inputrichmessagecontent) and allowed it to be used as [InputMessageContent](https://core.telegram.org/bots/api#inputmessagecontent) in results of inline, guest, and Web App queries.
- [x] Added the method [sendRichMessage](https://core.telegram.org/bots/api#sendrichmessage), allowing bots to send rich messages.
- [x] Added the method [sendRichMessageDraft](https://core.telegram.org/bots/api#sendrichmessagedraft), allowing bots to stream partial rich messages.
- [x] Added the parameter rich_message to the method [editMessageText](https://core.telegram.org/bots/api#editmessagetext), allowing bots to edit rich messages.

**Join Request Queries**

- [x] Added the field supports_join_request_queries to the class [User](https://core.telegram.org/bots/api#user).
- [x] Added the field guard_bot to the class [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo).
- [x] Added the field query_id to the class [ChatJoinRequest](https://core.telegram.org/bots/api#chatjoinrequest).
- [x] Added the method [answerChatJoinRequestQuery](https://core.telegram.org/bots/api#answerchatjoinrequestquery).
- [x] Added the method [sendChatJoinRequestWebApp](https://core.telegram.org/bots/api#sendchatjoinrequestwebapp).

**Polls**


- [x] Added the class [Link](https://core.telegram.org/bots/api#link) and the field link to the class [PollMedia](https://core.telegram.org/bots/api#pollmedia).
- [x] Added the class [InputMediaLink](https://core.telegram.org/bots/api#inputmedialink) and allowed it to be used as [InputPollOptionMedia](https://core.telegram.org/bots/api#inputpolloptionmedia).