### PR TITLE
Botapi 10.2

### DIFF
--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1766,7 +1766,9 @@ class TeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send text messages.
 
@@ -1833,6 +1835,14 @@ class TeleBot:
             required if the message is sent to a direct messages chat
         :type direct_messages_topic_id: :obj:`int`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :param suggested_post_parameters: A JSON-serialized object containing the parameters of the suggested post to send;
             for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post
             is automatically declined.
@@ -1887,7 +1897,7 @@ class TeleBot:
                 timeout=timeout, entities=entities, protect_content=protect_content, message_thread_id=message_thread_id,
                 reply_parameters=reply_parameters, link_preview_options=link_preview_options, business_connection_id=business_connection_id,
                 message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast, direct_messages_topic_id=direct_messages_topic_id,
-                suggested_post_parameters=suggested_post_parameters
+                suggested_post_parameters=suggested_post_parameters, receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
             )
         )
 
@@ -2537,7 +2547,9 @@ class TeleBot:
             show_caption_above_media: Optional[bool]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send photos. On success, the sent Message is returned.
 
@@ -2611,6 +2623,14 @@ class TeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2644,7 +2664,8 @@ class TeleBot:
                 message_thread_id=message_thread_id, has_spoiler=has_spoiler, reply_parameters=reply_parameters,
                 business_connection_id=business_connection_id, message_effect_id=message_effect_id,
                 show_caption_above_media=show_caption_above_media, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
             )
         )
     
@@ -2760,7 +2781,9 @@ class TeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player.
         Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size,
@@ -2849,6 +2872,14 @@ class TeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -2885,7 +2916,8 @@ class TeleBot:
                 timeout=timeout, thumbnail=thumbnail, caption_entities=caption_entities, protect_content=protect_content,
                 message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id,
                 message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
             )
         )
 
@@ -2906,7 +2938,9 @@ class TeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .OGG file encoded with OPUS, or in .MP3 format, or in .M4A format (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
 
@@ -2976,6 +3010,14 @@ class TeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
@@ -3007,7 +3049,7 @@ class TeleBot:
                 caption_entities=caption_entities, protect_content=protect_content,
                 message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id,
                 message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast, direct_messages_topic_id=direct_messages_topic_id,
-                suggested_post_parameters=suggested_post_parameters
+                suggested_post_parameters=suggested_post_parameters, receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
             )
         )
 
@@ -3033,7 +3075,9 @@ class TeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send general files.
 
@@ -3115,6 +3159,14 @@ class TeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3160,7 +3212,8 @@ class TeleBot:
                 disable_content_type_detection=disable_content_type_detection, visible_file_name=visible_file_name,
                 protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters,
                 business_connection_id=business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters)
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id)
         )
 
 
@@ -3181,7 +3234,9 @@ class TeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers.
         On success, the sent Message is returned.
@@ -3246,6 +3301,14 @@ class TeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3281,7 +3344,8 @@ class TeleBot:
                 protect_content=protect_content, message_thread_id=message_thread_id, emoji=emoji,
                 reply_parameters=reply_parameters, business_connection_id=business_connection_id,
                 message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters)
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id,receiver_user_id=receiver_user_id, callback_query_id=callback_query_id)
         )
 
 
@@ -3313,7 +3377,9 @@ class TeleBot:
             cover: Optional[Union[Any, str]]=None,
             start_timestamp: Optional[int]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
 
@@ -3416,6 +3482,14 @@ class TeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3459,7 +3533,7 @@ class TeleBot:
                 reply_parameters=reply_parameters, business_connection_id=business_connection_id, message_effect_id=message_effect_id,
                 show_caption_above_media=show_caption_above_media, allow_paid_broadcast=allow_paid_broadcast,
                 cover=cover, start_timestamp=start_timestamp, direct_messages_topic_id=direct_messages_topic_id,
-                suggested_post_parameters=suggested_post_parameters)
+                suggested_post_parameters=suggested_post_parameters, receiver_user_id=receiver_user_id, callback_query_id=callback_query_id)
         )
 
 
@@ -3487,7 +3561,9 @@ class TeleBot:
             show_caption_above_media: Optional[bool]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
@@ -3579,6 +3655,14 @@ class TeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3616,7 +3700,8 @@ class TeleBot:
                 width=width, height=height, message_thread_id=message_thread_id, reply_parameters=reply_parameters,
                 has_spoiler=has_spoiler, business_connection_id=business_connection_id, message_effect_id=message_effect_id,
                 show_caption_above_media=show_caption_above_media, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters)
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id)
             )
 
 
@@ -3638,7 +3723,9 @@ class TeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         As of v.4.0, Telegram clients support rounded square MPEG4 videos of up to 1 minute long.
         Use this method to send video messages. On success, the sent Message is returned.
@@ -3712,6 +3799,14 @@ class TeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3746,7 +3841,8 @@ class TeleBot:
                 disable_notification=disable_notification, timeout=timeout, thumbnail=thumbnail,
                 protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters,
                 business_connection_id=business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters)
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id)
         )
 
     def send_paid_media(
@@ -3951,7 +4047,9 @@ class TeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send point on the map. On success, the sent Message is returned.
 
@@ -4023,6 +4121,14 @@ class TeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4054,7 +4160,7 @@ class TeleBot:
                 heading=heading, proximity_alert_radius=proximity_alert_radius, protect_content=protect_content,
                 message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id,
                 message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast, direct_messages_topic_id=direct_messages_topic_id,
-                suggested_post_parameters=suggested_post_parameters)
+                suggested_post_parameters=suggested_post_parameters, receiver_user_id=receiver_user_id, callback_query_id=callback_query_id)
             )
 
 
@@ -4188,7 +4294,9 @@ class TeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send information about a venue. On success, the sent Message is returned.
 
@@ -4267,6 +4375,14 @@ class TeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4298,7 +4414,7 @@ class TeleBot:
                 timeout=timeout, google_place_id=google_place_id, google_place_type=google_place_type,
                 protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id,
                 message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast, direct_messages_topic_id=direct_messages_topic_id,
-                suggested_post_parameters=suggested_post_parameters)
+                suggested_post_parameters=suggested_post_parameters, receiver_user_id=receiver_user_id, callback_query_id=callback_query_id)
             )
 
 
@@ -4317,7 +4433,9 @@ class TeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send phone contacts. On success, the sent Message is returned.
 
@@ -4383,6 +4501,14 @@ class TeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4413,7 +4539,7 @@ class TeleBot:
                 disable_notification=disable_notification, reply_markup=reply_markup, timeout=timeout,
                 protect_content=protect_content, message_thread_id=message_thread_id, reply_parameters=reply_parameters,
                 business_connection_id=business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters)
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters, receiver_user_id=receiver_user_id, callback_query_id=callback_query_id)
             )
     
 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -3345,7 +3345,8 @@ class TeleBot:
                 reply_parameters=reply_parameters, business_connection_id=business_connection_id,
                 message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast,
                 direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
-                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id,receiver_user_id=receiver_user_id, callback_query_id=callback_query_id)
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
+                )
         )
 
 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -251,6 +251,7 @@ class TeleBot:
         self.purchased_paid_media_handlers = []
         self.managed_bot_handlers = []
         self.guest_message_handlers = []
+        self.subscription_handlers = []
 
         self.custom_filters = {}
         self.state_handlers = []
@@ -730,6 +731,7 @@ class TeleBot:
         new_purchased_paid_media = None
         new_managed_bots = None
         new_guest_messages = None
+        new_subscriptions = None
 
         for update in updates:
             if apihelper.ENABLE_MIDDLEWARE and not self.use_class_middlewares:
@@ -820,6 +822,9 @@ class TeleBot:
             if update.guest_message:
                 if new_guest_messages is None: new_guest_messages = []
                 new_guest_messages.append(update.guest_message)
+            if update.subscription:
+                if new_subscriptions is None: new_subscriptions = []
+                new_subscriptions.append(update.subscription)
 
         if new_messages:
             self.process_new_messages(new_messages)
@@ -847,6 +852,8 @@ class TeleBot:
             self.process_new_my_chat_member(new_my_chat_members)
         if new_chat_members:
             self.process_new_chat_member(new_chat_members)
+        if new_subscriptions:
+            self.process_new_subscription(new_subscriptions)
         if new_chat_join_request:
             self.process_new_chat_join_request(new_chat_join_request)
         if new_message_reactions:
@@ -1024,6 +1031,12 @@ class TeleBot:
         :meta private:
         """
         self._notify_command_handlers(self.guest_message_handlers, new_guest_messages, 'guest_message')
+
+    def process_new_subscription(self, new_subscriptions):
+        """
+        :meta private:
+        """
+        self._notify_command_handlers(self.subscription_handlers, new_subscriptions, 'subscription')
 
     def process_middlewares(self, update):
         """
@@ -11237,6 +11250,54 @@ class TeleBot:
         """
         handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
         self.add_guest_message_handler(handler_dict)
+
+    def subscription_handler(self, func=None, **kwargs):
+        """
+        User payment subscription has changed.
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+        :return: None
+        """
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
+            self.add_subscription_handler(handler_dict)
+            return handler
+
+        return decorator
+
+    def add_subscription_handler(self, handler_dict):
+        """
+        Adds a subscription handler.
+        Note that you should use register_subscription_handler to add subscription_handler to the bot.
+
+        :meta private:
+
+        :param handler_dict:
+        :return:
+        """
+        self.subscription_handlers.append(handler_dict)
+
+    def register_subscription_handler(self, callback: Callable, func: Optional[Callable]=None, pass_bot: Optional[bool]=False, **kwargs):
+        """
+        Registers subscription handler.
+
+        :param callback: function to be called
+        :type callback: :obj:`function`
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
+        :type pass_bot: :obj:`bool`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+        :return: None
+        """
+        handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
+        self.add_subscription_handler(handler_dict)
 
 
     def add_custom_filter(self, custom_filter: Union[SimpleCustomFilter, AdvancedCustomFilter]):

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -6833,6 +6833,176 @@ class TeleBot:
         return types.Poll.de_json(
             apihelper.stop_poll(self.token, chat_id, message_id, reply_markup=reply_markup, business_connection_id=business_connection_id)
         )
+    
+    def delete_ephemeral_message(
+            self, chat_id: Union[int, str], receiver_user_id: int, ephemeral_message_id: int) -> bool:
+        """
+        Use this method to delete an ephemeral message. Note that it is not guaranteed that the
+        user will receive the message deletion event, especially if they are offline. Returns True on success
+
+        Telegram documentation: https://core.telegram.org/bots/api#deleteephemeralmessage
+
+        :param chat_id: Unique identifier for the target chat or username of the target supergroup in the format @username
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param receiver_user_id: Identifier of the user who received the message
+        :type receiver_user_id: :obj:`int`
+
+        :param ephemeral_message_id: Identifier of the ephemeral message to delete
+        :type ephemeral_message_id: :obj:`int`
+
+        :return: Returns True on success.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.delete_ephemeral_message(
+            self.token, chat_id, receiver_user_id, ephemeral_message_id)
+
+    
+    def edit_ephemeral_message_text(
+            self, chat_id: Union[int, str], receiver_user_id: int, ephemeral_message_id: int, text: str,
+            parse_mode: Optional[str]=None, entities: Optional[List[types.MessageEntity]]=None,
+            link_preview_options: Optional[types.LinkPreviewOptions]=None, reply_markup: Optional[types.InlineKeyboardMarkup]=None) -> bool:
+        """
+        Use this method to edit an ephemeral text message. Note that it is not guaranteed that the
+        user will receive the message edit event, especially if they are offline. On success, True is returned.
+
+        Telegram documentation: https://core.telegram.org/bots/api#editephemeralmessagetext
+
+        :param chat_id: Unique identifier for the target chat or username of the target supergroup in the format @username
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param receiver_user_id: Identifier of the user who received the message
+        :type receiver_user_id: :obj:`int`
+
+        :param ephemeral_message_id: Identifier of the ephemeral message to edit
+        :type ephemeral_message_id: :obj:`int`
+
+        :param text: New text of the message, 1-4096 characters after entity parsing
+        :type text: :obj:`str`
+
+        :param parse_mode: Mode for parsing entities in the message text. See formatting options for more details.
+        :type parse_mode: :obj:`str`
+
+        :param entities: A JSON-serialized list of special entities that appear in message text, which can be specified instead of parse_mode
+        :type entities: :obj:`list` of :obj:`MessageEntity`
+
+        :param link_preview_options: Link preview generation options for the message
+        :type link_preview_options: :obj:`LinkPreviewOptions`
+
+        :param reply_markup: A JSON-serialized object for an inline keyboard
+        :type reply_markup: :obj:`InlineKeyboardMarkup`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
+
+        return apihelper.edit_ephemeral_message_text(
+            self.token, chat_id, receiver_user_id, ephemeral_message_id, text,
+            parse_mode=parse_mode, entities=entities,
+            link_preview_options=link_preview_options, reply_markup=reply_markup)
+
+    def edit_ephemeral_message_media(
+            self, chat_id: Union[int, str], receiver_user_id: int, ephemeral_message_id: int, media: types.InputMedia,
+            reply_markup: Optional[types.InlineKeyboardMarkup]=None) -> bool:
+        """
+        Use this method to edit the media of an ephemeral message. Note that it is not guaranteed
+        that the user will receive the message edit event, especially if they are offline. On success, True is returned.
+
+        Telegram documentation: https://core.telegram.org/bots/api#editephemeralmessagemedia
+
+        :param chat_id: Unique identifier for the target chat or username of the target supergroup in the format @username
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param receiver_user_id: Identifier of the user who received the message
+        :type receiver_user_id: :obj:`int`
+
+        :param ephemeral_message_id: Identifier of the ephemeral message to edit
+        :type ephemeral_message_id: :obj:`int`
+
+        :param media: A JSON-serialized object for the new media content of the message. A new file can't be uploaded; use a previously uploaded file via its file_id or specify a URL.
+        :type media: :obj:`InputMedia`
+
+        :param reply_markup: A JSON-serialized object for an inline keyboard
+        :type reply_markup: :obj:`InlineKeyboardMarkup`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.edit_ephemeral_message_media(
+            self.token, chat_id, receiver_user_id, ephemeral_message_id, media,
+            reply_markup=reply_markup)
+
+
+    def edit_ephemeral_message_caption(
+            self, chat_id: Union[int, str], receiver_user_id: int, ephemeral_message_id: int, caption: Optional[str]=None,
+            parse_mode: Optional[str]=None,
+            caption_entities: Optional[List[types.MessageEntity]]=None,
+            reply_markup: Optional[types.InlineKeyboardMarkup]=None) -> bool:
+        """
+        Use this method to edit the caption of an ephemeral message. Note that it is not guaranteed
+        that the user will receive the message edit event, especially if they are offline. On success, True is returned.
+
+        Telegram documentation: https://core.telegram.org/bots/api#editephemeralmessagecaption
+
+        :param chat_id: Unique identifier for the target chat or username of the target supergroup in the format @username
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param receiver_user_id: Identifier of the user who received the message
+        :type receiver_user_id: :obj:`int`
+
+        :param ephemeral_message_id: Identifier of the ephemeral message to edit
+        :type ephemeral_message_id: :obj:`int`
+
+        :param caption: New caption of the message, 0-1024 characters after entities parsing
+        :type caption: :obj:`str`
+
+        :param parse_mode: Mode for parsing entities in the message caption. See formatting options for more details.
+        :type parse_mode: :obj:`str`
+
+        :param caption_entities: A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
+        :type caption_entities: :obj:`list` of :obj:`MessageEntity`
+
+        :param reply_markup: A JSON-serialized object for an inline keyboard
+        :type reply_markup: :obj:`InlineKeyboardMarkup`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
+
+        return apihelper.edit_ephemeral_message_caption(
+            self.token, chat_id, receiver_user_id, ephemeral_message_id, caption,
+            parse_mode=parse_mode, caption_entities=caption_entities,
+            reply_markup=reply_markup)
+
+    
+    def edit_ephemeral_message_reply_markup(
+            self, chat_id: Union[int, str], receiver_user_id: int, ephemeral_message_id: int,
+            reply_markup: Optional[types.InlineKeyboardMarkup]=None) -> bool:
+        """
+        Use this method to edit only the reply markup of an ephemeral message. Note that it is
+        not guaranteed that the user will receive the message edit event, especially if they are offline. On success, True is returned.
+
+        Telegram documentation: https://core.telegram.org/bots/api#editephemeralmessagereplymarkup
+
+        :param chat_id: Unique identifier for the target chat or username of the target supergroup in the format @username
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param receiver_user_id: Identifier of the user who received the message
+        :type receiver_user_id: :obj:`int`
+
+        :param ephemeral_message_id: Identifier of the ephemeral message to edit
+        :type ephemeral_message_id: :obj:`int`
+
+        :param reply_markup: A JSON-serialized object for an inline keyboard
+        :type reply_markup: :obj:`InlineKeyboardMarkup`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return apihelper.edit_ephemeral_message_reply_markup(
+            self.token, chat_id, receiver_user_id, ephemeral_message_id, reply_markup=reply_markup)
 
 
     def answer_shipping_query(

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -2884,6 +2884,67 @@ def stop_poll(token, chat_id, message_id, reply_markup=None, business_connection
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
     return _make_request(token, method_url, params=payload)
+    
+def edit_ephemeral_message_text(token, chat_id, receiver_user_id, ephemeral_message_id, text, parse_mode=None,
+                                entities=None, link_preview_options=None, reply_markup=None):
+    method_url = r'editEphemeralMessageText'
+    payload = {
+        'chat_id': chat_id,
+        'receiver_user_id': receiver_user_id,
+        'ephemeral_message_id': ephemeral_message_id,
+        'text': text
+    }
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
+    if entities:
+        payload['entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(entities))
+    if link_preview_options:
+        payload['link_preview_options'] = link_preview_options.to_json()
+    if reply_markup:
+        payload['reply_markup'] = _convert_markup(reply_markup)
+    return _make_request(token, method_url, params=payload)
+
+def edit_ephemeral_message_media(token, chat_id, receiver_user_id, ephemeral_message_id, media, reply_markup=None):
+    method_url = r'editEphemeralMessageMedia'
+    media_json, files = convert_input_media(media)
+    payload = {
+        'chat_id': chat_id,
+        'receiver_user_id': receiver_user_id,
+        'ephemeral_message_id': ephemeral_message_id,
+        'media': media_json
+    }
+    if reply_markup:
+        payload['reply_markup'] = _convert_markup(reply_markup)
+    return _make_request(token, method_url, params=payload, files=files)
+
+def edit_ephemeral_message_caption(token, chat_id, receiver_user_id, ephemeral_message_id, caption=None,
+                                   parse_mode=None, caption_entities=None, reply_markup=None):
+    method_url = r'editEphemeralMessageCaption'
+    payload = {
+        'chat_id': chat_id,
+        'receiver_user_id': receiver_user_id,
+        'ephemeral_message_id': ephemeral_message_id
+    }
+    if caption:
+        payload['caption'] = caption
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
+    if caption_entities:
+        payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
+    if reply_markup:
+        payload['reply_markup'] = _convert_markup(reply_markup)
+    return _make_request(token, method_url, params=payload)
+
+def edit_ephemeral_message_reply_markup(token, chat_id, receiver_user_id, ephemeral_message_id, reply_markup=None):
+    method_url = r'editEphemeralMessageReplyMarkup'
+    payload = {
+        'chat_id': chat_id,
+        'receiver_user_id': receiver_user_id,
+        'ephemeral_message_id': ephemeral_message_id
+    }
+    if reply_markup:
+        payload['reply_markup'] = _convert_markup(reply_markup)
+    return _make_request(token, method_url, params=payload)
 
 def edit_general_forum_topic(token, chat_id, name):
     method_url = r'editGeneralForumTopic'
@@ -2915,6 +2976,16 @@ def delete_messages(token, chat_id, message_ids):
     payload = {
         'chat_id': chat_id,
         'message_ids': json.dumps(message_ids)
+    }
+    return _make_request(token, method_url, params=payload)
+
+
+def delete_ephemeral_message(token, chat_id, receiver_user_id, ephemeral_message_id):
+    method_url = 'deleteEphemeralMessage'
+    payload = {
+        'chat_id': chat_id,
+        'receiver_user_id': receiver_user_id,
+        'ephemeral_message_id': ephemeral_message_id
     }
     return _make_request(token, method_url, params=payload)
 

--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -248,7 +248,8 @@ def send_message(
         entities=None, protect_content=None,
         message_thread_id=None, reply_parameters=None, link_preview_options=None,
         business_connection_id=None, message_effect_id=None, allow_paid_broadcast=None,
-        direct_messages_topic_id=None, suggested_post_parameters=None):
+        direct_messages_topic_id=None, suggested_post_parameters=None,
+        receiver_user_id=None, callback_query_id=None):
     method_url = r'sendMessage'
     payload = {'chat_id': str(chat_id), 'text': text}
     if link_preview_options is not None:
@@ -279,6 +280,10 @@ def send_message(
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return _make_request(token, method_url, params=payload, method='post')
 
 
@@ -617,7 +622,7 @@ def send_photo(
         caption_entities=None, protect_content=None,
         message_thread_id=None, has_spoiler=None, reply_parameters=None, business_connection_id=None,
         message_effect_id=None, show_caption_above_media=None, allow_paid_broadcast=None,
-        direct_messages_topic_id=None, suggested_post_parameters=None):
+        direct_messages_topic_id=None, suggested_post_parameters=None,receiver_user_id=None, callback_query_id=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None
@@ -659,6 +664,10 @@ def send_photo(
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
     
 def send_live_photo(
@@ -793,7 +802,7 @@ def send_location(
         proximity_alert_radius=None, protect_content=None,
         message_thread_id=None, reply_parameters=None, business_connection_id=None,
         message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None,
-        suggested_post_parameters=None):
+        suggested_post_parameters=None, receiver_user_id=None, callback_query_id=None):
     method_url = r'sendLocation'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude}
     if live_period:
@@ -826,6 +835,10 @@ def send_location(
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return _make_request(token, method_url, params=payload)
 
 
@@ -882,7 +895,8 @@ def send_venue(
         foursquare_id=None, foursquare_type=None, disable_notification=None,
         reply_markup=None, timeout=None, google_place_id=None,
         google_place_type=None, protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None,
-        message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+        message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None,
+        receiver_user_id=None, callback_query_id=None):
     method_url = r'sendVenue'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude, 'title': title, 'address': address}
     if foursquare_id:
@@ -915,6 +929,10 @@ def send_venue(
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return _make_request(token, method_url, params=payload)
 
 
@@ -922,7 +940,8 @@ def send_contact(
         token, chat_id, phone_number, first_name, last_name=None, vcard=None,
         disable_notification=None, reply_markup=None, timeout=None,
         protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None,
-        message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+        message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None,
+        receiver_user_id=None, callback_query_id=None):
     method_url = r'sendContact'
     payload = {'chat_id': chat_id, 'phone_number': phone_number, 'first_name': first_name}
     if last_name:
@@ -951,6 +970,10 @@ def send_contact(
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
 
     return _make_request(token, method_url, params=payload)
 
@@ -986,7 +1009,8 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_markup=N
                thumbnail=None, width=None, height=None, caption_entities=None, protect_content=None,
                message_thread_id=None, has_spoiler=None, reply_parameters=None, business_connection_id=None,
                message_effect_id=None, show_caption_above_media=None, allow_paid_broadcast=None,
-               cover=None, start_timestamp=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+               cover=None, start_timestamp=None, direct_messages_topic_id=None, suggested_post_parameters=None,
+               receiver_user_id=None, callback_query_id=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -1028,6 +1052,10 @@ def send_video(token, chat_id, data, duration=None, caption=None, reply_markup=N
         payload['message_thread_id'] = message_thread_id
     if has_spoiler is not None:
         payload['has_spoiler'] = has_spoiler
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     if reply_parameters is not None:
         payload['reply_parameters'] = reply_parameters.to_json()
     if business_connection_id:
@@ -1061,7 +1089,8 @@ def send_animation(
         parse_mode=None, disable_notification=None, timeout=None, thumbnail=None, caption_entities=None,
         protect_content=None, width=None, height=None, message_thread_id=None, reply_parameters=None,
         has_spoiler=None, business_connection_id=None, message_effect_id=None, show_caption_above_media=None,
-        allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+        allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None,
+        receiver_user_id=None, callback_query_id=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}
     files = None
@@ -1113,6 +1142,10 @@ def send_animation(
         payload['allow_paid_broadcast'] = allow_paid_broadcast
     if direct_messages_topic_id is not None:
         payload['direct_messages_topic_id'] = direct_messages_topic_id
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
     return _make_request(token, method_url, params=payload, files=files, method='post')
@@ -1121,7 +1154,8 @@ def send_animation(
 def send_voice(token, chat_id, voice, caption=None, duration=None, reply_markup=None,
                parse_mode=None, disable_notification=None, timeout=None, caption_entities=None,
                  protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None,
-                 message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+                 message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None,
+                 receiver_user_id=None, callback_query_id=None):
     method_url = r'sendVoice'
     payload = {'chat_id': chat_id}
     files = None
@@ -1159,13 +1193,18 @@ def send_voice(token, chat_id, voice, caption=None, duration=None, reply_markup=
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_video_note(token, chat_id, data, duration=None, length=None, reply_markup=None,
                     disable_notification=None, timeout=None, thumbnail=None, protect_content=None,
                     message_thread_id=None, reply_parameters=None,business_connection_id=None, message_effect_id=None,
-                    allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+                    allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None,
+                    receiver_user_id=None, callback_query_id=None):
     method_url = r'sendVideoNote'
     payload = {'chat_id': chat_id}
     files = None
@@ -1209,13 +1248,18 @@ def send_video_note(token, chat_id, data, duration=None, length=None, reply_mark
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
 def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None,
                reply_markup=None, parse_mode=None, disable_notification=None, timeout=None, thumbnail=None,
                caption_entities=None, protect_content=None, message_thread_id=None, reply_parameters=None, business_connection_id=None,
-               message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+               message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None,
+               receiver_user_id=None, callback_query_id=None):
     method_url = r'sendAudio'
     payload = {'chat_id': chat_id}
     files = None
@@ -1265,6 +1309,10 @@ def send_audio(token, chat_id, audio, caption=None, duration=None, performer=Non
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1272,7 +1320,8 @@ def send_data(token, chat_id, data, data_type, reply_markup=None, parse_mode=Non
               disable_notification=None, timeout=None, caption=None, thumbnail=None, caption_entities=None,
               disable_content_type_detection=None, visible_file_name=None,
               protect_content = None, message_thread_id=None, emoji=None, reply_parameters=None, business_connection_id=None,
-              message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+              message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None,
+              receiver_user_id=None, callback_query_id=None):
     method_url = get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None
@@ -1323,6 +1372,10 @@ def send_data(token, chat_id, data, data_type, reply_markup=None, parse_mode=Non
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return _make_request(token, method_url, params=payload, files=files, method='post')
 
 

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -8428,6 +8428,175 @@ class AsyncTeleBot:
         :rtype: :obj:`types.Poll`
         """
         return types.Poll.de_json(await asyncio_helper.stop_poll(self.token, chat_id, message_id, reply_markup, business_connection_id))
+    
+    async def edit_ephemeral_message_text(
+            self, chat_id: Union[int, str], receiver_user_id: int, ephemeral_message_id: int, text: str,
+            parse_mode: Optional[str]=None, entities: Optional[List[types.MessageEntity]]=None,
+            link_preview_options: Optional[types.LinkPreviewOptions]=None, reply_markup: Optional[types.InlineKeyboardMarkup]=None) -> bool:
+        """
+        Use this method to edit an ephemeral text message. Note that it is not guaranteed that the
+        user will receive the message edit event, especially if they are offline. On success, True is returned.
+
+        Telegram documentation: https://core.telegram.org/bots/api#editephemeralmessagetext
+
+        :param chat_id: Unique identifier for the target chat or username of the target supergroup in the format @username
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param receiver_user_id: Identifier of the user who received the message
+        :type receiver_user_id: :obj:`int`
+
+        :param ephemeral_message_id: Identifier of the ephemeral message to edit
+        :type ephemeral_message_id: :obj:`int`
+
+        :param text: New text of the message, 1-4096 characters after entity parsing
+        :type text: :obj:`str`
+
+        :param parse_mode: Mode for parsing entities in the message text. See formatting options for more details.
+        :type parse_mode: :obj:`str`
+
+        :param entities: A JSON-serialized list of special entities that appear in message text, which can be specified instead of parse_mode
+        :type entities: :obj:`list` of :obj:`MessageEntity`
+
+        :param link_preview_options: Link preview generation options for the message
+        :type link_preview_options: :obj:`LinkPreviewOptions`
+
+        :param reply_markup: A JSON-serialized object for an inline keyboard
+        :type reply_markup: :obj:`InlineKeyboardMarkup`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
+
+        return await asyncio_helper.edit_ephemeral_message_text(
+            self.token, chat_id, receiver_user_id, ephemeral_message_id, text,
+            parse_mode=parse_mode, entities=entities,
+            link_preview_options=link_preview_options, reply_markup=reply_markup)
+
+    async def edit_ephemeral_message_media(
+            self, chat_id: Union[int, str], receiver_user_id: int, ephemeral_message_id: int, media: types.InputMedia,
+            reply_markup: Optional[types.InlineKeyboardMarkup]=None) -> bool:
+        """
+        Use this method to edit the media of an ephemeral message. Note that it is not guaranteed
+        that the user will receive the message edit event, especially if they are offline. On success, True is returned.
+
+        Telegram documentation: https://core.telegram.org/bots/api#editephemeralmessagemedia
+
+        :param chat_id: Unique identifier for the target chat or username of the target supergroup in the format @username
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param receiver_user_id: Identifier of the user who received the message
+        :type receiver_user_id: :obj:`int`
+
+        :param ephemeral_message_id: Identifier of the ephemeral message to edit
+        :type ephemeral_message_id: :obj:`int`
+
+        :param media: A JSON-serialized object for the new media content of the message. A new file can't be uploaded; use a previously uploaded file via its file_id or specify a URL.
+        :type media: :obj:`InputMedia`
+
+        :param reply_markup: A JSON-serialized object for an inline keyboard
+        :type reply_markup: :obj:`InlineKeyboardMarkup`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.edit_ephemeral_message_media(
+            self.token, chat_id, receiver_user_id, ephemeral_message_id, media,
+            reply_markup=reply_markup)
+
+
+    async def edit_ephemeral_message_caption(
+            self, chat_id: Union[int, str], receiver_user_id: int, ephemeral_message_id: int, caption: Optional[str]=None,
+            parse_mode: Optional[str]=None,
+            caption_entities: Optional[List[types.MessageEntity]]=None,
+            reply_markup: Optional[types.InlineKeyboardMarkup]=None) -> bool:
+        """
+        Use this method to edit the caption of an ephemeral message. Note that it is not guaranteed
+        that the user will receive the message edit event, especially if they are offline. On success, True is returned.
+
+        Telegram documentation: https://core.telegram.org/bots/api#editephemeralmessagecaption
+
+        :param chat_id: Unique identifier for the target chat or username of the target supergroup in the format @username
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param receiver_user_id: Identifier of the user who received the message
+        :type receiver_user_id: :obj:`int`
+
+        :param ephemeral_message_id: Identifier of the ephemeral message to edit
+        :type ephemeral_message_id: :obj:`int`
+
+        :param caption: New caption of the message, 0-1024 characters after entities parsing
+        :type caption: :obj:`str`
+
+        :param parse_mode: Mode for parsing entities in the message caption. See formatting options for more details.
+        :type parse_mode: :obj:`str`
+
+        :param caption_entities: A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
+        :type caption_entities: :obj:`list` of :obj:`MessageEntity`
+
+        :param reply_markup: A JSON-serialized object for an inline keyboard
+        :type reply_markup: :obj:`InlineKeyboardMarkup`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
+
+        return await asyncio_helper.edit_ephemeral_message_caption(
+            self.token, chat_id, receiver_user_id, ephemeral_message_id, caption,
+            parse_mode=parse_mode, caption_entities=caption_entities,
+            reply_markup=reply_markup)
+
+    
+    async def edit_ephemeral_message_reply_markup(
+            self, chat_id: Union[int, str], receiver_user_id: int, ephemeral_message_id: int,
+            reply_markup: Optional[types.InlineKeyboardMarkup]=None) -> bool:
+        """
+        Use this method to edit only the reply markup of an ephemeral message. Note that it is
+        not guaranteed that the user will receive the message edit event, especially if they are offline. On success, True is returned.
+
+        Telegram documentation: https://core.telegram.org/bots/api#editephemeralmessagereplymarkup
+
+        :param chat_id: Unique identifier for the target chat or username of the target supergroup in the format @username
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param receiver_user_id: Identifier of the user who received the message
+        :type receiver_user_id: :obj:`int`
+
+        :param ephemeral_message_id: Identifier of the ephemeral message to edit
+        :type ephemeral_message_id: :obj:`int`
+
+        :param reply_markup: A JSON-serialized object for an inline keyboard
+        :type reply_markup: :obj:`InlineKeyboardMarkup`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.edit_ephemeral_message_reply_markup(
+            self.token, chat_id, receiver_user_id, ephemeral_message_id, reply_markup=reply_markup)
+
+    async def delete_ephemeral_message(
+            self, chat_id: Union[int, str], receiver_user_id: int, ephemeral_message_id: int) -> bool:
+        """
+        Use this method to delete an ephemeral message. Note that it is not guaranteed that the user
+        will receive the message deletion event, especially if they are offline. Returns True on success.
+
+        Telegram documentation: https://core.telegram.org/bots/api#deleteephemeralmessage
+
+        :param chat_id: Unique identifier for the target chat or username of the target supergroup in the format @username
+        :type chat_id: :obj:`int` | :obj:`str`
+
+        :param receiver_user_id: Identifier of the user who received the message
+        :type receiver_user_id: :obj:`int`
+
+        :param ephemeral_message_id: Identifier of the ephemeral message to delete
+        :type ephemeral_message_id: :obj:`int`
+
+        :return: On success, True is returned.
+        :rtype: :obj:`bool`
+        """
+        return await asyncio_helper.delete_ephemeral_message(
+            self.token, chat_id, receiver_user_id, ephemeral_message_id)
 
     async def answer_shipping_query(
             self, shipping_query_id: str, ok: bool,

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -187,6 +187,7 @@ class AsyncTeleBot:
         self.purchased_paid_media_handlers = []
         self.managed_bot_handlers = []
         self.guest_message_handlers = []
+        self.subscription_handlers = []
 
         self.custom_filters = {}
         self.state_handlers = []
@@ -652,6 +653,7 @@ class AsyncTeleBot:
         new_purchased_paid_media = None
         new_managed_bots = None
         new_guest_messages = None
+        new_subscriptions = None
 
 
         for update in updates:
@@ -731,6 +733,9 @@ class AsyncTeleBot:
             if update.guest_message:
                 if new_guest_messages is None: new_guest_messages = []
                 new_guest_messages.append(update.guest_message)
+            if update.subscription:
+                if new_subscriptions is None: new_subscriptions = []
+                new_subscriptions.append(update.subscription)
 
 
         if new_messages:
@@ -781,6 +786,8 @@ class AsyncTeleBot:
             await self.process_new_managed_bots(new_managed_bots)
         if new_guest_messages:
             await self.process_new_guest_message(new_guest_messages)
+        if new_subscriptions:
+            await self.process_new_subscriptions(new_subscriptions)
 
     async def process_new_messages(self, new_messages):
         """
@@ -932,6 +939,12 @@ class AsyncTeleBot:
         :meta private:
         """
         await self._process_updates(self.guest_message_handlers, new_guest_messages, 'guest_message')
+
+    async def process_new_subscriptions(self, new_subscriptions):
+        """
+        :meta private:
+        """
+        await self._process_updates(self.subscription_handlers, new_subscriptions, 'subscription')
 
     async def _get_middlewares(self, update_type):
         """
@@ -2773,6 +2786,54 @@ class AsyncTeleBot:
         """
         handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
         self.add_guest_message_handler(handler_dict)
+
+    def subscription_handler(self, func=None, **kwargs):
+        """
+        User payment subscription has changed.
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+        :return: None
+        """
+        def decorator(handler):
+            handler_dict = self._build_handler_dict(handler, func=func, **kwargs)
+            self.add_subscription_handler(handler_dict)
+            return handler
+        
+        return decorator
+    
+    def add_subscription_handler(self, handler_dict):
+        """
+        Adds a subscription handler.
+        Note that you should use register_subscription_handler to add subscription_handler to the bot.
+
+        :meta private:
+
+        :param handler_dict:
+        :return:
+        """
+        self.subscription_handlers.append(handler_dict)
+
+    def register_subscription_handler(self, callback: Callable, func: Optional[Callable]=None, pass_bot: Optional[bool]=False, **kwargs):
+        """
+        Registers subscription handler.
+
+        :param callback: function to be called
+        :type callback: :obj:`function`
+
+        :param func: Function executed as a filter
+        :type func: :obj:`function`
+
+        :param pass_bot: True if you need to pass TeleBot instance to handler(useful for separating handlers into different files)
+        :type pass_bot: :obj:`bool`
+
+        :param kwargs: Optional keyword arguments(custom filters)
+        :return: None
+        """
+        handler_dict = self._build_handler_dict(callback, func=func, pass_bot=pass_bot, **kwargs)
+        self.add_subscription_handler(handler_dict)
 
 
     @staticmethod

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -3408,7 +3408,9 @@ class AsyncTeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send text messages.
 
@@ -3480,6 +3482,14 @@ class AsyncTeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -3536,7 +3546,8 @@ class AsyncTeleBot:
                 reply_markup, parse_mode, disable_notification, timeout,
                 entities, protect_content, message_thread_id, reply_parameters, link_preview_options, business_connection_id,
                 message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
             )
         )
 
@@ -4174,7 +4185,9 @@ class AsyncTeleBot:
             show_caption_above_media: Optional[bool]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send photos. On success, the sent Message is returned.
 
@@ -4248,6 +4261,14 @@ class AsyncTeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4282,7 +4303,8 @@ class AsyncTeleBot:
                 parse_mode, disable_notification, timeout, caption_entities,
                 protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id, message_effect_id=message_effect_id,
                 show_caption_above_media=show_caption_above_media, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
             )
         )
 
@@ -4400,7 +4422,9 @@ class AsyncTeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player.
         Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size,
@@ -4489,6 +4513,14 @@ class AsyncTeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4526,7 +4558,8 @@ class AsyncTeleBot:
                 self.token, chat_id, audio, caption, duration, performer, title,
                 reply_markup, parse_mode, disable_notification, timeout, thumbnail,
                 caption_entities, protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
             )
         )
 
@@ -4547,7 +4580,9 @@ class AsyncTeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .OGG file encoded with OPUS, or in .MP3 format, or in .M4A format (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
 
@@ -4617,7 +4652,16 @@ class AsyncTeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
+        :rtype: :class:`telebot.types.Message`
         """
         parse_mode = self.parse_mode if (parse_mode is None) else parse_mode
         disable_notification = self.disable_notification if (disable_notification is None) else disable_notification
@@ -4649,7 +4693,8 @@ class AsyncTeleBot:
                 self.token, chat_id, voice, caption, duration, reply_markup,
                 parse_mode, disable_notification, timeout, caption_entities,
                 protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id,
-                allow_paid_broadcast=allow_paid_broadcast, direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters
+                allow_paid_broadcast=allow_paid_broadcast, direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
             )
         )
 
@@ -4675,7 +4720,9 @@ class AsyncTeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send general files.
 
@@ -4757,6 +4804,14 @@ class AsyncTeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4806,7 +4861,8 @@ class AsyncTeleBot:
                 caption_entities = caption_entities,
                 disable_content_type_detection = disable_content_type_detection, visible_file_name = visible_file_name, protect_content = protect_content,
                 message_thread_id = message_thread_id, reply_parameters=reply_parameters, business_connection_id=business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
             )
         )
 
@@ -4826,7 +4882,9 @@ class AsyncTeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers.
         On success, the sent Message is returned.
@@ -4891,6 +4949,14 @@ class AsyncTeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -4930,7 +4996,7 @@ class AsyncTeleBot:
                 disable_notification=disable_notification, timeout=timeout,
                 protect_content=protect_content,
                 message_thread_id=message_thread_id, emoji=emoji, reply_parameters=reply_parameters, business_connection_id=business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast,
-                suggested_post_parameters=suggested_post_parameters, direct_messages_topic_id=direct_messages_topic_id
+                suggested_post_parameters=suggested_post_parameters, direct_messages_topic_id=direct_messages_topic_id,receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
             )
         )
 
@@ -4962,7 +5028,9 @@ class AsyncTeleBot:
             cover: Optional[Union[Any, str]]=None,
             start_timestamp: Optional[int]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
 
@@ -5062,6 +5130,14 @@ class AsyncTeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -5105,7 +5181,8 @@ class AsyncTeleBot:
                 parse_mode, supports_streaming, disable_notification, timeout, thumbnail, width, height,
                 caption_entities, protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id, message_effect_id=message_effect_id,
                 show_caption_above_media=show_caption_above_media, allow_paid_broadcast=allow_paid_broadcast, cover=cover, start_timestamp=start_timestamp,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters))
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id))
 
     async def send_animation(
             self, chat_id: Union[int, str], animation: Union[Any, str],
@@ -5131,7 +5208,9 @@ class AsyncTeleBot:
             show_caption_above_media: Optional[bool]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
         On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
@@ -5223,6 +5302,14 @@ class AsyncTeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -5261,7 +5348,10 @@ class AsyncTeleBot:
                 reply_markup, parse_mode, disable_notification, timeout, thumbnail,
                 caption_entities, width, height, protect_content, message_thread_id, has_spoiler, reply_parameters, business_connection_id,
                 message_effect_id=message_effect_id, show_caption_above_media=show_caption_above_media, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters))
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
+            )
+        )
 
     async def send_video_note(
             self, chat_id: Union[int, str], data: Union[Any, str],
@@ -5281,7 +5371,9 @@ class AsyncTeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         As of v.4.0, Telegram clients support rounded square MPEG4 videos of up to 1 minute long.
         Use this method to send video messages. On success, the sent Message is returned.
@@ -5355,6 +5447,14 @@ class AsyncTeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -5391,7 +5491,7 @@ class AsyncTeleBot:
                 self.token, chat_id, data, duration, length, reply_markup,
                 disable_notification, timeout, thumbnail, protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id,
                 allow_paid_broadcast=allow_paid_broadcast, direct_messages_topic_id=direct_messages_topic_id,
-                suggested_post_parameters=suggested_post_parameters
+                suggested_post_parameters=suggested_post_parameters,receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
             )
         )
 
@@ -5595,7 +5695,9 @@ class AsyncTeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send point on the map. On success, the sent Message is returned.
 
@@ -5667,6 +5769,14 @@ class AsyncTeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -5700,7 +5810,7 @@ class AsyncTeleBot:
                 reply_markup, disable_notification, timeout, 
                 horizontal_accuracy, heading, proximity_alert_radius, 
                 protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
             )
         )
 
@@ -5830,7 +5940,9 @@ class AsyncTeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send information about a venue. On success, the sent Message is returned.
 
@@ -5910,6 +6022,14 @@ class AsyncTeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -5942,7 +6062,9 @@ class AsyncTeleBot:
                 self.token, chat_id, latitude, longitude, title, address, foursquare_id, foursquare_type,
                 disable_notification, reply_markup, timeout,
                 google_place_id, google_place_type, protect_content, message_thread_id, reply_parameters, business_connection_id, message_effect_id=message_effect_id,
-                allow_paid_broadcast=allow_paid_broadcast, direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters)
+                allow_paid_broadcast=allow_paid_broadcast, direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
+            )
         )
 
     async def send_contact(
@@ -5961,7 +6083,9 @@ class AsyncTeleBot:
             message_effect_id: Optional[str]=None,
             allow_paid_broadcast: Optional[bool]=None,
             direct_messages_topic_id: Optional[int]=None,
-            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None) -> types.Message:
+            suggested_post_parameters: Optional[types.SuggestedPostParameters]=None,
+            receiver_user_id: Optional[int]=None,
+            callback_query_id: Optional[str]=None) -> types.Message:
         """
         Use this method to send phone contacts. On success, the sent Message is returned.
 
@@ -6028,6 +6152,14 @@ class AsyncTeleBot:
             is automatically declined.
         :type suggested_post_parameters: :class:`telebot.types.SuggestedPostParameters`
 
+        :param receiver_user_id: For outgoing ephemeral messages, unique identifier of the user who will receive the message;
+            for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially
+            if they are offline. See ephemeral message sending for more details.
+        :type receiver_user_id: :obj:`int`
+
+        :param callback_query_id: For outgoing ephemeral messages, identifier of the callback query which triggered the message if any
+        :type callback_query_id: :obj:`str`
+
         :return: On success, the sent Message is returned.
         :rtype: :class:`telebot.types.Message`
         """
@@ -6061,7 +6193,10 @@ class AsyncTeleBot:
                 disable_notification, reply_markup, timeout,
                 protect_content, message_thread_id, reply_parameters, business_connection_id,
                 message_effect_id=message_effect_id, allow_paid_broadcast=allow_paid_broadcast,
-                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters))
+                direct_messages_topic_id=direct_messages_topic_id, suggested_post_parameters=suggested_post_parameters,
+                receiver_user_id=receiver_user_id, callback_query_id=callback_query_id
+            )
+        )
     
     async def send_rich_message(
             self, chat_id: Union[int, str],

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -3001,6 +3001,79 @@ async def stop_poll(token, chat_id, message_id, reply_markup=None, business_conn
         payload['business_connection_id'] = business_connection_id
     return await _process_request(token, method_url, params=payload)
 
+async def edit_ephemeral_message_text(token, chat_id, receiver_user_id, ephemeral_message_id, text,
+                                    parse_mode=None, entities=None, link_preview_options=None,
+                                    reply_markup=None):
+    method_url = r'editEphemeralMessageText'
+    payload = {
+        'chat_id': chat_id,
+        'receiver_user_id': receiver_user_id,
+        'ephemeral_message_id': ephemeral_message_id,
+        'text': text
+    }
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
+    if entities:
+        payload['entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(entities))
+    if link_preview_options:
+        payload['link_preview_options'] = json.dumps(link_preview_options.to_dict())
+    if reply_markup:
+        payload['reply_markup'] = await _convert_markup(reply_markup)
+    return await _process_request(token, method_url, params=payload)
+
+
+async def edit_ephemeral_message_media(token, chat_id, receiver_user_id, ephemeral_message_id, media,
+                                    reply_markup=None):
+    method_url = r'editEphemeralMessageMedia'
+    payload = {
+        'chat_id': chat_id,
+        'receiver_user_id': receiver_user_id,
+        'ephemeral_message_id': ephemeral_message_id
+    }
+    media_json, files = await convert_input_media(media)
+    payload['media'] = media_json
+    if reply_markup:
+        payload['reply_markup'] = await _convert_markup(reply_markup)
+    return await _process_request(token, method_url, params=payload, files=files if files else None)
+
+async def delete_ephemeral_message(token, chat_id, receiver_user_id, ephemeral_message_id):
+    method_url = r'deleteEphemeralMessage'
+    payload = {
+        'chat_id': chat_id,
+        'receiver_user_id': receiver_user_id,
+        'ephemeral_message_id': ephemeral_message_id
+    }
+    return await _process_request(token, method_url, params=payload)
+
+async def edit_ephemeral_message_caption(token, chat_id, receiver_user_id, ephemeral_message_id, caption,
+                                    parse_mode=None, caption_entities=None, reply_markup=None):
+    method_url = r'editEphemeralMessageCaption'
+    payload = {
+        'chat_id': chat_id,
+        'receiver_user_id': receiver_user_id,
+        'ephemeral_message_id': ephemeral_message_id
+    }
+    if caption:
+        payload['caption'] = caption
+    if parse_mode:
+        payload['parse_mode'] = parse_mode
+    if caption_entities:
+        payload['caption_entities'] = json.dumps(types.MessageEntity.to_list_of_dicts(caption_entities))
+    if reply_markup:
+        payload['reply_markup'] = await _convert_markup(reply_markup)
+    return await _process_request(token, method_url, params=payload)
+
+async def edit_ephemeral_message_reply_markup(token, chat_id, receiver_user_id, ephemeral_message_id, reply_markup):
+    method_url = r'editEphemeralMessageReplyMarkup'
+    payload = {
+        'chat_id': chat_id,
+        'receiver_user_id': receiver_user_id,
+        'ephemeral_message_id': ephemeral_message_id
+    }
+    if reply_markup:
+        payload['reply_markup'] = await _convert_markup(reply_markup)
+    return await _process_request(token, method_url, params=payload)
+
 # exceptions
 class ApiException(Exception):
     """

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -294,7 +294,7 @@ async def send_message(
         parse_mode=None, disable_notification=None, timeout=None,
         entities=None, protect_content=None,
         message_thread_id=None, reply_parameters=None, link_preview_options=None, business_connection_id=None, message_effect_id=None,
-        allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+        allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None, receiver_user_id=None, callback_query_id=None):
     method_name = 'sendMessage'
     params = {'chat_id': str(chat_id), 'text': text}
     if link_preview_options is not None:
@@ -325,7 +325,10 @@ async def send_message(
         params['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         params['suggested_post_parameters'] = suggested_post_parameters.to_json()
-    
+    if receiver_user_id is not None:
+        params['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        params['callback_query_id'] = callback_query_id
     return await _process_request(token, method_name, params=params, method='post')
 
 async def send_rich_message(
@@ -631,7 +634,7 @@ async def send_photo(
         caption_entities=None,  protect_content=None,
         message_thread_id=None, has_spoiler=None,reply_parameters=None,
         business_connection_id=None, message_effect_id=None, show_caption_above_media=None, allow_paid_broadcast=None,
-        direct_messages_topic_id=None, suggested_post_parameters=None):
+        direct_messages_topic_id=None, suggested_post_parameters=None, receiver_user_id=None, callback_query_id=None):
     method_url = r'sendPhoto'
     payload = {'chat_id': chat_id}
     files = None
@@ -673,6 +676,10 @@ async def send_photo(
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
     
 async def send_live_photo(
@@ -811,7 +818,8 @@ async def send_location(
         reply_markup=None, disable_notification=None, 
         timeout=None, horizontal_accuracy=None, heading=None,
         proximity_alert_radius=None,  protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None,
-        message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+        message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None, 
+        receiver_user_id=None, callback_query_id=None):
     method_url = r'sendLocation'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude}
     if live_period:
@@ -844,6 +852,10 @@ async def send_location(
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -901,7 +913,8 @@ async def send_venue(
          reply_markup=None, timeout=None,
          google_place_id=None,
         google_place_type=None, protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None,
-        message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+        message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None,
+        receiver_user_id=None, callback_query_id=None):
     method_url = r'sendVenue'
     payload = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude, 'title': title, 'address': address}
     if foursquare_id:
@@ -934,6 +947,10 @@ async def send_venue(
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return await _process_request(token, method_url, params=payload)
 
 
@@ -941,7 +958,7 @@ async def send_contact(
         token, chat_id, phone_number, first_name, last_name=None, vcard=None,
         disable_notification=None,  reply_markup=None, timeout=None,
          protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None, message_effect_id=None,
-         allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+         allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None, receiver_user_id=None, callback_query_id=None):
     method_url = r'sendContact'
     payload = {'chat_id': chat_id, 'phone_number': phone_number, 'first_name': first_name}
     if last_name:
@@ -970,6 +987,10 @@ async def send_contact(
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return await _process_request(token, method_url, params=payload)
 
 async def send_message_draft(
@@ -1002,7 +1023,7 @@ async def send_video(token, chat_id, data, duration=None, caption=None,  reply_m
                      thumbnail=None, width=None, height=None, caption_entities=None, 
                      protect_content=None, message_thread_id=None, has_spoiler=None,reply_parameters=None, business_connection_id=None,
                      message_effect_id=None, show_caption_above_media=None, allow_paid_broadcast=None, cover=None, start_timestamp=None,
-                     direct_messages_topic_id=None, suggested_post_parameters=None):
+                     direct_messages_topic_id=None, suggested_post_parameters=None, receiver_user_id=None, callback_query_id=None):
     method_url = r'sendVideo'
     payload = {'chat_id': chat_id}
     files = None
@@ -1068,6 +1089,10 @@ async def send_video(token, chat_id, data, duration=None, caption=None,  reply_m
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:   
+        payload['callback_query_id'] = callback_query_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
@@ -1076,7 +1101,7 @@ async def send_animation(
         parse_mode=None, disable_notification=None, timeout=None, thumbnail=None, caption_entities=None,
          width=None, height=None, protect_content=None, message_thread_id=None,
         has_spoiler=None,reply_parameters=None, business_connection_id=None, message_effect_id=None, show_caption_above_media=None,
-        allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+        allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None, receiver_user_id=None, callback_query_id=None):
     method_url = r'sendAnimation'
     payload = {'chat_id': chat_id}
     files = None
@@ -1111,11 +1136,16 @@ async def send_animation(
     if width:
         payload['width'] = width
     if height:
+    if height:
         payload['height'] = height
     if protect_content is not None:
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     if has_spoiler is not None:
         payload['has_spoiler'] = has_spoiler
     if business_connection_id:
@@ -1136,7 +1166,7 @@ async def send_animation(
 async def send_voice(token, chat_id, voice, caption=None, duration=None,  reply_markup=None,
                parse_mode=None, disable_notification=None, timeout=None, caption_entities=None,
                 protect_content=None, message_thread_id=None,reply_parameters=None,business_connection_id=None, message_effect_id=None,
-                allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+                allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None, receiver_user_id=None, callback_query_id=None):
     method_url = r'sendVoice'
     payload = {'chat_id': chat_id}
     files = None
@@ -1174,13 +1204,17 @@ async def send_voice(token, chat_id, voice, caption=None, duration=None,  reply_
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_video_note(token, chat_id, data, duration=None, length=None,  reply_markup=None,
                           disable_notification=None, timeout=None, thumbnail=None,  protect_content=None,
                           message_thread_id=None,reply_parameters=None, business_connection_id=None, message_effect_id=None, allow_paid_broadcast=None,
-                          direct_messages_topic_id=None, suggested_post_parameters=None):
+                          direct_messages_topic_id=None, suggested_post_parameters=None, receiver_user_id=None, callback_query_id=None):
     method_url = r'sendVideoNote'
     payload = {'chat_id': chat_id}
     files = None
@@ -1224,13 +1258,17 @@ async def send_video_note(token, chat_id, data, duration=None, length=None,  rep
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 
 async def send_audio(token, chat_id, audio, caption=None, duration=None, performer=None, title=None, 
                      reply_markup=None, parse_mode=None, disable_notification=None, timeout=None, thumbnail=None,
                      caption_entities=None,  protect_content=None, message_thread_id=None,reply_parameters=None, business_connection_id=None,
-                     message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+                     message_effect_id=None, allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None, receiver_user_id=None, callback_query_id=None):
     method_url = r'sendAudio'
     payload = {'chat_id': chat_id}
     files = None
@@ -1270,6 +1308,10 @@ async def send_audio(token, chat_id, audio, caption=None, duration=None, perform
         payload['protect_content'] = protect_content
     if message_thread_id:
         payload['message_thread_id'] = message_thread_id
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     if business_connection_id:
         payload['business_connection_id'] = business_connection_id
     if message_effect_id:
@@ -1287,7 +1329,7 @@ async def send_data(token, chat_id, data, data_type,  reply_markup=None, parse_m
                     disable_notification=None, timeout=None, caption=None, thumbnail=None, caption_entities=None,
                      disable_content_type_detection=None, visible_file_name=None, protect_content=None,
                     message_thread_id=None, emoji=None,reply_parameters=None, business_connection_id=None, message_effect_id=None,
-                    allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None):
+                    allow_paid_broadcast=None, direct_messages_topic_id=None, suggested_post_parameters=None, receiver_user_id=None, callback_query_id=None):
     method_url = await get_method_by_type(data_type)
     payload = {'chat_id': chat_id}
     files = None
@@ -1338,6 +1380,10 @@ async def send_data(token, chat_id, data, data_type,  reply_markup=None, parse_m
         payload['direct_messages_topic_id'] = direct_messages_topic_id
     if suggested_post_parameters is not None:
         payload['suggested_post_parameters'] = suggested_post_parameters.to_json()
+    if receiver_user_id is not None:
+        payload['receiver_user_id'] = receiver_user_id
+    if callback_query_id is not None:
+        payload['callback_query_id'] = callback_query_id
     return await _process_request(token, method_url, params=payload, files=files, method='post')
 
 

--- a/telebot/asyncio_helper.py
+++ b/telebot/asyncio_helper.py
@@ -1136,7 +1136,6 @@ async def send_animation(
     if width:
         payload['width'] = width
     if height:
-    if height:
         payload['height'] = height
     if protect_content is not None:
         payload['protect_content'] = protect_content

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -212,6 +212,9 @@ class Update(JsonDeserializable):
     :param guest_message: Optional. New guest message. The bot can use the field Message.guest_query_id and the method answerGuestQuery to send a message in response.
     :type guest_message: :class:`telebot.types.Message`
 
+    :param subscription: Optional. User payment subscription has changed
+    :type subscription: :class:`telebot.types.BotSubscriptionUpdated`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.Update`
 
@@ -246,18 +249,19 @@ class Update(JsonDeserializable):
         purchased_paid_media = PaidMediaPurchased.de_json(obj.get('purchased_paid_media'))
         managed_bot = ManagedBotUpdated.de_json(obj.get('managed_bot'))
         guest_message = Message.de_json(obj.get('guest_message'))
+        subscription = BotSubscriptionUpdated.de_json(obj.get('subscription'))
 
         return cls(update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                    chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
                    my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count,
                    removed_chat_boost, chat_boost, business_connection, business_message, edited_business_message,
-                   deleted_business_messages, purchased_paid_media, managed_bot, guest_message)
+                   deleted_business_messages, purchased_paid_media, managed_bot, guest_message, subscription)
 
     def __init__(self, update_id, message, edited_message, channel_post, edited_channel_post, inline_query,
                  chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
                  my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count,
                  removed_chat_boost, chat_boost, business_connection, business_message, edited_business_message,
-                 deleted_business_messages, purchased_paid_media, managed_bot, guest_message):
+                 deleted_business_messages, purchased_paid_media, managed_bot, guest_message, subscription):
         self.update_id: int = update_id
         self.message: Optional[Message] = message
         self.edited_message: Optional[Message] = edited_message
@@ -284,6 +288,7 @@ class Update(JsonDeserializable):
         self.purchased_paid_media: Optional[PaidMediaPurchased] = purchased_paid_media
         self.managed_bot: Optional[ManagedBotUpdated] = managed_bot
         self.guest_message: Optional[Message] = guest_message
+        self.subscription: Optional[BotSubscriptionUpdated] = subscription
 
 class ChatMemberUpdated(JsonDeserializable):
     """
@@ -16764,8 +16769,6 @@ class InputRichBlockDivider(InputRichBlock):
     def __init__(self, **kwargs):
         super().__init__(type='divider', **kwargs)
 
-    def to_dict(self) -> dict:
-        return super().to_dict()
 
 
 class InputRichBlockMathematicalExpression(InputRichBlock):
@@ -17355,4 +17358,41 @@ class CommunityChatRemoved(JsonDeserializable):
     """
     def __init__(self, **kwargs):
         pass
-        
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+    
+
+class BotSubscriptionUpdated(JsonDeserializable):
+    """
+    This object contains information about changes to a user payment subscription toward the current bot.
+
+    Telegram documentation: https://core.telegram.org/bots/api#botsubscriptionupdated
+
+    :param user: User who subscribed for payments toward the bot
+    :type user: :class:`User`
+
+    :param invoice_payload: Bot-specified invoice payload
+    :type invoice_payload: :obj:`str`
+
+    :param state: The new state of the subscription. Currently, it can be one of “canceled” if the user canceled the subscription,
+        “active” if the user re-enabled a previously canceled subscription, or “failed” if payment for the subscription failed.
+    :type state: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`BotSubscriptionUpdated`
+    """
+    def __init__(self, user: User, invoice_payload: str, state: str, **kwargs):
+        self.user: User = user
+        self.invoice_payload: str = invoice_payload
+        self.state: str = state
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        obj['user'] = User.de_json(obj.get('user'))
+        return cls(**obj)

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -17343,7 +17343,7 @@ class CommunityChatAdded(JsonDeserializable):
     def de_json(cls, json_string):
         if json_string is None: return None
         obj = cls.check_json(json_string)
-        community = Community.de_json(obj.get('community'))
+        obj['community'] = Community.de_json(obj.get('community'))
         return cls(**obj)
     
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -800,6 +800,9 @@ class ChatFullInfo(JsonDeserializable):
     :param guard_bot: Optional. The bot that processes join request queries in the chat. The field is only available to chat administrators.
     :type guard_bot: :class:`telebot.types.User`
 
+    :param community: Optional. The Community to which the chat belongs
+    :type community: :class:`telebot.types.Community`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.ChatFullInfo`
     """
@@ -839,6 +842,8 @@ class ChatFullInfo(JsonDeserializable):
             obj['first_profile_audio'] = Audio.de_json(obj['first_profile_audio'])
         if 'guard_bot' in obj:
             obj['guard_bot'] = User.de_json(obj['guard_bot'])
+        if 'community' in obj:
+            obj['community'] = Community.de_json(obj['community'])
         return cls(**obj)
 
     def __init__(self, id, type, title=None, username=None, first_name=None,
@@ -856,7 +861,7 @@ class ChatFullInfo(JsonDeserializable):
                 business_opening_hours=None, personal_chat=None, birthdate=None,
                 can_send_paid_media=None,
                 accepted_gift_types=None, is_direct_messages=None, parent_chat=None, rating=None, paid_message_star_count=None,
-                unique_gift_colors=None, first_profile_audio=None, guard_bot=None, **kwargs):
+                unique_gift_colors=None, first_profile_audio=None, guard_bot=None, community=None, **kwargs):
         self.id: int = id
         self.type: str = type
         self.title: Optional[str] = title
@@ -909,6 +914,7 @@ class ChatFullInfo(JsonDeserializable):
         self.unique_gift_colors: Optional[UniqueGiftColors] = unique_gift_colors
         self.first_profile_audio: Optional[Audio] = first_profile_audio
         self.guard_bot: Optional[User] = guard_bot
+        self.community: Optional[Community] = community
 
 
     @property
@@ -1305,6 +1311,12 @@ class Message(JsonDeserializable):
 
     :param checklist_tasks_added: Optional. Service message: tasks were added to a checklist
     :type checklist_tasks_added: :class:`telebot.types.ChecklistTasksAdded`
+
+    :param community_chat_added: Optional. Service message: chat added to a Community
+    :type community_chat_added: :class:`telebot.types.CommunityChatAdded`
+
+    :param community_chat_removed: Optional. Service message: chat removed from a Community
+    :type community_chat_removed: :class:`telebot.types.CommunityChatRemoved`
 
     :param direct_message_price_changed: Optional. Service message: the price for paid messages in the corresponding direct messages chat of a channel has changed
     :type direct_message_price_changed: :class:`telebot.types.DirectMessagePriceChanged`
@@ -1706,6 +1718,12 @@ class Message(JsonDeserializable):
             opts['receiver_user'] = User.de_json(obj['receiver_user'])
         if 'ephemeral_message_id' in obj:
             opts['ephemeral_message_id'] = obj['ephemeral_message_id']
+        if 'community_chat_added' in obj:
+            opts['community_chat_added'] = CommunityChatAdded.de_json(obj['community_chat_added'])
+            content_type = 'community_chat_added'
+        if 'community_chat_removed' in obj:
+            opts['community_chat_removed'] = CommunityChatRemoved.de_json(obj['community_chat_removed'])
+            content_type = 'community_chat_removed'
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
     @classmethod
@@ -17273,3 +17291,68 @@ class InputRichBlockThinking(InputRichBlock):
         data = super().to_dict()
         data['text'] = self.text.to_dict()
         return data
+    
+
+class Community(JsonDeserializable):
+    """
+    Represents a community (a group of chats).
+
+    Telegram documentation: https://core.telegram.org/bots/api#community
+
+    :param id: Unique identifier for this community. This number may have more than 32 significant bits and some programming
+    languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit
+    integer or double-precision float type are safe for storing this identifier.
+    :type id: :obj:`int`
+
+    :param name: Name of the community
+    :type name: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`Community`
+    """
+    def __init__(self, id: int, name: str, **kwargs):
+        self.id: int = id
+        self.name: str = name
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        return cls(**obj)
+
+
+class CommunityChatAdded(JsonDeserializable):
+    """
+    Describes a service message about a chat being added to a community.
+
+    Telegram documentation: https://core.telegram.org/bots/api#communitychatadded
+
+    :param community: The new community to which the chat belongs
+    :type community: :class:`Community`
+
+    :return: Instance of the class
+    :rtype: :class:`CommunityChatAdded`
+    """
+    def __init__(self, community: Community, **kwargs):
+        self.community: Community = community
+
+    @classmethod
+    def de_json(cls, json_string):
+        if json_string is None: return None
+        obj = cls.check_json(json_string)
+        community = Community.de_json(obj.get('community'))
+        return cls(**obj)
+    
+
+class CommunityChatRemoved(JsonDeserializable):
+    """
+    Describes a service message about a chat being removed from a community. Currently holds no information
+
+    Telegram documentation: https://core.telegram.org/bots/api#communitychatremoved
+
+    :return: Instance of the class
+    :rtype: :class:`CommunityChatRemoved`
+    """
+    def __init__(self, **kwargs):
+        pass
+        

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -1020,6 +1020,13 @@ class Message(JsonDeserializable):
     :param sender_tag: Optional. The tag of the message sender in the chat
     :type sender_tag: :obj:`str`
 
+    :param receiver_user: Optional. For ephemeral messages, the user who received the message
+    :type receiver_user: :class:`telebot.types.User`
+
+    :param ephemeral_message_id: Optional. For ephemeral messages, identifier of the ephemeral message inside this chat.
+        The identifier may be reused for another ephemeral message after the message is deleted or expires.
+    :type ephemeral_message_id: :obj:`int`
+
     :param sender_business_bot info: Optional. Information about the business bot that sent the message
     :type sender_business_bot_info: :class:`telebot.types.User`
 
@@ -1695,6 +1702,10 @@ class Message(JsonDeserializable):
         if 'rich_message' in obj:
             opts['rich_message'] = RichMessage.de_json(obj['rich_message'])
             content_type = 'rich_message'
+        if 'receiver_user' in obj:
+            opts['receiver_user'] = User.de_json(obj['receiver_user'])
+        if 'ephemeral_message_id' in obj:
+            opts['ephemeral_message_id'] = obj['ephemeral_message_id']
         return cls(message_id, from_user, date, chat, content_type, opts, json_string)
 
     @classmethod
@@ -4049,6 +4060,9 @@ class BotCommand(JsonSerializable, JsonDeserializable, Dictionaryable):
     :param description: Description of the command; 1-256 characters.
     :type description: :obj:`str`
 
+    :param is_ephemeral: Optional. True, if the command sends an ephemeral message, which can be seen only by the sender of the message and the bot
+    :type is_ephemeral: :obj:`bool`
+
     :return: Instance of the class
     :rtype: :class:`telebot.types.BotCommand`
     """
@@ -4058,15 +4072,19 @@ class BotCommand(JsonSerializable, JsonDeserializable, Dictionaryable):
         obj = cls.check_json(json_string, dict_copy=False)
         return cls(**obj)
 
-    def __init__(self, command, description, **kwargs):
+    def __init__(self, command: str, description: str, is_ephemeral: Optional[bool] = None, **kwargs):
         self.command: str = command
         self.description: str = description
+        self.is_ephemeral: Optional[bool] = is_ephemeral
 
     def to_json(self):
         return json.dumps(self.to_dict())
 
     def to_dict(self):
-        return {'command': self.command, 'description': self.description}
+        data = {'command': self.command, 'description': self.description}
+        if self.is_ephemeral is not None:
+            data['is_ephemeral'] = self.is_ephemeral
+        return data
 
 
 # BotCommandScopes
@@ -16350,6 +16368,9 @@ class InputRichMessage(Dictionaryable):
     """
     This object represents a rich message to be sent. Exactly one of the fields html or markdown must be used.
 
+    :param blocks: Optional. Content of the rich message to send described as a list of blocks
+    :type blocks: :obj:`list` of :class:`InputRichBlock`
+
     :param html: Optional. Content of the rich message to send described using HTML formatting.
         See rich message formatting options for more details.
     :type html: :obj:`str`
@@ -16373,12 +16394,13 @@ class InputRichMessage(Dictionaryable):
     :rtype: :class:`InputRichMessage`
     """
     def __init__(self, html: Optional[str] = None, markdown: Optional[str] = None, is_rtl: Optional[bool] = None, skip_entity_detection: Optional[bool] = None,
-                    media: Optional[List[InputRichMessageMedia]] = None, **kwargs):
+                    media: Optional[List[InputRichMessageMedia]] = None, blocks: Optional[List[InputRichBlock]] = None, **kwargs):
         self.html: Optional[str] = html
         self.markdown: Optional[str] = markdown
         self.is_rtl: Optional[bool] = is_rtl
         self.skip_entity_detection: Optional[bool] = skip_entity_detection
         self.media: Optional[List[InputRichMessageMedia]] = media
+        self.blocks: Optional[List[InputRichBlock]] = blocks
 
     def to_dict(self) -> dict:
         data = {}
@@ -16392,6 +16414,8 @@ class InputRichMessage(Dictionaryable):
             data['skip_entity_detection'] = self.skip_entity_detection
         if self.media is not None:
             data['media'] = [m.to_dict() for m in self.media]
+        if self.blocks is not None:
+            data['blocks'] = [b.to_dict() for b in self.blocks]
         return data
     
     def to_json(self) -> str:

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -16358,6 +16358,10 @@ class InputRichMessage(Dictionaryable):
     See rich message formatting options for more details.
     :type markdown: :obj:`str`
 
+    :param media: Optional. List of media that are specified in the markdown or html fields
+        using tg://photo?id=, tg://video?id=, and tg://audio?id= links
+    :type media: :obj:`list` of :class:`InputRichMessageMedia`
+
     :param is_rtl: Optional. Pass True if the rich message must be shown right-to-left
     :type is_rtl: :obj:`bool`
 
@@ -16368,11 +16372,13 @@ class InputRichMessage(Dictionaryable):
     :return: Instance of the class
     :rtype: :class:`InputRichMessage`
     """
-    def __init__(self, html: Optional[str] = None, markdown: Optional[str] = None, is_rtl: Optional[bool] = None, skip_entity_detection: Optional[bool] = None, **kwargs):
+    def __init__(self, html: Optional[str] = None, markdown: Optional[str] = None, is_rtl: Optional[bool] = None, skip_entity_detection: Optional[bool] = None,
+                    media: Optional[List[InputRichMessageMedia]] = None, **kwargs):
         self.html: Optional[str] = html
         self.markdown: Optional[str] = markdown
         self.is_rtl: Optional[bool] = is_rtl
         self.skip_entity_detection: Optional[bool] = skip_entity_detection
+        self.media: Optional[List[InputRichMessageMedia]] = media
 
     def to_dict(self) -> dict:
         data = {}
@@ -16384,6 +16390,8 @@ class InputRichMessage(Dictionaryable):
             data['is_rtl'] = self.is_rtl
         if self.skip_entity_detection is not None:
             data['skip_entity_detection'] = self.skip_entity_detection
+        if self.media is not None:
+            data['media'] = [m.to_dict() for m in self.media]
         return data
     
     def to_json(self) -> str:
@@ -16410,3 +16418,127 @@ class Link(JsonDeserializable):
         if json_string is None: return None
         obj = cls.check_json(json_string)
         return cls(**obj)
+    
+
+class InputMediaVoiceNote(InputMedia):
+    """
+    Represents a voice message file to be sent.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputmediavoicenote
+
+    :param type: Type of the media, must be voice_note
+    :type type: :obj:`str`
+
+    :param media: File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended),
+        pass an HTTP URL for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>"
+        to upload a new one using multipart/form-data under <file_attach_name> name. More information on Sending Files »
+    :type media: :obj:`str`
+
+    :param caption: Optional. Caption of the voice message to be sent, 0-1024 characters after entities parsing
+    :type caption: :obj:`str`
+
+    :param parse_mode: Optional. Mode for parsing entities in the voice message caption. See formatting options for more details.
+    :type parse_mode: :obj:`str`
+
+    :param caption_entities: Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
+    :type caption_entities: :obj:`list` of :class:`MessageEntity`
+
+    :param duration: Optional. Duration of the voice message in seconds
+    :type duration: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`InputMediaVoiceNote`
+    """
+    def __init__(self, media: str, caption: Optional[str] = None, parse_mode: Optional[str] = None, caption_entities: Optional[List[MessageEntity]] = None,
+                    duration: Optional[int] = None, **kwargs):
+        super().__init__(type='voice_note', media=media, caption=caption, parse_mode=parse_mode, caption_entities=caption_entities)
+        self.duration: Optional[int] = duration
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        if self.duration is not None:
+            data['duration'] = self.duration
+        return data
+    
+
+class InputRichMessageMedia(Dictionaryable):
+    """
+    This object represents a media element embedded in an outgoing rich message.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichmessagemedia
+
+    :param id: Unique identifier of the media used in a tg://photo?id=, tg://video?id=, or tg://audio?id= link.
+        1-64 characters, only A-Z, a-z, 0-9, _ and - are allowed.
+    :type id: :obj:`str`
+
+    :param media: The media to be sent. Everything except the media itself and its properties is ignored.
+    :type media: :obj:`InputMediaAnimation` or :obj:`InputMediaAudio` or :obj:`InputMediaPhoto` or :obj:`InputMediaVideo` or :obj:`InputMediaVoiceNote`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichMessageMedia`
+    """
+    def __init__(self, id: str, media: Union[InputMediaAnimation, InputMediaAudio, InputMediaPhoto, InputMediaVideo, InputMediaVoiceNote], **kwargs):
+        self.id: str = id
+        self.media: Union[InputMediaAnimation, InputMediaAudio, InputMediaPhoto, InputMediaVideo, InputMediaVoiceNote] = media
+
+    def to_dict(self) -> dict:
+        data = {
+            'id': self.id,
+            'media': self.media.to_dict()
+        }
+        return data
+    
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+    
+
+class InputRichBlockListItem(Dictionaryable):
+    """
+    An item of a list to be sent.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblocklistitem
+
+    :param blocks: The content of the item
+    :type blocks: :obj:`list` of :class:`InputRichBlock`
+
+    :param has_checkbox: Optional. Pass True if the item has a checkbox
+    :type has_checkbox: :obj:`bool`
+
+    :param is_checked: Optional. Pass True if the item has a checked checkbox
+    :type is_checked: :obj:`bool`
+
+    :param value: Optional. For ordered lists, the numeric value of the item label
+    :type value: :obj:`int`
+
+    :param type: Optional. For ordered lists, the type of the item label; must be one of “a” for lowercase letters, “A” for uppercase letters, 
+        “i” for lowercase Roman numerals, “I” for uppercase Roman numerals, or “1” for decimal numbers
+    :type type: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockListItem`
+    """
+    def __init__(self, blocks: List[InputRichBlock], has_checkbox: Optional[bool] = None, is_checked: Optional[bool] = None,
+                    value: Optional[int] = None, type: Optional[str] = None, **kwargs):
+        self.blocks: List[InputRichBlock] = blocks
+        self.has_checkbox: Optional[bool] = has_checkbox
+        self.is_checked: Optional[bool] = is_checked
+        self.value: Optional[int] = value
+        self.type: Optional[str] = type
+
+    def to_dict(self) -> dict:
+        data = {
+            'blocks': [block.to_dict() for block in self.blocks]
+        }
+        if self.has_checkbox is not None:
+            data['has_checkbox'] = self.has_checkbox
+        if self.is_checked is not None:
+            data['is_checked'] = self.is_checked
+        if self.value is not None:
+            data['value'] = self.value
+        if self.type is not None:
+            data['type'] = self.type
+        return data
+    
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+    

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -10029,12 +10029,18 @@ class ReplyParameters(JsonDeserializable, Dictionaryable, JsonSerializable):
 
     Telegram documentation: https://core.telegram.org/bots/api#replyparameters
 
-    :param message_id: Identifier of the message that will be replied to in the current chat, or in the chat chat_id if it is specified
+    :param message_id: Optional. Identifier of the message that will be replied to in the current chat,
+        or in the chat chat_id if it is specified. Required if ephemeral_message_id isn't specified.
     :type message_id: :obj:`int`
 
     :param chat_id: Optional. If the message to be replied to is from a different chat, unique identifier for the chat or username
         of the channel (in the format @channelusername)
     :type chat_id: :obj:`int` or :obj:`str`
+
+    :param ephemeral_message_id: Optional. Identifier of the incoming ephemeral message that will be replied to in the current chat.
+        A reply to an ephemeral message must itself be an ephemeral message. An ephemeral message may only be replied to within 15 seconds
+        of being sent. Required if message_id isn't specified.
+    :type ephemeral_message_id: :obj:`int`
 
     :param allow_sending_without_reply: Optional. Pass True if the message should be sent even if the specified message to be replied to is not found;
         can be used only for replies in the same chat and forum topic.
@@ -10073,11 +10079,11 @@ class ReplyParameters(JsonDeserializable, Dictionaryable, JsonSerializable):
             obj['quote_entities'] = [MessageEntity.de_json(entity) for entity in obj['quote_entities']]
         return cls(**obj)
 
-    def __init__(self, message_id: int, chat_id: Optional[Union[int, str]] = None,
+    def __init__(self, message_id: Optional[int] = None, chat_id: Optional[Union[int, str]] = None,
                  allow_sending_without_reply: Optional[bool] = None, quote: Optional[str] = None,
                  quote_parse_mode: Optional[str] = None, quote_entities: Optional[List[MessageEntity]] = None,
                  quote_position: Optional[int] = None, checklist_task_id: Optional[int] = None,
-                    poll_option_id: Optional[str] = None, **kwargs) -> None:
+                    poll_option_id: Optional[str] = None, ephemeral_message_id: Optional[int] = None, **kwargs) -> None:
         self.message_id: int = message_id
         self.chat_id: Optional[Union[int, str]] = chat_id
         self.allow_sending_without_reply: Optional[bool] = allow_sending_without_reply
@@ -10087,6 +10093,10 @@ class ReplyParameters(JsonDeserializable, Dictionaryable, JsonSerializable):
         self.quote_position: Optional[int] = quote_position
         self.checklist_task_id: Optional[int] = checklist_task_id
         self.poll_option_id: Optional[str] = poll_option_id
+        self.ephemeral_message_id: Optional[int] = ephemeral_message_id
+
+        if self.message_id is None and self.ephemeral_message_id is None:
+            raise ValueError("Either 'message_id' or 'ephemeral_message_id' must be provided.")
 
     def to_dict(self) -> dict:
         json_dict = {
@@ -10108,8 +10118,9 @@ class ReplyParameters(JsonDeserializable, Dictionaryable, JsonSerializable):
             json_dict['checklist_task_id'] = self.checklist_task_id
         if self.poll_option_id is not None:
             json_dict['poll_option_id'] = self.poll_option_id
+        if self.ephemeral_message_id is not None:
+            json_dict['ephemeral_message_id'] = self.ephemeral_message_id
         return json_dict
-
     def to_json(self) -> str:
         return json.dumps(self.to_dict())
 

--- a/telebot/types.py
+++ b/telebot/types.py
@@ -16541,4 +16541,700 @@ class InputRichBlockListItem(Dictionaryable):
     
     def to_json(self) -> str:
         return json.dumps(self.to_dict())
+
+class InputRichBlock(Dictionaryable, JsonSerializable):
+    """
+    This object represents a block in a rich formatted message to be sent.
+    Currently, it can be any of the following types:
+    - InputRichBlockParagraph
+    - InputRichBlockSectionHeading
+    - InputRichBlockPreformatted
+    - InputRichBlockFooter
+    - InputRichBlockDivider
+    - InputRichBlockMathematicalExpression
+    - InputRichBlockAnchor
+    - InputRichBlockList
+    - InputRichBlockBlockQuotation
+    - InputRichBlockPullQuotation
+    - InputRichBlockCollage
+    - InputRichBlockSlideshow
+    - InputRichBlockTable
+    - InputRichBlockDetails
+    - InputRichBlockMap
+    - InputRichBlockAnimation
+    - InputRichBlockAudio
+    - InputRichBlockPhoto
+    - InputRichBlockVideo
+    - InputRichBlockVoiceNote
+    - InputRichBlockThinking
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblock
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlock`
+    """
+    def __init__(self, type: str, **kwargs):
+        self.type: str = type
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
     
+    def to_dict(self) -> dict:
+        return {
+            'type': self.type
+        }
+    
+
+class InputRichBlockParagraph(InputRichBlock):
+    """
+    A text paragraph, corresponding to the HTML tag <p>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockparagraph
+
+    :param type: Type of the block, always “paragraph”
+    :type type: :obj:`str`
+
+    :param text: Text of the block
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockParagraph`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='paragraph', **kwargs)
+        self.text: RichText = text
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['text'] = self.text.to_dict()
+        return data
+    
+
+class InputRichBlockSectionHeading(InputRichBlock):
+    """
+    A section heading, corresponding to the HTML tags <h1>, <h2>, <h3>, <h4>, <h5>, or <h6>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblocksectionheading
+
+    :param type: Type of the block, always “heading”
+    :type type: :obj:`str`
+
+    :param text: Text of the block
+    :type text: :class:`RichText`
+
+    :param size: Relative size of the text font; 1-6, 1 is the largest, 6 is the smallest
+    :type size: :obj:`int`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockSectionHeading`
+    """
+    def __init__(self, text: RichText, size: int, **kwargs):
+        super().__init__(type='heading', **kwargs)
+        self.text: RichText = text
+        self.size: int = size
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['text'] = self.text.to_dict()
+        data['size'] = self.size
+        return data
+
+    
+class InputRichBlockPreformatted(InputRichBlock):
+    """
+    A preformatted text block, corresponding to the nested HTML tags <pre> and <code>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockpreformatted
+
+    :param type: Type of the block, always “pre”
+    :type type: :obj:`str`
+
+    :param text: Text of the block
+    :type text: :class:`RichText`
+
+    :param language: Optional. The programming language of the text
+    :type language: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockPreformatted`
+    """
+    def __init__(self, text: RichText, language: Optional[str] = None, **kwargs):
+        super().__init__(type='pre', **kwargs)
+        self.text: RichText = text
+        self.language: Optional[str] = language
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['text'] = self.text.to_dict()
+        if self.language is not None:
+            data['language'] = self.language
+        return data
+
+
+class InputRichBlockFooter(InputRichBlock):
+    """
+    A footer, corresponding to the HTML tag <footer>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockfooter
+
+    :param type: Type of the block, always “footer”
+    :type type: :obj:`str`
+
+    :param text: Text of the block
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockFooter`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='footer', **kwargs)
+        self.text: RichText = text
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['text'] = self.text.to_dict()
+        return data
+
+
+class InputRichBlockDivider(InputRichBlock):
+    """
+    A divider, corresponding to the HTML tag <hr/>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockdivider
+
+    :param type: Type of the block, always “divider”
+    :type type: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockDivider`
+    """
+    def __init__(self, **kwargs):
+        super().__init__(type='divider', **kwargs)
+
+    def to_dict(self) -> dict:
+        return super().to_dict()
+
+
+class InputRichBlockMathematicalExpression(InputRichBlock):
+    """
+    A block with a mathematical expression in LaTeX format, corresponding to the custom HTML tag <tg-math-block>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockmathematicalexpression
+
+    :param type: Type of the block, always “mathematical_expression”
+    :type type: :obj:`str`
+
+    :param expression: The mathematical expression in LaTeX format
+    :type expression: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockMathematicalExpression`
+    """
+    def __init__(self, expression: str, **kwargs):
+        super().__init__(type='mathematical_expression', **kwargs)
+        self.expression: str = expression
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['expression'] = self.expression
+        return data
+
+
+class InputRichBlockAnchor(InputRichBlock):
+    """
+    A block with an anchor, corresponding to the HTML tag <a> with the attribute name.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockanchor
+
+    :param type: Type of the block, always “anchor”
+    :type type: :obj:`str`
+
+    :param name: The name of the anchor
+    :type name: :obj:`str`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockAnchor`
+    """
+    def __init__(self, name: str, **kwargs):
+        super().__init__(type='anchor', **kwargs)
+        self.name: str = name
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['name'] = self.name
+        return data
+
+
+class InputRichBlockList(InputRichBlock):
+    """
+    A list of blocks, corresponding to the HTML tag <ul> or <ol> with multiple nested tags <li>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblocklist
+
+    :param type: Type of the block, always “list”
+    :type type: :obj:`str`
+
+    :param items: Items of the list
+    :type items: :obj:`list` of :class:`InputRichBlockListItem`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockList`
+    """
+    def __init__(self, items: List[InputRichBlockListItem], **kwargs):
+        super().__init__(type='list', **kwargs)
+        self.items: List[InputRichBlockListItem] = items
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['items'] = [item.to_dict() for item in self.items]
+        return data
+
+
+class InputRichBlockBlockQuotation(InputRichBlock):
+    """
+    A block quotation, corresponding to the HTML tag <blockquote>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockblockquotation
+
+    :param type: Type of the block, always “blockquote”
+    :type type: :obj:`str`
+
+    :param blocks: Content of the block
+    :type blocks: :obj:`list` of :class:`InputRichBlock`
+
+    :param credit: Optional. Credit of the block
+    :type credit: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockBlockQuotation`
+    """
+    def __init__(self, blocks: List[InputRichBlock], credit: Optional[RichText] = None, **kwargs):
+        super().__init__(type='blockquote', **kwargs)
+        self.blocks: List[InputRichBlock] = blocks
+        self.credit: Optional[RichText] = credit
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['blocks'] = [block.to_dict() for block in self.blocks]
+        if self.credit is not None:
+            data['credit'] = self.credit.to_dict()
+        return data
+
+
+class InputRichBlockPullQuotation(InputRichBlock):
+    """
+    A quotation with centered text, loosely corresponding to the HTML tag <aside>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockpullquotation
+
+    :param type: Type of the block, always “pullquote”
+    :type type: :obj:`str`
+
+    :param text: Text of the block
+    :type text: :class:`RichText`
+
+    :param credit: Optional. Credit of the block
+    :type credit: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockPullQuotation`
+    """
+    def __init__(self, text: RichText, credit: Optional[RichText] = None, **kwargs):
+        super().__init__(type='pullquote', **kwargs)
+        self.text: RichText = text
+        self.credit: Optional[RichText] = credit
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['text'] = self.text.to_dict()
+        if self.credit is not None:
+            data['credit'] = self.credit.to_dict()
+        return data
+
+
+class InputRichBlockCollage(InputRichBlock):
+    """
+    A collage, corresponding to the custom HTML tag <tg-collage>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockcollage
+
+    :param type: Type of the block, always “collage”
+    :type type: :obj:`str`
+
+    :param blocks: Elements of the collage
+    :type blocks: :obj:`list` of :class:`InputRichBlock`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockCollage`
+    """
+    def __init__(self, blocks: List[InputRichBlock], caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='collage', **kwargs)
+        self.blocks: List[InputRichBlock] = blocks
+        self.caption: Optional[RichBlockCaption] = caption
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['blocks'] = [block.to_dict() for block in self.blocks]
+        if self.caption is not None:
+            data['caption'] = self.caption.to_dict()
+        return data
+
+
+class InputRichBlockSlideshow(InputRichBlock):
+    """
+    A slideshow, corresponding to the custom HTML tag <tg-slideshow>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockslideshow
+
+    :param type: Type of the block, always “slideshow”
+    :type type: :obj:`str`
+
+    :param blocks: Elements of the slideshow
+    :type blocks: :obj:`list` of :class:`InputRichBlock`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockSlideshow`
+    """
+    def __init__(self, blocks: List[InputRichBlock], caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='slideshow', **kwargs)
+        self.blocks: List[InputRichBlock] = blocks
+        self.caption: Optional[RichBlockCaption] = caption
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['blocks'] = [block.to_dict() for block in self.blocks]
+        if self.caption is not None:
+            data['caption'] = self.caption.to_dict()
+        return data
+
+
+class InputRichBlockTable(InputRichBlock):
+    """
+    A table, corresponding to the HTML tag <table>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblocktable
+
+    :param type: Type of the block, always “table”
+    :type type: :obj:`str`
+
+    :param cells: Cells of the table
+    :type cells: :obj:`list` of :obj:`list` of :class:`RichBlockTableCell`
+
+    :param is_bordered: Optional. Pass True if the table has borders
+    :type is_bordered: :obj:`bool`
+
+    :param is_striped: Optional. Pass True if the table is striped
+    :type is_striped: :obj:`bool`
+
+    :param caption: Optional. Caption of the table
+    :type caption: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockTable`
+    """
+    def __init__(
+        self,
+        cells: List[List[RichBlockTableCell]],
+        is_bordered: Optional[bool] = None,
+        is_striped: Optional[bool] = None,
+        caption: Optional[RichText] = None,
+        **kwargs
+    ):
+        super().__init__(type='table', **kwargs)
+        self.cells: List[List[RichBlockTableCell]] = cells
+        self.is_bordered: Optional[bool] = is_bordered
+        self.is_striped: Optional[bool] = is_striped
+        self.caption: Optional[RichText] = caption
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['cells'] = [[cell.to_dict() for cell in row] for row in self.cells]
+        if self.is_bordered is not None:
+            data['is_bordered'] = self.is_bordered
+        if self.is_striped is not None:
+            data['is_striped'] = self.is_striped
+        if self.caption is not None:
+            data['caption'] = self.caption.to_dict()
+        return data
+
+
+class InputRichBlockDetails(InputRichBlock):
+    """
+    An expandable block for details disclosure, corresponding to the HTML tag <details>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockdetails
+
+    :param type: Type of the block, always “details”
+    :type type: :obj:`str`
+
+    :param summary: Always shown summary of the block
+    :type summary: :class:`RichText`
+
+    :param blocks: Content of the block
+    :type blocks: :obj:`list` of :class:`InputRichBlock`
+
+    :param is_open: Optional. Pass True if the content of the block is visible by default
+    :type is_open: :obj:`bool`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockDetails`
+    """
+    def __init__(
+        self,
+        summary: RichText,
+        blocks: List[InputRichBlock],
+        is_open: Optional[bool] = None,
+        **kwargs
+    ):
+        super().__init__(type='details', **kwargs)
+        self.summary: RichText = summary
+        self.blocks: List[InputRichBlock] = blocks
+        self.is_open: Optional[bool] = is_open
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['summary'] = self.summary.to_dict()
+        data['blocks'] = [block.to_dict() for block in self.blocks]
+        if self.is_open is not None:
+            data['is_open'] = self.is_open
+        return data
+
+
+class InputRichBlockMap(InputRichBlock):
+    """
+    A block with a map, corresponding to the custom HTML tag <tg-map>. The map's width and height must not exceed 10000 in total. The width and height ratio must be at most 20.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockmap
+
+    :param type: Type of the block, always “map”
+    :type type: :obj:`str`
+
+    :param location: Location of the center of the map
+    :type location: :class:`Location`
+
+    :param zoom: Map zoom level; 0-24
+    :type zoom: :obj:`int`
+
+    :param width: Map width; 0-10000
+    :type width: :obj:`int`
+
+    :param height: Map height; 0-10000
+    :type height: :obj:`int`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockMap`
+    """
+    def __init__(
+        self,
+        location: Location,
+        zoom: int,
+        width: int,
+        height: int,
+        caption: Optional[RichBlockCaption] = None,
+        **kwargs
+    ):
+        super().__init__(type='map', **kwargs)
+        self.location: Location = location
+        self.zoom: int = zoom
+        self.width: int = width
+        self.height: int = height
+        self.caption: Optional[RichBlockCaption] = caption
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['location'] = self.location.to_dict()
+        data['zoom'] = self.zoom
+        data['width'] = self.width
+        data['height'] = self.height
+        if self.caption is not None:
+            data['caption'] = self.caption.to_dict()
+        return data
+
+
+class InputRichBlockAnimation(InputRichBlock):
+    """
+    A block with an animation, corresponding to the HTML tag <video>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockanimation
+
+    :param type: Type of the block, always “animation”
+    :type type: :obj:`str`
+
+    :param animation: The animation. Caption is ignored.
+    :type animation: :class:`InputMediaAnimation`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockAnimation`
+    """
+    def __init__(self, animation: InputMediaAnimation, caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='animation', **kwargs)
+        self.animation: InputMediaAnimation = animation
+        self.caption: Optional[RichBlockCaption] = caption
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['animation'] = self.animation.to_dict()
+        if self.caption is not None:
+            data['caption'] = self.caption.to_dict()
+        return data
+
+
+class InputRichBlockAudio(InputRichBlock):
+    """
+    A block with a music file, corresponding to the HTML tag <audio>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockaudio
+
+    :param type: Type of the block, always “audio”
+    :type type: :obj:`str`
+
+    :param audio: The audio. Caption is ignored.
+    :type audio: :class:`InputMediaAudio`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockAudio`
+    """
+    def __init__(self, audio: InputMediaAudio, caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='audio', **kwargs)
+        self.audio: InputMediaAudio = audio
+        self.caption: Optional[RichBlockCaption] = caption
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['audio'] = self.audio.to_dict()
+        if self.caption is not None:
+            data['caption'] = self.caption.to_dict()
+        return data
+
+
+class InputRichBlockPhoto(InputRichBlock):
+    """
+    A block with a photo, corresponding to the HTML tag <img>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockphoto
+
+    :param type: Type of the block, always “photo”
+    :type type: :obj:`str`
+
+    :param photo: The photo. Caption is ignored.
+    :type photo: :class:`InputMediaPhoto`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockPhoto`
+    """
+    def __init__(self, photo: InputMediaPhoto, caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='photo', **kwargs)
+        self.photo: InputMediaPhoto = photo
+        self.caption: Optional[RichBlockCaption] = caption
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['photo'] = self.photo.to_dict()
+        if self.caption is not None:
+            data['caption'] = self.caption.to_dict()
+        return data
+
+
+class InputRichBlockVideo(InputRichBlock):
+    """
+    A block with a video, corresponding to the HTML tag <video>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockvideo
+
+    :param type: Type of the block, always “video”
+    :type type: :obj:`str`
+
+    :param video: The video. Caption is ignored.
+    :type video: :class:`InputMediaVideo`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockVideo`
+    """
+    def __init__(self, video: InputMediaVideo, caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='video', **kwargs)
+        self.video: InputMediaVideo = video
+        self.caption: Optional[RichBlockCaption] = caption
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['video'] = self.video.to_dict()
+        if self.caption is not None:
+            data['caption'] = self.caption.to_dict()
+        return data
+
+
+class InputRichBlockVoiceNote(InputRichBlock):
+    """
+    A block with a voice note, corresponding to the HTML tag <audio>.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockvoicenote
+
+    :param type: Type of the block, always “voice_note”
+    :type type: :obj:`str`
+
+    :param voice_note: The voice note. Caption is ignored.
+    :type voice_note: :class:`InputMediaVoiceNote`
+
+    :param caption: Optional. Caption of the block
+    :type caption: :class:`RichBlockCaption`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockVoiceNote`
+    """
+    def __init__(self, voice_note: InputMediaVoiceNote, caption: Optional[RichBlockCaption] = None, **kwargs):
+        super().__init__(type='voice_note', **kwargs)
+        self.voice_note: InputMediaVoiceNote = voice_note
+        self.caption: Optional[RichBlockCaption] = caption
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['voice_note'] = self.voice_note.to_dict()
+        if self.caption is not None:
+            data['caption'] = self.caption.to_dict()
+        return data
+
+
+class InputRichBlockThinking(InputRichBlock):
+    """
+    A block with a "Thinking…" placeholder, corresponding to the custom HTML tag <tg-thinking>. The block may be used only in sendRichMessageDraft, therefore it can't be received in messages. See https://t.me/addemoji/AIActions for examples of custom emoji that are recommended for usage in the block.
+
+    Telegram documentation: https://core.telegram.org/bots/api#inputrichblockthinking
+
+    :param type: Type of the block, always “thinking”
+    :type type: :obj:`str`
+
+    :param text: Text of the block. See https://t.me/addemoji/AIActions for examples of custom emoji that are recommended for usage in the block.
+    :type text: :class:`RichText`
+
+    :return: Instance of the class
+    :rtype: :class:`InputRichBlockThinking`
+    """
+    def __init__(self, text: RichText, **kwargs):
+        super().__init__(type='thinking', **kwargs)
+        self.text: RichText = text
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data['text'] = self.text.to_dict()
+        return data

--- a/telebot/util.py
+++ b/telebot/util.py
@@ -44,7 +44,7 @@ content_type_service = [
     'checklist_tasks_done', 'checklist_tasks_added', 'direct_message_price_changed', 'suggested_post_refunded',
     'suggested_post_info', 'suggested_post_approved', 'suggested_post_approval_failed', 'suggested_post_declined',
     'suggested_post_paid', 'gift_upgrade_sent', 'chat_owner_left', 'chat_owner_changed', 'managed_bot_created',
-    'poll_option_added', 'poll_option_deleted'
+    'poll_option_added', 'poll_option_deleted', 'community_chat_added', 'community_chat_removed'
 ]
 
 #: All update types, should be used for allowed_updates parameter in polling.
@@ -53,7 +53,7 @@ update_types = [
     "callback_query", "shipping_query", "pre_checkout_query", "poll", "poll_answer", "my_chat_member", "chat_member",
     "chat_join_request", "message_reaction", "message_reaction_count", "removed_chat_boost", "chat_boost",
     "business_connection", "business_message", "edited_business_message", "deleted_business_messages",
-    "purchased_paid_media", "managed_bot", "guest_message"
+    "purchased_paid_media", "managed_bot", "guest_message", "subscription"
 ]
 
 

--- a/tests/test_handler_backends.py
+++ b/tests/test_handler_backends.py
@@ -71,7 +71,8 @@ def update_type(message):
     chat_boost_removed = None
     return types.Update(1001234038283, message, edited_message, channel_post, edited_channel_post, inline_query,
                         chosen_inline_result, callback_query, shipping_query, pre_checkout_query, poll, poll_answer,
-                        my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, chat_boost, chat_boost_removed, None, None, None, None, None, None, None)
+                        my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, chat_boost, chat_boost_removed, None,
+                        None, None, None, None, None, None, None)
 
 
 @pytest.fixture()
@@ -95,7 +96,8 @@ def reply_to_message_update_type(reply_to_message):
     chat_boost_removed = None
     return types.Update(1001234038284, reply_to_message, edited_message, channel_post, edited_channel_post,
                         inline_query, chosen_inline_result, callback_query, shipping_query, pre_checkout_query, 
-                        poll, poll_answer, my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, chat_boost, chat_boost_removed, None, None, None, None, None, None, None)
+                        poll, poll_answer, my_chat_member, chat_member, chat_join_request, message_reaction, message_reaction_count, chat_boost, chat_boost_removed, None, None, None, None, None, None, None,
+                        None)
 
 
 def next_handler(message):

--- a/tests/test_telebot.py
+++ b/tests/test_telebot.py
@@ -556,7 +556,8 @@ let number = loop {
             edited_business_message=None,
             deleted_business_messages=None,
             managed_bot=None,
-            guest_message=message)
+            guest_message=None,
+            subscription=None)
 
     def test_is_string_unicode(self):
         s1 = u'string'


### PR DESCRIPTION
July 14, 2026
Bot API 10.2

**Rich Messages**

- [x] Added the class [InputRichMessageMedia](https://core.telegram.org/bots/api#inputrichmessagemedia) and the field media to the class [InputRichMessage](https://core.telegram.org/bots/api#inputrichmessage), allowing bots to explicitly specify media used in markdown or html formatting when sending a rich message.
- [x] Added the class [InputMediaVoiceNote](https://core.telegram.org/bots/api#inputmediavoicenote), representing a voice message to be sent.
- [x] Added the class [InputRichBlockListItem](https://core.telegram.org/bots/api#inputrichblocklistitem), which represents an item in a list to be sent.
- [x] Added the classes [InputRichBlockParagraph](https://core.telegram.org/bots/api#inputrichblockparagraph), [InputRichBlockSectionHeading](https://core.telegram.org/bots/api#inputrichblocksectionheading), [InputRichBlockPreformatted](https://core.telegram.org/bots/api#inputrichblockpreformatted), [InputRichBlockFooter](https://core.telegram.org/bots/api#inputrichblockfooter), [InputRichBlockDivider](https://core.telegram.org/bots/api#inputrichblockdivider), [InputRichBlockMathematicalExpression](https://core.telegram.org/bots/api#inputrichblockmathematicalexpression), [InputRichBlockAnchor](https://core.telegram.org/bots/api#inputrichblockanchor), [InputRichBlockList](https://core.telegram.org/bots/api#inputrichblocklist), [InputRichBlockBlockQuotation](https://core.telegram.org/bots/api#inputrichblockblockquotation), [InputRichBlockPullQuotation](https://core.telegram.org/bots/api#inputrichblockpullquotation), [InputRichBlockCollage](https://core.telegram.org/bots/api#inputrichblockcollage), [InputRichBlockSlideshow](https://core.telegram.org/bots/api#inputrichblockslideshow), [InputRichBlockTable](https://core.telegram.org/bots/api#inputrichblocktable), [InputRichBlockDetails](https://core.telegram.org/bots/api#inputrichblockdetails), [InputRichBlockMap](https://core.telegram.org/bots/api#inputrichblockmap), [InputRichBlockAnimation](https://core.telegram.org/bots/api#inputrichblockanimation), [InputRichBlockAudio](https://core.telegram.org/bots/api#inputrichblockaudio), [InputRichBlockPhoto](https://core.telegram.org/bots/api#inputrichblockphoto), [InputRichBlockVideo](https://core.telegram.org/bots/api#inputrichblockvideo), [InputRichBlockVoiceNote](https://core.telegram.org/bots/api#inputrichblockvoicenote) and [InputRichBlockThinking](https://core.telegram.org/bots/api#inputrichblockthinking), which represent different types of blocks available to format an outgoing rich message.
- [x] Added the field blocks to the class [InputRichMessage](https://core.telegram.org/bots/api#inputrichmessage), allowing bots to specify rich message formatting via block entities.

**Ephemeral Messages**

- [x] Introduced support for [Ephemeral Messages](https://core.telegram.org/bots/features#ephemeral-messages), allowing bots to send group messages and receive commands that are visible only to a specific user and the bot.
- [x] Added the field is_ephemeral to the class [BotCommand](https://core.telegram.org/bots/api#botcommand).
- [x] Added the field receiver_user to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the field ephemeral_message_id to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the parameters receiver_user_id and callback_query_id to the methods [sendMessage](https://core.telegram.org/bots/api#sendmessage), [sendAnimation](https://core.telegram.org/bots/api#sendanimation), [sendAudio](https://core.telegram.org/bots/api#sendaudio), [sendDocument](https://core.telegram.org/bots/api#senddocument), [sendPhoto](https://core.telegram.org/bots/api#sendphoto), [sendSticker](https://core.telegram.org/bots/api#sendsticker), [sendVideo](https://core.telegram.org/bots/api#sendvideo), [sendVideoNote](https://core.telegram.org/bots/api#sendvideonote), [sendVoice](https://core.telegram.org/bots/api#sendvoice), [sendContact](https://core.telegram.org/bots/api#sendcontact), [sendLocation](https://core.telegram.org/bots/api#sendlocation), [sendVenue](https://core.telegram.org/bots/api#sendvenue).
- [x] Added the field ephemeral_message_id to the class [ReplyParameters](https://core.telegram.org/bots/api#replyparameters), allowing bots to reply to ephemeral messages.
- [x] Marked the field message_id in the class [ReplyParameters](https://core.telegram.org/bots/api#replyparameters) as optional if the field ephemeral_message_id is present.
- [x] Added the methods [editEphemeralMessageText](https://core.telegram.org/bots/api#editephemeralmessagetext), [editEphemeralMessageMedia](https://core.telegram.org/bots/api#editephemeralmessagemedia), [editEphemeralMessageCaption](https://core.telegram.org/bots/api#editephemeralmessagecaption), and [editEphemeralMessageReplyMarkup](https://core.telegram.org/bots/api#editephemeralmessagereplymarkup) allowing bots to edit ephemeral messages.
- [x] Added the method [deleteEphemeralMessage](https://core.telegram.org/bots/api#deleteephemeralmessage) allowing bots to delete ephemeral messages.

**Communities**

- [x] Introduced initial support for Communities - several supergroups, channels, and bots linked together around a shared topic or audience.
- [x] Added the class [Community](https://core.telegram.org/bots/api#community) which represents a community.
- [x] Added the class [CommunityChatAdded](https://core.telegram.org/bots/api#communitychatadded) and the field community_chat_added to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the class [CommunityChatRemoved](https://core.telegram.org/bots/api#communitychatremoved) and the field community_chat_removed to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the field community to the class [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo).

**General**

- [ ] 
- [x] Added updates about changes to a user payment subscription, represented by the class [BotSubscriptionUpdated](https://core.telegram.org/bots/api#botsubscriptionupdated) and the field subscription in the class [Update](https://core.telegram.org/bots/api#update).
- [x] Hardened the security of Mini Apps by disallowing the usage of Mini App methods from origins different from the original Mini App domain. The protection will be automatically enabled for all Mini Apps on July 20, 2026. You can opt-out from the protection through the [@BotFather](https://t.me/BotFather) Mini App. If you do so, you acknowledge that it is the responsibility of the bot to ensure that the Mini App has no links to untrusted sites.